### PR TITLE
feat: node01 を 4c/12GB/50GB にスケールアップ

### DIFF
--- a/terraform/proxmox/providers.tf
+++ b/terraform/proxmox/providers.tf
@@ -1,5 +1,6 @@
 terraform {
-  required_version = "1.14.1"
+  # 完全一致 pin は nix 管理の terraform (nixpkgs 更新で動く) と噛み合わないため範囲指定。
+  required_version = "~> 1.15"
 
   # Terraform Cloud backend for state management
   cloud {

--- a/terraform/proxmox/vm-nixos.tf
+++ b/terraform/proxmox/vm-nixos.tf
@@ -36,19 +36,19 @@ resource "proxmox_virtual_environment_vm" "node01" {
   }
 
   cpu {
-    cores = 2
+    cores = 4
     type  = "host"
   }
 
   memory {
-    dedicated = 8192
+    dedicated = 12288
   }
 
   # Import disk from downloaded qcow2 image (no template/clone needed)
   disk {
     datastore_id = "local-lvm"
     interface    = "virtio0"
-    size         = 20
+    size         = 50
     file_format  = "raw"
     import_from  = proxmox_virtual_environment_download_file.nixos_image.id
   }


### PR DESCRIPTION
pbs (112) を停止して確保したホストリソースを node01 に割り当てる。PR #44 (Coder) から Terraform 部分だけを切り出したもの。

## ⚠️ マージ前に必須の作業

**Doppler の `NIXOS_IMAGE_VERSION` を `v0.3.1` → `v0.2.5` に戻すこと。**

戻さずに `terraform apply` すると **node01 が破棄・再作成され、local-path の PVC が全部消えます**（immich の写真、vaultwarden の 781 件、dex 等）。pbs を停止した今、バックアップもありません。

これは本 PR の変更が原因ではなく、**main に元から存在する状態**です。詳細は「発見した既存の問題」を参照。

## 変更

`terraform/proxmox/vm-nixos.tf` — node01 のリソース拡張

| 項目 | 変更前 | 変更後 |
|---|---|---|
| cores | 2 | 4 |
| memory | 8192 | 12288 |
| disk | 20 | 50 |

`terraform/proxmox/providers.tf` — `required_version` を `"1.14.1"` → `"~> 1.15"`

ローカルの terraform は nix 管理（`/nix/store/...-terraform-1.15.5`）で nixpkgs の更新につれて動くため、完全一致 pin では plan すら通らない（実際 1.15.5 でブロックされた）。execution-mode は `local` なので、効いているのはローカル CLI のバージョンのみ。

なお 1.15.5 で apply すると state が 1.15 系で書き直され、1.14.x では読めなくなる（片道）。

## 根拠となる実測値

Proxmox ホスト `hikuo-homeserver`: **4 コア / 約 15.4 GiB RAM / local-lvm 852.9 GB（空き 713.7 GB）**

RAM の割当:

| 時点 | 割当合計 |
|---|---|
| pbs 停止前 | pbs 8 + node01 8 + syncthing 2 = **18 GiB**（物理超過） |
| pbs 停止後 | node01 8 + syncthing 2 = 10 GiB |
| 本 PR 適用後 | node01 12 + syncthing 2 = 14 GiB（ホストに約 1.4 GiB 残る） |

ディスクは 713.7 GB 空いており 20→50 GB は余裕がある。現在ノードの空きは **4.2 GB** しかなく、これが Plans.md M2（syncthing 移行、実データ 105.1 GB）を止めている原因でもあった。本 PR で M2 のディスク面の障害は解ける。

## plan の確認結果

`NIXOS_IMAGE_VERSION` を実デプロイ済みの v0.2.5 に固定した状態:

```
Plan: 0 to add, 1 to change, 0 to destroy
  ~ cores      2 -> 4
  ~ size      20 -> 50
  ~ dedicated 8192 -> 12288
```

**完全な in-place 更新**。ディスク拡張が VM 再作成を誘発する懸念は外れだった。

## 発見した既存の問題（本 PR とは独立）

`vm-nixos.tf:81-85` に「ベースイメージが変わったら VM を作り直す」lifecycle がある。

```hcl
lifecycle {
  replace_triggered_by = [
    proxmox_virtual_environment_download_file.nixos_image.id
  ]
}
```

イミュータブルインフラとしては妥当な設計だが、**Doppler の `NIXOS_IMAGE_VERSION` が v0.3.1 で、デプロイ済み VM は v0.2.5 由来**という乖離がある。この状態では変更の有無にかかわらず `terraform apply` を打つだけで node01 が再作成される。

```
# proxmox_virtual_environment_download_file.nixos_image must be replaced
  ~ file_name = "...v0.2.5.qcow2" -> "...v0.3.1.qcow2"  # forces replacement
# proxmox_virtual_environment_vm.node01 will be replaced due to changes in replace_triggered_by
```

変数の値は「今デプロイされているもの」を表すべきで、上げるのはリビルドを意図的に起こすときに限る。v0.3.1 への更新自体は、PVC データの退避計画とセットで別途扱う必要がある。

## apply 後に必要な確認

- [ ] ゲスト内でパーティション/ファイルシステムが 50 GB に追随したか（cloud-init の growpart 任せ。伸びていなければ手動）
- [ ] cores/memory の反映に VM 再起動が要るか
- [ ] `mcp__kubectl__node_stats_summary_tool` でノードの空きが増えたことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vpwwtewofx3gkPELD9RQG