### PR TITLE
feat(immich): add Immich K8s manifests for LXC migration

### DIFF
--- a/apps/immich/application.yaml
+++ b/apps/immich/application.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: immich
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/hikuohiku/homelab.git
+    targetRevision: HEAD
+    path: apps/immich
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: immich
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/immich/ingress.yaml
+++ b/apps/immich/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: immich
+  namespace: immich
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: immich-server
+      port:
+        number: 2283
+  tls:
+    - hosts:
+        - immich

--- a/apps/immich/kustomization.yaml
+++ b/apps/immich/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+helmCharts:
+  - name: immich
+    repo: oci://ghcr.io/immich-app/immich-charts
+    version: 0.12.0
+    releaseName: immich
+    namespace: immich
+    valuesFile: values.yaml
+
+resources:
+  - ingress.yaml
+  - library-pvc.yaml
+  - postgres.yaml
+  - postgres-external-secret.yaml

--- a/apps/immich/library-pvc.yaml
+++ b/apps/immich/library-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-library
+  namespace: immich
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 50Gi

--- a/apps/immich/postgres-external-secret.yaml
+++ b/apps/immich/postgres-external-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: immich-postgres-credentials
+  namespace: immich
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler
+  target:
+    name: immich-postgres-credentials
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: password
+      remoteRef:
+        key: IMMICH_DB_PASSWORD

--- a/apps/immich/postgres.yaml
+++ b/apps/immich/postgres.yaml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-postgres-data
+  namespace: immich
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: immich-postgres
+  namespace: immich
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: immich-postgres
+  template:
+    metadata:
+      labels:
+        app: immich-postgres
+    spec:
+      securityContext:
+        fsGroup: 70
+      initContainers:
+        - name: init-permissions
+          image: busybox:1.36
+          command: ["sh", "-c", "chown -R 70:70 /var/lib/postgresql/data"]
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      containers:
+        - name: postgres
+          image: ghcr.io/tensorchord/cloudnative-vectorchord:16.9-0.4.3
+          args:
+            - -c
+            - shared_preload_libraries=vchord.so
+          env:
+            - name: POSTGRES_USER
+              value: immich
+            - name: POSTGRES_DB
+              value: immich
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: immich-postgres-credentials
+                  key: password
+            - name: POSTGRES_INITDB_ARGS
+              value: "--data-checksums"
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - immich
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - immich
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: immich-postgres-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: immich-postgres
+  namespace: immich
+spec:
+  selector:
+    app: immich-postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/apps/immich/values.yaml
+++ b/apps/immich/values.yaml
@@ -1,0 +1,65 @@
+controllers:
+  main:
+    containers:
+      main:
+        image:
+          tag: v2.6.3
+        env:
+          DB_HOSTNAME: immich-postgres
+          DB_USERNAME: immich
+          DB_DATABASE_NAME: immich
+          REDIS_HOSTNAME: '{{ printf "%s-valkey" .Release.Name }}'
+          IMMICH_MACHINE_LEARNING_URL: '{{ printf "http://%s-machine-learning:3003" .Release.Name }}'
+          DB_PASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: immich-postgres-credentials
+                key: password
+
+immich:
+  persistence:
+    library:
+      existingClaim: immich-library
+
+valkey:
+  enabled: true
+  controllers:
+    main:
+      containers:
+        main:
+          image:
+            repository: docker.io/valkey/valkey
+            tag: 9.1-alpine
+  persistence:
+    data:
+      enabled: true
+      size: 1Gi
+      type: persistentVolumeClaim
+      accessMode: ReadWriteOnce
+      storageClass: local-path
+
+server:
+  enabled: true
+  ingress:
+    main:
+      enabled: false
+
+machine-learning:
+  enabled: true
+  controllers:
+    main:
+      containers:
+        main:
+          image:
+            repository: ghcr.io/immich-app/immich-machine-learning
+          env:
+            TRANSFORMERS_CACHE: /cache
+            HF_XET_CACHE: /cache/huggingface-xet
+            MPLCONFIGDIR: /cache/matplotlib-config
+  persistence:
+    cache:
+      enabled: true
+      size: 10Gi
+      type: persistentVolumeClaim
+      accessMode: ReadWriteOnce
+      storageClass: local-path

--- a/apps/immich/values.yaml
+++ b/apps/immich/values.yaml
@@ -52,6 +52,7 @@ machine-learning:
         main:
           image:
             repository: ghcr.io/immich-app/immich-machine-learning
+            tag: v2.6.3
           env:
             TRANSFORMERS_CACHE: /cache
             HF_XET_CACHE: /cache/huggingface-xet

--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - dex/application.yaml
   - external-secrets/application.yaml
   - tailscale-operator/application.yaml
+  - immich/application.yaml
   # - nextcloud/application.yaml  # disabled - manifests kept for reference
 


### PR DESCRIPTION
## Summary

- Immich (写真管理) を LXC コンテナ (vmid 111) から Kubernetes へ移行するためのマニフェスト一式を追加
- Helm chart v0.12.0 / Immich v2.6.3 で構成
- PostgreSQL (vectorchord 拡張), Valkey, ML コンポーネント, Tailscale Ingress を含む
- データ移行（DB ダンプ + 写真ライブラリ）は完了済み、K8s 上で動作確認済み

## 変更内容

- `apps/immich/` — 7 ファイル新規作成（application, kustomization, values, postgres, ExternalSecret, PVC, ingress）
- `apps/kustomization.yaml` — App of Apps に immich を追加

## 構成

| コンポーネント | イメージ | 備考 |
|--------------|---------|------|
| Immich Server | ghcr.io/immich-app/immich-server:v2.6.3 | |
| Machine Learning | ghcr.io/immich-app/immich-machine-learning:v2.6.3 | CPU only |
| PostgreSQL | ghcr.io/tensorchord/cloudnative-vectorchord:16.9-0.4.3 | vchord 拡張 |
| Valkey | docker.io/valkey/valkey:9.1-alpine | Redis 互換 |

## Test plan

- [x] ArgoCD で Synced / Healthy を確認
- [x] 全 Pod (server, postgres, ML, valkey) が Running
- [x] Tailscale 経由で Immich UI にアクセス可能
- [x] LXC からの DB ダンプリストア成功（v2.3.1 → v2.6.3 マイグレーション完了）
- [x] 既存写真・アルバム・人物情報の表示を確認
- [x] LXC コンテナ (vmid 111) を停止済み

Closes #38 の Immich 部分

🤖 Generated with [Claude Code](https://claude.com/claude-code)