### PR TITLE
feat: Terraform実行時にTailscaleを自動セットアップ

### DIFF
--- a/nix/hosts/node01/configuration.nix
+++ b/nix/hosts/node01/configuration.nix
@@ -19,8 +19,13 @@
         22 # SSH
         6443 # k3s: API server (pods からアクセス必須)
       ];
+      # Tailscale インターフェースを信頼
+      trustedInterfaces = [ "tailscale0" ];
     };
   };
+
+  # Tailscale VPN
+  services.tailscale.enable = true;
 
   # SSH 設定 (リモートアクセス必須)
   services.openssh = {

--- a/terraform/proxmox/variables.tf
+++ b/terraform/proxmox/variables.tf
@@ -38,3 +38,10 @@ variable "github_repo" {
   type        = string
   default     = "hikuohiku/homelab"
 }
+
+# Tailscale Variables
+variable "tailscale_auth_key" {
+  description = "Tailscale auth key for node registration"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/proxmox/vm-nixos.tf
+++ b/terraform/proxmox/vm-nixos.tf
@@ -52,6 +52,23 @@ resource "proxmox_virtual_environment_vm" "node01" {
   }
 
   started = true
+
+  # Wait for VM to be ready and setup Tailscale
+  provisioner "remote-exec" {
+    inline = [
+      "echo 'Waiting for system to be ready...'",
+      "sleep 10",
+      "tailscale up --authkey=${var.tailscale_auth_key} --hostname=node01 --accept-routes"
+    ]
+
+    connection {
+      type        = "ssh"
+      host        = "192.168.0.129"
+      user        = "root"
+      timeout     = "5m"
+      agent       = true
+    }
+  }
 }
 
 output "node01_ip" {


### PR DESCRIPTION
- NixOS configuration.nix に Tailscale サービスを追加
- Terraform provisioner で tailscale up を実行
- justfile に apply-with-tailscale コマンドを追加
  - ローカルの tailscale CLI で auth key を動的生成
  - 環境変数経由で Terraform に渡す