### PR TITLE
fix: include version in release image filename

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -60,19 +60,22 @@ jobs:
 
       - name: Build qcow2 image
         run: |
+          VERSION=${{ steps.version.outputs.version }}
           nix build ./nix/images/proxmox-cloud#packages.x86_64-linux.qcow2 --no-link --print-out-paths > result-path.txt
           RESULT_PATH=$(cat result-path.txt)
-          cp "${RESULT_PATH}/nixos.qcow2" nixos-proxmox-cloud.qcow2
+          cp "${RESULT_PATH}/nixos.qcow2" "nixos-proxmox-cloud-${VERSION}.qcow2"
 
       - name: Compress with zstd
         run: |
-          zstd -T0 nixos-proxmox-cloud.qcow2 -o nixos-proxmox-cloud.qcow2.zst
-          ls -lh nixos-proxmox-cloud.qcow2*
+          VERSION=${{ steps.version.outputs.version }}
+          zstd -T0 "nixos-proxmox-cloud-${VERSION}.qcow2" -o "nixos-proxmox-cloud-${VERSION}.qcow2.zst"
+          ls -lh nixos-proxmox-cloud-*
 
       - name: Generate checksum
         run: |
-          sha256sum nixos-proxmox-cloud.qcow2.zst > nixos-proxmox-cloud.qcow2.zst.sha256
-          cat nixos-proxmox-cloud.qcow2.zst.sha256
+          VERSION=${{ steps.version.outputs.version }}
+          sha256sum "nixos-proxmox-cloud-${VERSION}.qcow2.zst" > "nixos-proxmox-cloud-${VERSION}.qcow2.zst.sha256"
+          cat "nixos-proxmox-cloud-${VERSION}.qcow2.zst.sha256"
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
@@ -83,8 +86,8 @@ jobs:
             ## NixOS Proxmox Cloud Image
 
             ### Files
-            - `nixos-proxmox-cloud.qcow2.zst` - zstd compressed qcow2 disk image
-            - `nixos-proxmox-cloud.qcow2.zst.sha256` - SHA256 checksum
+            - `nixos-proxmox-cloud-${{ steps.version.outputs.version }}.qcow2.zst` - zstd compressed qcow2 disk image
+            - `nixos-proxmox-cloud-${{ steps.version.outputs.version }}.qcow2.zst.sha256` - SHA256 checksum
 
             ### Usage with Terraform
             ```hcl
@@ -95,7 +98,7 @@ jobs:
 
             Proxmox will automatically decompress the image when downloading.
           files: |
-            nixos-proxmox-cloud.qcow2.zst
-            nixos-proxmox-cloud.qcow2.zst.sha256
+            nixos-proxmox-cloud-${{ steps.version.outputs.version }}.qcow2.zst
+            nixos-proxmox-cloud-${{ steps.version.outputs.version }}.qcow2.zst.sha256
           draft: false
           prerelease: false

--- a/terraform/proxmox/nixos-image.tf
+++ b/terraform/proxmox/nixos-image.tf
@@ -8,7 +8,7 @@ resource "proxmox_virtual_environment_download_file" "nixos_image" {
   node_name    = var.proxmox_node
 
   # Image URL from GitHub Releases (zstd compressed)
-  url                     = "https://github.com/${var.github_repo}/releases/download/${var.nixos_image_version}/nixos-proxmox-cloud.qcow2.zst"
+  url                     = "https://github.com/${var.github_repo}/releases/download/${var.nixos_image_version}/nixos-proxmox-cloud-${var.nixos_image_version}.qcow2.zst"
   file_name               = "nixos-proxmox-cloud-${var.nixos_image_version}.qcow2"
   decompression_algorithm = "zst"
 


### PR DESCRIPTION
## Summary
- Change filename from \`nixos-proxmox-cloud.qcow2.zst\` to \`nixos-proxmox-cloud-vX.Y.Z.qcow2.zst\`
- Update Terraform URL to match new filename pattern

## Example
\`\`\`
v0.2.2 release -> nixos-proxmox-cloud-v0.2.2.qcow2.zst
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)