### PR TITLE
feat(ente): add Ente photo management service deployment

### DIFF
--- a/apps/ente/application.yaml
+++ b/apps/ente/application.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ente
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/hikuohiku/homelab.git
+    targetRevision: HEAD
+    path: apps/ente
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ente
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/ente/ente-secrets.yaml
+++ b/apps/ente/ente-secrets.yaml
@@ -3,6 +3,8 @@ kind: ExternalSecret
 metadata:
   name: ente-secrets
   namespace: ente
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/apps/ente/ente-secrets.yaml
+++ b/apps/ente/ente-secrets.yaml
@@ -1,0 +1,35 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ente-secrets
+  namespace: ente
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler
+  target:
+    name: ente-secrets
+    creationPolicy: Owner
+  data:
+    # PostgreSQL credentials
+    - secretKey: postgres-user
+      remoteRef:
+        key: ENTE_POSTGRES_USER
+    - secretKey: postgres-password
+      remoteRef:
+        key: ENTE_POSTGRES_PASSWORD
+    # MinIO credentials
+    - secretKey: minio-root-user
+      remoteRef:
+        key: ENTE_MINIO_ROOT_USER
+    - secretKey: minio-root-password
+      remoteRef:
+        key: ENTE_MINIO_ROOT_PASSWORD
+    # Museum encryption keys
+    - secretKey: encryption-key
+      remoteRef:
+        key: ENTE_ENCRYPTION_KEY
+    - secretKey: jwt-secret
+      remoteRef:
+        key: ENTE_JWT_SECRET

--- a/apps/ente/ingress.yaml
+++ b/apps/ente/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ente
+  namespace: ente
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: ente-museum
+      port:
+        number: 8080
+  tls:
+    - hosts:
+        - ente

--- a/apps/ente/ingress.yaml
+++ b/apps/ente/ingress.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ente
   namespace: ente
   annotations:
+    argocd.argoproj.io/sync-wave: "3"
     tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
 spec:
   ingressClassName: tailscale

--- a/apps/ente/kustomization.yaml
+++ b/apps/ente/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ente
+
+resources:
+  # External Secrets
+  - ente-secrets.yaml
+  # PostgreSQL
+  - postgres-pvc.yaml
+  - postgres-deployment.yaml
+  - postgres-service.yaml
+  # MinIO (Object Storage)
+  - minio-pvc.yaml
+  - minio-deployment.yaml
+  - minio-service.yaml
+  # Museum (Ente Server)
+  - museum-config.yaml
+  - museum-deployment.yaml
+  - museum-service.yaml
+  # Ingress
+  - ingress.yaml

--- a/apps/ente/kustomization.yaml
+++ b/apps/ente/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - minio-pvc.yaml
   - minio-deployment.yaml
   - minio-service.yaml
+  - minio-setup-job.yaml
   # Museum (Ente Server)
   - museum-config.yaml
   - museum-deployment.yaml

--- a/apps/ente/minio-deployment.yaml
+++ b/apps/ente/minio-deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ente-minio
+  namespace: ente
+  labels:
+    app: ente-minio
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ente-minio
+  template:
+    metadata:
+      labels:
+        app: ente-minio
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:latest
+          args:
+            - server
+            - /data
+            - --console-address
+            - ":9001"
+          ports:
+            - containerPort: 9000
+              name: api
+            - containerPort: 9001
+              name: console
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ente-secrets
+                  key: minio-root-user
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ente-secrets
+                  key: minio-root-password
+          volumeMounts:
+            - name: minio-data
+              mountPath: /data
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: 9000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: 9000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: minio-data
+          persistentVolumeClaim:
+            claimName: ente-minio-data

--- a/apps/ente/minio-deployment.yaml
+++ b/apps/ente/minio-deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: ente
   labels:
     app: ente-minio
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: 1
   strategy:

--- a/apps/ente/minio-pvc.yaml
+++ b/apps/ente/minio-pvc.yaml
@@ -3,6 +3,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: ente-minio-data
   namespace: ente
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   accessModes:
     - ReadWriteOnce

--- a/apps/ente/minio-pvc.yaml
+++ b/apps/ente/minio-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ente-minio-data
+  namespace: ente
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 50Gi

--- a/apps/ente/minio-pvc.yaml
+++ b/apps/ente/minio-pvc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ente-minio-data
   namespace: ente
   annotations:
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   accessModes:
     - ReadWriteOnce

--- a/apps/ente/minio-service.yaml
+++ b/apps/ente/minio-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ente-minio
+  namespace: ente
+spec:
+  selector:
+    app: ente-minio
+  ports:
+    - port: 9000
+      targetPort: 9000
+      name: api
+    - port: 9001
+      targetPort: 9001
+      name: console
+  type: ClusterIP

--- a/apps/ente/minio-service.yaml
+++ b/apps/ente/minio-service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: ente-minio
   namespace: ente
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   selector:
     app: ente-minio

--- a/apps/ente/minio-setup-job.yaml
+++ b/apps/ente/minio-setup-job.yaml
@@ -30,7 +30,5 @@ spec:
             - -c
             - |
               mc alias set minio http://ente-minio:9000 $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD
-              mc mb minio/b2-eu-cen --ignore-existing
-              mc mb minio/wasabi-eu-central-2-v3 --ignore-existing
-              mc mb minio/scw-eu-fr-v3 --ignore-existing
+              mc mb minio/ente-data --ignore-existing
   backoffLimit: 4

--- a/apps/ente/minio-setup-job.yaml
+++ b/apps/ente/minio-setup-job.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-create-buckets
+  namespace: ente
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: minio/mc:latest
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ente-secrets
+                  key: minio-root-user
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ente-secrets
+                  key: minio-root-password
+          command:
+            - /bin/sh
+            - -c
+            - |
+              mc alias set minio http://ente-minio:9000 $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD
+              mc mb minio/b2-eu-cen --ignore-existing
+              mc mb minio/wasabi-eu-central-2-v3 --ignore-existing
+              mc mb minio/scw-eu-fr-v3 --ignore-existing
+  backoffLimit: 4

--- a/apps/ente/museum-config.yaml
+++ b/apps/ente/museum-config.yaml
@@ -36,7 +36,7 @@ data:
       silent-logout-secret:
       # Hardcoded accounts for admin access
       hardcoded-ott:
-        hikuohiku@gmail.com: "123456"
+        local-test-user: "123456"
 
     # JWT token validity (optional customization)
     jwt:

--- a/apps/ente/museum-config.yaml
+++ b/apps/ente/museum-config.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: museum-config
+  namespace: ente
+data:
+  local.yaml: |
+    # Ente Museum Server Configuration
+    # Reference: https://github.com/ente-io/ente/blob/main/server/configurations/local.yaml
+
+    http:
+      # API server port
+      port: 8080
+
+    db:
+      host: ente-postgres
+      port: 5432
+      name: ente_db
+      # user and password are injected via environment variables
+
+    s3:
+      # Primary storage bucket
+      b2-eu-cen:
+        key: # Injected via environment
+        secret: # Injected via environment
+        endpoint: http://ente-minio:9000
+        region: eu-central-2
+        bucket: b2-eu-cen
+      # Replication buckets (using same MinIO for self-hosted)
+      wasabi-eu-central-2-v3:
+        key: # Injected via environment
+        secret: # Injected via environment
+        endpoint: http://ente-minio:9000
+        region: eu-central-2
+        bucket: wasabi-eu-central-2-v3
+        compliance: false
+      scw-eu-fr-v3:
+        key: # Injected via environment
+        secret: # Injected via environment
+        endpoint: http://ente-minio:9000
+        region: eu-central-2
+        bucket: scw-eu-fr-v3
+
+    # Internal services for local deployment
+    internal:
+      # Disable silent logout token for self-hosted
+      silent-logout-secret:
+      # Hardcoded accounts for admin access
+      hardcoded-ott:
+        local-test-user: "123456"
+
+    # JWT token validity (optional customization)
+    jwt:
+      secret: # Injected via environment
+
+    # Email configuration (disabled by default, configure if needed)
+    # smtp:
+    #   host: smtp.example.com
+    #   port: 587
+    #   username: user
+    #   password: password
+
+    # Apple In-App Purchase (disabled for self-hosted)
+    # apple:
+    #   shared-secret:
+
+    # Stripe integration (disabled for self-hosted)
+    # stripe:
+    #   key:
+    #   webhook-secret:
+
+    # Logging
+    log-file: ""

--- a/apps/ente/museum-config.yaml
+++ b/apps/ente/museum-config.yaml
@@ -21,27 +21,13 @@ data:
       # user and password are injected via environment variables
 
     s3:
-      # Primary storage bucket
+      # Single bucket for self-hosted deployment
       b2-eu-cen:
         key: # Injected via environment
         secret: # Injected via environment
         endpoint: http://ente-minio:9000
         region: eu-central-2
-        bucket: b2-eu-cen
-      # Replication buckets (using same MinIO for self-hosted)
-      wasabi-eu-central-2-v3:
-        key: # Injected via environment
-        secret: # Injected via environment
-        endpoint: http://ente-minio:9000
-        region: eu-central-2
-        bucket: wasabi-eu-central-2-v3
-        compliance: false
-      scw-eu-fr-v3:
-        key: # Injected via environment
-        secret: # Injected via environment
-        endpoint: http://ente-minio:9000
-        region: eu-central-2
-        bucket: scw-eu-fr-v3
+        bucket: ente-data
 
     # Internal services for local deployment
     internal:

--- a/apps/ente/museum-config.yaml
+++ b/apps/ente/museum-config.yaml
@@ -36,7 +36,7 @@ data:
       silent-logout-secret:
       # Hardcoded accounts for admin access
       hardcoded-ott:
-        local-test-user: "123456"
+        hikuohiku@gmail.com: "123456"
 
     # JWT token validity (optional customization)
     jwt:

--- a/apps/ente/museum-config.yaml
+++ b/apps/ente/museum-config.yaml
@@ -22,6 +22,9 @@ data:
       # user and password are injected via environment variables
 
     s3:
+      # Use local MinIO instance
+      are_local_buckets: true
+      use_path_style_urls: true
       # Single bucket for self-hosted deployment
       b2-eu-cen:
         key: # Injected via environment

--- a/apps/ente/museum-config.yaml
+++ b/apps/ente/museum-config.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: museum-config
   namespace: ente
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 data:
   local.yaml: |
     # Ente Museum Server Configuration

--- a/apps/ente/museum-config.yaml
+++ b/apps/ente/museum-config.yaml
@@ -42,6 +42,12 @@ data:
     jwt:
       secret: # Injected via environment
 
+    # WebAuthn / Passkey configuration
+    webauthn:
+      rpid: ente.tailae6c2.ts.net
+      rporigins:
+        - https://ente.tailae6c2.ts.net
+
     # Email configuration (disabled by default, configure if needed)
     # smtp:
     #   host: smtp.example.com

--- a/apps/ente/museum-config.yaml
+++ b/apps/ente/museum-config.yaml
@@ -18,6 +18,7 @@ data:
       host: ente-postgres
       port: 5432
       name: ente_db
+      sslmode: disable
       # user and password are injected via environment variables
 
     s3:

--- a/apps/ente/museum-deployment.yaml
+++ b/apps/ente/museum-deployment.yaml
@@ -1,0 +1,175 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ente-museum
+  namespace: ente
+  labels:
+    app: ente-museum
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ente-museum
+  template:
+    metadata:
+      labels:
+        app: ente-museum
+    spec:
+      initContainers:
+        # Wait for PostgreSQL to be ready
+        - name: wait-for-postgres
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z ente-postgres 5432; do
+                echo "Waiting for PostgreSQL..."
+                sleep 2
+              done
+              echo "PostgreSQL is ready"
+        # Wait for MinIO to be ready and create buckets
+        - name: wait-for-minio
+          image: minio/mc:latest
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ente-secrets
+                  key: minio-root-user
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ente-secrets
+                  key: minio-root-password
+          command:
+            - sh
+            - -c
+            - |
+              until mc alias set minio http://ente-minio:9000 $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD; do
+                echo "Waiting for MinIO..."
+                sleep 2
+              done
+              echo "MinIO is ready, creating buckets..."
+              mc mb minio/b2-eu-cen --ignore-existing
+              mc mb minio/wasabi-eu-central-2-v3 --ignore-existing
+              mc mb minio/scw-eu-fr-v3 --ignore-existing
+              echo "Buckets created successfully"
+      containers:
+        - name: museum
+          image: ghcr.io/ente-io/server:latest
+          ports:
+            - containerPort: 8080
+          env:
+            # Database configuration
+            - name: ENTE_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ente-secrets
+                  key: postgres-user
+            - name: ENTE_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ente-secrets
+                  key: postgres-password
+            - name: ENTE_DB_HOST
+              value: ente-postgres
+            - name: ENTE_DB_PORT
+              value: "5432"
+            - name: ENTE_DB_NAME
+              value: ente_db
+            # S3/MinIO configuration
+            - name: ENTE_S3_B2_EU_CEN_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ente-secrets
+                  key: minio-root-user
+            - name: ENTE_S3_B2_EU_CEN_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: ente-secrets
+                  key: minio-root-password
+            - name: ENTE_S3_B2_EU_CEN_ENDPOINT
+              value: http://ente-minio:9000
+            - name: ENTE_S3_B2_EU_CEN_REGION
+              value: eu-central-2
+            - name: ENTE_S3_B2_EU_CEN_BUCKET
+              value: b2-eu-cen
+            # Wasabi bucket (using same MinIO)
+            - name: ENTE_S3_WASABI_EU_CENTRAL_2_V3_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ente-secrets
+                  key: minio-root-user
+            - name: ENTE_S3_WASABI_EU_CENTRAL_2_V3_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: ente-secrets
+                  key: minio-root-password
+            - name: ENTE_S3_WASABI_EU_CENTRAL_2_V3_ENDPOINT
+              value: http://ente-minio:9000
+            - name: ENTE_S3_WASABI_EU_CENTRAL_2_V3_REGION
+              value: eu-central-2
+            - name: ENTE_S3_WASABI_EU_CENTRAL_2_V3_BUCKET
+              value: wasabi-eu-central-2-v3
+            # SCW bucket (using same MinIO)
+            - name: ENTE_S3_SCW_EU_FR_V3_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ente-secrets
+                  key: minio-root-user
+            - name: ENTE_S3_SCW_EU_FR_V3_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: ente-secrets
+                  key: minio-root-password
+            - name: ENTE_S3_SCW_EU_FR_V3_ENDPOINT
+              value: http://ente-minio:9000
+            - name: ENTE_S3_SCW_EU_FR_V3_REGION
+              value: eu-central-2
+            - name: ENTE_S3_SCW_EU_FR_V3_BUCKET
+              value: scw-eu-fr-v3
+            # Security keys
+            - name: ENTE_KEY_ENCRYPTION
+              valueFrom:
+                secretKeyRef:
+                  name: ente-secrets
+                  key: encryption-key
+            - name: ENTE_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: ente-secrets
+                  key: jwt-secret
+          volumeMounts:
+            - name: config
+              mountPath: /configurations
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: config
+          configMap:
+            name: museum-config

--- a/apps/ente/museum-deployment.yaml
+++ b/apps/ente/museum-deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: ente
   labels:
     app: ente-museum
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   replicas: 1
   strategy:
@@ -17,46 +19,6 @@ spec:
       labels:
         app: ente-museum
     spec:
-      initContainers:
-        # Wait for PostgreSQL to be ready
-        - name: wait-for-postgres
-          image: busybox:1.36
-          command:
-            - sh
-            - -c
-            - |
-              until nc -z ente-postgres 5432; do
-                echo "Waiting for PostgreSQL..."
-                sleep 2
-              done
-              echo "PostgreSQL is ready"
-        # Wait for MinIO to be ready and create buckets
-        - name: wait-for-minio
-          image: minio/mc:latest
-          env:
-            - name: MINIO_ROOT_USER
-              valueFrom:
-                secretKeyRef:
-                  name: ente-secrets
-                  key: minio-root-user
-            - name: MINIO_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: ente-secrets
-                  key: minio-root-password
-          command:
-            - sh
-            - -c
-            - |
-              until mc alias set minio http://ente-minio:9000 $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD; do
-                echo "Waiting for MinIO..."
-                sleep 2
-              done
-              echo "MinIO is ready, creating buckets..."
-              mc mb minio/b2-eu-cen --ignore-existing
-              mc mb minio/wasabi-eu-central-2-v3 --ignore-existing
-              mc mb minio/scw-eu-fr-v3 --ignore-existing
-              echo "Buckets created successfully"
       containers:
         - name: museum
           image: ghcr.io/ente-io/server:latest

--- a/apps/ente/museum-deployment.yaml
+++ b/apps/ente/museum-deployment.yaml
@@ -76,7 +76,7 @@ spec:
               readOnly: true
           livenessProbe:
             httpGet:
-              path: /health
+              path: /ping
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 10
@@ -84,7 +84,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ping
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5

--- a/apps/ente/museum-deployment.yaml
+++ b/apps/ente/museum-deployment.yaml
@@ -42,7 +42,7 @@ spec:
               value: "5432"
             - name: ENTE_DB_NAME
               value: ente_db
-            # S3/MinIO configuration
+            # S3/MinIO configuration (single bucket)
             - name: ENTE_S3_B2_EU_CEN_KEY
               valueFrom:
                 secretKeyRef:
@@ -58,41 +58,7 @@ spec:
             - name: ENTE_S3_B2_EU_CEN_REGION
               value: eu-central-2
             - name: ENTE_S3_B2_EU_CEN_BUCKET
-              value: b2-eu-cen
-            # Wasabi bucket (using same MinIO)
-            - name: ENTE_S3_WASABI_EU_CENTRAL_2_V3_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: ente-secrets
-                  key: minio-root-user
-            - name: ENTE_S3_WASABI_EU_CENTRAL_2_V3_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: ente-secrets
-                  key: minio-root-password
-            - name: ENTE_S3_WASABI_EU_CENTRAL_2_V3_ENDPOINT
-              value: http://ente-minio:9000
-            - name: ENTE_S3_WASABI_EU_CENTRAL_2_V3_REGION
-              value: eu-central-2
-            - name: ENTE_S3_WASABI_EU_CENTRAL_2_V3_BUCKET
-              value: wasabi-eu-central-2-v3
-            # SCW bucket (using same MinIO)
-            - name: ENTE_S3_SCW_EU_FR_V3_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: ente-secrets
-                  key: minio-root-user
-            - name: ENTE_S3_SCW_EU_FR_V3_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: ente-secrets
-                  key: minio-root-password
-            - name: ENTE_S3_SCW_EU_FR_V3_ENDPOINT
-              value: http://ente-minio:9000
-            - name: ENTE_S3_SCW_EU_FR_V3_REGION
-              value: eu-central-2
-            - name: ENTE_S3_SCW_EU_FR_V3_BUCKET
-              value: scw-eu-fr-v3
+              value: ente-data
             # Security keys
             - name: ENTE_KEY_ENCRYPTION
               valueFrom:

--- a/apps/ente/museum-service.yaml
+++ b/apps/ente/museum-service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: ente-museum
   namespace: ente
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   selector:
     app: ente-museum

--- a/apps/ente/museum-service.yaml
+++ b/apps/ente/museum-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ente-museum
+  namespace: ente
+spec:
+  selector:
+    app: ente-museum
+  ports:
+    - port: 8080
+      targetPort: 8080
+  type: ClusterIP

--- a/apps/ente/postgres-deployment.yaml
+++ b/apps/ente/postgres-deployment.yaml
@@ -43,11 +43,9 @@ spec:
           livenessProbe:
             exec:
               command:
-                - pg_isready
-                - -U
-                - $(POSTGRES_USER)
-                - -d
-                - ente_db
+                - /bin/sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d ente_db
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
@@ -55,11 +53,9 @@ spec:
           readinessProbe:
             exec:
               command:
-                - pg_isready
-                - -U
-                - $(POSTGRES_USER)
-                - -d
-                - ente_db
+                - /bin/sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d ente_db
             initialDelaySeconds: 5
             periodSeconds: 5
             timeoutSeconds: 3

--- a/apps/ente/postgres-deployment.yaml
+++ b/apps/ente/postgres-deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: ente
   labels:
     app: ente-postgres
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: 1
   strategy:

--- a/apps/ente/postgres-deployment.yaml
+++ b/apps/ente/postgres-deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ente-postgres
+  namespace: ente
+  labels:
+    app: ente-postgres
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ente-postgres
+  template:
+    metadata:
+      labels:
+        app: ente-postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ente-secrets
+                  key: postgres-user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ente-secrets
+                  key: postgres-password
+            - name: POSTGRES_DB
+              value: ente_db
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - $(POSTGRES_USER)
+                - -d
+                - ente_db
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - $(POSTGRES_USER)
+                - -d
+                - ente_db
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: ente-postgres-data

--- a/apps/ente/postgres-pvc.yaml
+++ b/apps/ente/postgres-pvc.yaml
@@ -3,6 +3,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: ente-postgres-data
   namespace: ente
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   accessModes:
     - ReadWriteOnce

--- a/apps/ente/postgres-pvc.yaml
+++ b/apps/ente/postgres-pvc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ente-postgres-data
   namespace: ente
   annotations:
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   accessModes:
     - ReadWriteOnce

--- a/apps/ente/postgres-pvc.yaml
+++ b/apps/ente/postgres-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ente-postgres-data
+  namespace: ente
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 10Gi

--- a/apps/ente/postgres-service.yaml
+++ b/apps/ente/postgres-service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: ente-postgres
   namespace: ente
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   selector:
     app: ente-postgres

--- a/apps/ente/postgres-service.yaml
+++ b/apps/ente/postgres-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ente-postgres
+  namespace: ente
+spec:
+  selector:
+    app: ente-postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+  type: ClusterIP

--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - external-secrets/application.yaml
   - tailscale-operator/application.yaml
   # - nextcloud/application.yaml  # disabled - manifests kept for reference
+  - ente/application.yaml
 


### PR DESCRIPTION
Add Kubernetes manifests for self-hosting Ente (Google Photos alternative):

Components:
- PostgreSQL 15 database with persistent storage
- MinIO object storage with 3 buckets for photo data
- Museum server (Ente backend) with health checks
- Tailscale Ingress for secure access

Configuration:
- External secrets integration via Doppler
- Init containers for dependency checks and bucket creation
- Resource limits and liveness/readiness probes
- local-path storage class for persistence