### PR TITLE
feat: vaultwarden を k8s へ移行する manifest を追加

### DIFF
--- a/Plans.md
+++ b/Plans.md
@@ -36,4 +36,22 @@ pbs (qemu/112) の扱いを決定する。
 |------|------|-----|---------|--------|
 | A | 停止中 VM/LXC の棚卸し・削除（9台） | 現存は vaultwarden(100)/syncthing(101)/docker(106)/pbs(112)/node01(113) のみ | - | 完了 [PR #45] |
 | B | pbs を手動管理（Terraform 管理対象外）として明示 | pbs.tf.ignore に注記追記 / README・CLAUDE.md に明記 / Proxmox の `terraform` タグ削除 | A | 完了 [PR #45] |
-| C | IaC 管理外の空 namespace 削除（ente / nextcloud / vaultwarden） | 3 namespace を削除（nextcloud は 50Gi データ含め破棄合意済み）/ repo の nextcloud 定義（kustomization 行・apps/nextcloud/・dex OIDC client）を整理 | - | cc:完了 |
+| C | IaC 管理外の空 namespace 削除（ente / nextcloud / vaultwarden） | 3 namespace を削除（nextcloud は 50Gi データ含め破棄合意済み）/ repo の nextcloud 定義（kustomization 行・apps/nextcloud/・dex OIDC client）を整理 | - | 完了 [PR #46] |
+
+---
+
+# LXC → k8s 移行 Plans.md
+
+作成日: 2026-06-21
+
+## 概要
+
+Proxmox LXC で手動運用中のサービスを k8s (ArgoCD) へ移行する。manifest は helm chart を使わずゼロスクラッチで手書きする方針。immich が先行移行済み。
+
+## Phase 1: 移行バックログ
+
+| Task | 内容 | DoD | Depends | Status |
+|------|------|-----|---------|--------|
+| M0 | docker VM(106) 削除（未使用） | qemu/106 削除 / Tailscale `hikuo-homedocker` 削除 | - | TODO（ユーザー手動） |
+| M1 | vaultwarden を k8s 移行（手書き manifest） | apps/vaultwarden/ 作成・登録 / Doppler `VAULTWARDEN_ADMIN_TOKEN` 登録 / 旧 LXC tailscale 退避 / /data 移行 / 検証 | - | cc:manifest作成済（Doppler・データ移行・検証はユーザー実施待ち） |
+| M2 | syncthing を k8s 移行 | 後回し（~100G・P2P 特性のため移行可否も含め保留） | - | 保留 |

--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
   - external-secrets/application.yaml
   - tailscale-operator/application.yaml
   - immich/application.yaml
+  - vaultwarden/application.yaml
 

--- a/apps/vaultwarden/admin-token-external-secret.yaml
+++ b/apps/vaultwarden/admin-token-external-secret.yaml
@@ -1,0 +1,22 @@
+# Vaultwarden 管理画面 (/admin) 用 ADMIN_TOKEN を Doppler から取得
+# Requires: ClusterSecretStore 'doppler' (apps/external-secrets/cluster-secret-store.yaml)
+# Requires: Doppler secret VAULTWARDEN_ADMIN_TOKEN
+#   ADMIN_TOKEN は Argon2 PHC 文字列 (`vaultwarden hash` で生成) または平文を登録する。
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: vaultwarden-admin-token
+  namespace: vaultwarden
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler
+  target:
+    name: vaultwarden-admin-token
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: ADMIN_TOKEN
+      remoteRef:
+        key: VAULTWARDEN_ADMIN_TOKEN

--- a/apps/vaultwarden/application.yaml
+++ b/apps/vaultwarden/application.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vaultwarden
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/hikuohiku/homelab.git
+    targetRevision: HEAD
+    path: apps/vaultwarden
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: vaultwarden
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/vaultwarden/deployment.yaml
+++ b/apps/vaultwarden/deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vaultwarden
+  namespace: vaultwarden
+  labels:
+    app: vaultwarden
+spec:
+  replicas: 1
+  # SQLite は単一ファイル DB。RWO PVC を複数 Pod で同時マウントさせないよう
+  # Recreate にして rolling 中の二重起動を防ぐ。
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: vaultwarden
+  template:
+    metadata:
+      labels:
+        app: vaultwarden
+    spec:
+      securityContext:
+        # /data の所有権を揃える。下の runAsUser と合わせる。
+        fsGroup: 1000
+      initContainers:
+        # local-path の PVC は root:root で作成されるため、非 root 実行に備えて所有権を調整
+        - name: init-permissions
+          image: busybox:1.36
+          command: ["sh", "-c", "chown -R 1000:1000 /data"]
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      containers:
+        - name: vaultwarden
+          # latest ではなく具体的なバージョンに pin (最新安定版 1.36.0 / alpine variant)
+          image: vaultwarden/server:1.36.0-alpine
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+          env:
+            # 公開 URL。/admin の origin 検証や WebAuthn/メール内リンクに使用
+            - name: DOMAIN
+              value: https://vaultwarden.tailae6c2.ts.net
+            # 既存ユーザー移行のため新規サインアップは閉じる
+            - name: SIGNUPS_ALLOWED
+              value: "false"
+            # vaultwarden は ROCKET_PORT のデフォルトが 80。明示しておく
+            - name: ROCKET_PORT
+              value: "80"
+            # WebSocket 通知 (リアルタイム同期) は 1.x 系で HTTP ポートに統合済みのため
+            # 別ポート/別 env (WEBSOCKET_ENABLED) は不要。Ingress も 80 だけで完結する。
+            - name: ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: vaultwarden-admin-token
+                  key: ADMIN_TOKEN
+          ports:
+            - name: http
+              containerPort: 80
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /alive
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: vaultwarden-data

--- a/apps/vaultwarden/ingress.yaml
+++ b/apps/vaultwarden/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: vaultwarden
+  namespace: vaultwarden
+  annotations:
+    # immich パターン流用: クラスタ内トラフィックを Ingress 経由で転送
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: vaultwarden
+      port:
+        number: 80
+  tls:
+    # tailscale Ingress は tls.hosts の短縮名から MagicDNS 名
+    # vaultwarden.tailae6c2.ts.net を発行する (immich と同様)。
+    - hosts:
+        - vaultwarden

--- a/apps/vaultwarden/kustomization.yaml
+++ b/apps/vaultwarden/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# helm chart は使わず全リソースを手書き管理 (隠れリソースを作らない方針)
+resources:
+  - pvc.yaml
+  - admin-token-external-secret.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/apps/vaultwarden/pvc.yaml
+++ b/apps/vaultwarden/pvc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vaultwarden-data
+  namespace: vaultwarden
+  annotations:
+    # データ消失防止: ArgoCD prune / app 削除時も PVC を残す
+    argocd.argoproj.io/sync-options: Prune=false
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      # 現 LXC 100 の割当は 6Gi (実使用 ~4.5Gi)。
+      # SQLite + attachments/sends 程度なので控えめに 5Gi とする。
+      storage: 5Gi

--- a/apps/vaultwarden/service.yaml
+++ b/apps/vaultwarden/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vaultwarden
+  namespace: vaultwarden
+  labels:
+    app: vaultwarden
+spec:
+  type: ClusterIP
+  selector:
+    app: vaultwarden
+  ports:
+    - name: http
+      port: 80
+      targetPort: http


### PR DESCRIPTION
## 概要

Proxmox LXC(100) で手動運用していた vaultwarden を k8s (ArgoCD) へ移行します。LXC→k8s 移行方針の一環（immich に続く2例目）。

**manifest は helm chart を使わずゼロスクラッチで手書き**しています（chart 内部で生成されるリソースを制御できないため）。`kubectl kustomize` でビルド検証済み、生成されるのは下記の手書きリソースのみ。

## 追加リソース（apps/vaultwarden/）

| リソース | 要点 |
|---|---|
| Deployment `vaultwarden` | `vaultwarden/server:1.36.0-alpine`（pin）、`Recreate`（SQLite 二重起動防止）、initContainer で `/data` 所有権調整、runAsNonRoot(1000)、`/alive` probe、resource limits |
| PVC `vaultwarden-data` | local-path / RWO / 5Gi / `Prune=false`（データ保全） |
| Service `vaultwarden` | ClusterIP :80 |
| Ingress `vaultwarden` | `ingressClassName: tailscale`、`vaultwarden.tailae6c2.ts.net` |
| ExternalSecret `vaultwarden-admin-token` | ClusterSecretStore `doppler`、`VAULTWARDEN_ADMIN_TOKEN` → env `ADMIN_TOKEN` |
| Application | App of Apps 登録（automated prune+selfHeal、CreateNamespace=true） |

## マージ前/移行時にユーザーが行う作業

1. **Doppler**: `homelab/prd` に `VAULTWARDEN_ADMIN_TOKEN` を登録（`/admin` 用、Argon2 PHC 推奨）
2. **Tailscale 名前衝突回避**: 旧 LXC(100) のデバイス hostname `vaultwarden` と新 Ingress 名が競合。移行時に旧 LXC の tailscale を logout/デバイス削除
3. **データ移行**（ダウンタイムは③〜⑥のみ）: 旧 `pct stop 100` → `/data`（db.sqlite3 / attachments / sends / rsa_key.* / config.json）を取り出し → 新 PVC へ `kubectl cp`（所有権 1000:1000）→ 新 Pod 起動・`/admin`・同期確認 → 旧 LXC 破棄

## 関連

- Plans.md に LXC→k8s 移行バックログ（M0 docker VM 削除 / M1 vaultwarden / M2 syncthing 保留）を追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)