### PR TITLE
chore: kubectl を ask 付きで許可する方針を反映 + 移行 Plans 更新

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,9 @@
       "mcp__argocd__*",
       "mcp__proxmox__*",
       "mcp__tailscale__*"
+    ],
+    "ask": [
+      "Bash(kubectl:*)"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,8 @@ Doppler (homelab/prd)
 ### エージェント操作ルール
 
 - **インフラ参照は MCP ツール経由で行う**: `mcp__kubectl__*`, `mcp__argocd__*`, `mcp__proxmox__*`, `mcp__tailscale__*` を使う
-- **kubectl / curl 等の CLI を直接使わない**: CLI は管理者権限の kubeconfig を使うため credential 分離が無効になる。MCP サーバーが read-only 制約を担保している
+- **インフラの参照（read）は MCP を使う**: CLI は管理者権限の kubeconfig を使うため credential 分離が無効になる。参照は MCP サーバーが read-only 制約を担保しているので MCP 経由を原則とする
+- **kubectl の書き込み（write）は人間レビュー付き（ask）でのみ許可**: MCP は read-only のため、デプロイ検証・データ移行など write が必要な操作は `kubectl` CLI を使う。`.claude/settings.json` の `permissions.ask` に `Bash(kubectl:*)` を設定し、エージェントが叩く kubectl は毎回ユーザーがコマンドを目視レビューして承認する運用とする（無断実行は不可）
 - **例外**: `tailscale up` / `tailscale status` / `just *` は CLI 許可済み（MCP 非対応の操作）
 
 ### トラブルシューティング

--- a/Plans.md
+++ b/Plans.md
@@ -53,7 +53,7 @@ Proxmox LXC で手動運用中のサービスを k8s (ArgoCD) へ移行する。
 | Task | 内容 | DoD | Depends | Status |
 |------|------|-----|---------|--------|
 | M0 | docker VM(106) 削除（未使用） | qemu/106 削除 / Tailscale `hikuo-homedocker` 削除 | - | TODO（ユーザー手動） |
-| M1 | vaultwarden を k8s 移行（手書き manifest） | apps/vaultwarden/ 作成・登録 / Doppler `VAULTWARDEN_ADMIN_TOKEN` 登録 / 旧 LXC tailscale 退避 / /data 移行 / 検証 | - | 完了 [PR #47]（ciphers 781 件移行・ログイン確認済み。旧 LXC 100 破棄はユーザー手動待ち） |
+| M1 | vaultwarden を k8s 移行（手書き manifest） | apps/vaultwarden/ 作成・登録 / Doppler `VAULTWARDEN_ADMIN_TOKEN` 登録 / 旧 LXC tailscale 退避 / /data 移行 / 検証 | - | 完了 [PR #47]（ciphers 781 件移行・ログイン確認済み・旧 LXC 100 破棄済み） |
 | M2 | syncthing を k8s 移行 | 後回し（~100G・P2P 特性のため移行可否も含め保留） | - | 保留 |
 
 > 補足: k8s への書き込み操作（移行時の scale/cp/exec 等）に伴い、`.claude/settings.json` の `permissions.ask` に `Bash(kubectl:*)` を追加し、kubectl は人間レビュー（ask）付きで実行する方針に変更（CLAUDE.md 反映済み）。

--- a/Plans.md
+++ b/Plans.md
@@ -52,7 +52,7 @@ Proxmox LXC で手動運用中のサービスを k8s (ArgoCD) へ移行する。
 
 | Task | 内容 | DoD | Depends | Status |
 |------|------|-----|---------|--------|
-| M0 | docker VM(106) 削除（未使用） | qemu/106 削除 / Tailscale `hikuo-homedocker` 削除 | - | TODO（ユーザー手動） |
+| M0 | docker VM(106) 削除（未使用） | qemu/106 削除 / Tailscale `hikuo-homedocker` 削除 | - | 完了（qemu/106 削除済み・検証済み。Tailscale デバイス削除はユーザー手動） |
 | M1 | vaultwarden を k8s 移行（手書き manifest） | apps/vaultwarden/ 作成・登録 / Doppler `VAULTWARDEN_ADMIN_TOKEN` 登録 / 旧 LXC tailscale 退避 / /data 移行 / 検証 | - | 完了 [PR #47]（ciphers 781 件移行・ログイン確認済み・旧 LXC 100 破棄済み） |
 | M2 | syncthing を k8s 移行 | 後回し（~100G・P2P 特性のため移行可否も含め保留） | - | 保留 |
 

--- a/Plans.md
+++ b/Plans.md
@@ -53,5 +53,7 @@ Proxmox LXC で手動運用中のサービスを k8s (ArgoCD) へ移行する。
 | Task | 内容 | DoD | Depends | Status |
 |------|------|-----|---------|--------|
 | M0 | docker VM(106) 削除（未使用） | qemu/106 削除 / Tailscale `hikuo-homedocker` 削除 | - | TODO（ユーザー手動） |
-| M1 | vaultwarden を k8s 移行（手書き manifest） | apps/vaultwarden/ 作成・登録 / Doppler `VAULTWARDEN_ADMIN_TOKEN` 登録 / 旧 LXC tailscale 退避 / /data 移行 / 検証 | - | cc:manifest作成済（Doppler・データ移行・検証はユーザー実施待ち） |
+| M1 | vaultwarden を k8s 移行（手書き manifest） | apps/vaultwarden/ 作成・登録 / Doppler `VAULTWARDEN_ADMIN_TOKEN` 登録 / 旧 LXC tailscale 退避 / /data 移行 / 検証 | - | 完了 [PR #47]（ciphers 781 件移行・ログイン確認済み。旧 LXC 100 破棄はユーザー手動待ち） |
 | M2 | syncthing を k8s 移行 | 後回し（~100G・P2P 特性のため移行可否も含め保留） | - | 保留 |
+
+> 補足: k8s への書き込み操作（移行時の scale/cp/exec 等）に伴い、`.claude/settings.json` の `permissions.ask` に `Bash(kubectl:*)` を追加し、kubectl は人間レビュー（ask）付きで実行する方針に変更（CLAUDE.md 反映済み）。


### PR DESCRIPTION
## 概要

vaultwarden の k8s 移行（PR #47）に伴い判明した運用方針を文書・設定へ反映するフォローアップ。

## 変更

- **`.claude/settings.json`**: `permissions.ask` に `Bash(kubectl:*)` を追加。
  MCP kubectl は read-only のため、デプロイ検証・データ移行などの **write 操作は人間レビュー（ask）付きの kubectl CLI** で行う運用にする（エージェントが叩く kubectl は毎回ユーザーが承認）。
- **`CLAUDE.md`**: エージェント操作ルールを「**参照は MCP / write は ask 付き kubectl**」に更新。credential 分離の趣旨（無断の admin kubectl 禁止）は維持。
- **`Plans.md`**: M1 vaultwarden 移行を完了に更新（ciphers 781 件移行・ログイン確認済み。旧 LXC 100 破棄はユーザー手動待ち）。

## 補足

vaultwarden 本体は PR #47 でマージ済み・稼働中（ArgoCD Synced/Healthy）。本 PR はドキュメント/設定のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)