### PR TITLE
fix(vaultwarden): 1.36.0 → 1.37.1 でクライアント同期不具合を解消

### DIFF
--- a/apps/vaultwarden/deployment.yaml
+++ b/apps/vaultwarden/deployment.yaml
@@ -34,8 +34,10 @@ spec:
               mountPath: /data
       containers:
         - name: vaultwarden
-          # latest ではなく具体的なバージョンに pin (最新安定版 1.36.0 / alpine variant)
-          image: vaultwarden/server:1.36.0-alpine
+          # latest ではなく具体的なバージョンに pin (最新安定版 1.37.1 / alpine variant)
+          # 1.37.0 が Bitwarden クライアント 2026.7.0+ の対応に必須。
+          # 1.37.1 は alpine イメージのビルド不具合 (OpenSSL) 修正を含むため alpine では 1.37.1 を採る。
+          image: vaultwarden/server:1.37.1-alpine
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000


### PR DESCRIPTION
## 症状

Web vault からは正常にアクセスできるが、**モバイル / ブラウザ拡張 / デスクトップの各クライアントで vault のレコードが表示されない**。

## 原因

上流 1.37.0 のリリースノートに明記されている:

> This update is required for support with clients with version 2026.7.0+, please update before reporting any issues with them.

クライアントは自動更新で 2026.7 系に上がっている一方、サーバーは **1.36.0（2026-05-03 リリース）のまま**だった。イメージタグを pin しているため、誰かが上げない限りサーバー側は永久に据え置かれる。

この構図は症状と整合する:

- **Web vault が正常** — web vault はサーバー同梱（1.36.0 は v2026.4.1 を同梱）なので、サーバーとバージョンが揃っており影響を受けない
- **外部クライアントのみ失敗** — 自動更新で 2026.7.0+ に到達し、1.36.0 のサーバーと不整合

サーバーログ上も、クライアントは

```
POST /identity/connect/token      => 200 OK
GET  /api/accounts/revision-date  => 200 OK
```

までは到達しているが、**`/api/sync` が一度も現れていない**。認証は通り同期段階で失敗している、という挙動と一致する。

## 変更

`apps/vaultwarden/deployment.yaml` のイメージタグを 1 行更新（+ 根拠コメント）。

```diff
-          image: vaultwarden/server:1.36.0-alpine
+          image: vaultwarden/server:1.37.1-alpine
```

**1.37.0 ではなく 1.37.1 を採る理由**: 1.37.0 は alpine variant に OpenSSL 由来のビルド不具合（upstream #7475）があり、1.37.1 で修正されている。本デプロイは alpine variant を使っているため 1.37.1 が適切。

## 確認済み

- [x] `vaultwarden/server:1.37.1-alpine` が Docker Hub に存在（2026-07-29 更新、amd64 あり、59.3 MB）
- [x] `kubectl kustomize apps/vaultwarden/` がイメージタグ更新後もビルド成功
- [x] ノードの空きディスク 4.2 GB に対しイメージ 59.3 MB で収まる

## マージ後の検証

ArgoCD の Sync 後、以下を確認する:

- [ ] vaultwarden Pod が 1.37.1 で Running
- [ ] モバイル / 拡張 / デスクトップの各クライアントでレコードが表示される
- [ ] サーバーログに `/api/sync` が 200 で現れる

## 補足

本 PR は原因を「サーバーのバージョン据え置き」と判断して 1 行の更新のみに絞っている。同様の据え置きを再発させないための週次メンテナンス自動化は別ストリームで扱う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vpwwtewofx3gkPELD9RQG