### PR TITLE
feat: Coder 開発サーバーを手書き manifest で追加

### DIFF
--- a/apps/coder/application.yaml
+++ b/apps/coder/application.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: coder
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/hikuohiku/homelab.git
+    targetRevision: HEAD
+    path: apps/coder
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: coder
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/coder/deployment.yaml
+++ b/apps/coder/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coder
+  namespace: coder
+  labels:
+    app: coder
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: coder
+  template:
+    metadata:
+      labels:
+        app: coder
+    spec:
+      serviceAccountName: coder
+      # 終了時に workspace の後始末をする猶予を与える (chart 既定に合わせる)
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: coder
+          image: ghcr.io/coder/coder:v2.34.7
+          command: ["/opt/coder"]
+          args: ["server"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: CODER_HTTP_ADDRESS
+              value: 0.0.0.0:8080
+            # 公開 URL。ブラウザからのアクセス先で、workspace agent の接続先にもなる
+            - name: CODER_ACCESS_URL
+              value: https://coder.tailae6c2.ts.net
+            # 既定で有効な GitHub OAuth プロバイダを切る (認証は後で dex 経由に寄せる)
+            - name: CODER_OAUTH2_GITHUB_DEFAULT_PROVIDER_ENABLE
+              value: "false"
+            - name: CODER_PG_CONNECTION_URL
+              valueFrom:
+                secretKeyRef:
+                  name: coder-db-url
+                  key: url
+            # DERP 中継はレプリカ自身の Pod IP を広告する必要がある
+            - name: KUBE_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: CODER_DERP_SERVER_RELAY_URL
+              value: http://$(KUBE_POD_IP):8080
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            # chart 既定は requests/limits とも 2000m/4096Mi だが、node01 は
+            # 4c/11.7GiB で既に約 6GiB 使用済みのため単一ユーザー向けに絞る。
+            # workspace は別 Pod として起動するのでここは制御プレーン分のみ。
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30

--- a/apps/coder/ingress.yaml
+++ b/apps/coder/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: coder
+  namespace: coder
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: coder
+      port:
+        number: 80
+  tls:
+    - hosts:
+        - coder

--- a/apps/coder/kustomization.yaml
+++ b/apps/coder/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# helm chart は使わず全リソースを手書き管理 (隠れリソースを作らない方針)
+resources:
+  - postgres-external-secret.yaml
+  - postgres.yaml
+  - rbac.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/apps/coder/postgres-external-secret.yaml
+++ b/apps/coder/postgres-external-secret.yaml
@@ -1,0 +1,37 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: coder-postgres-credentials
+  namespace: coder
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler
+  target:
+    name: coder-postgres-credentials
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: password
+      remoteRef:
+        key: CODER_DB_PASSWORD
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: coder-db-url
+  namespace: coder
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler
+  target:
+    name: coder-db-url
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: url
+      remoteRef:
+        key: CODER_DB_URL

--- a/apps/coder/postgres.yaml
+++ b/apps/coder/postgres.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: coder-postgres-data
+  namespace: coder
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coder-postgres
+  namespace: coder
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: coder-postgres
+  template:
+    metadata:
+      labels:
+        app: coder-postgres
+    spec:
+      securityContext:
+        fsGroup: 999
+      initContainers:
+        - name: init-permissions
+          image: busybox:1.37
+          command: ["sh", "-c", "chown -R 999:999 /var/lib/postgresql/data"]
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      containers:
+        - name: postgres
+          image: postgres:17.5
+          env:
+            - name: POSTGRES_USER
+              value: coder
+            - name: POSTGRES_DB
+              value: coder
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: coder-postgres-credentials
+                  key: password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - coder
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - coder
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: coder-postgres-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coder-postgres
+  namespace: coder
+spec:
+  selector:
+    app: coder-postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/apps/coder/rbac.yaml
+++ b/apps/coder/rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coder
+  namespace: coder
+---
+# Coder は workspace を同 namespace の Pod/PVC/Deployment として払い出すため、
+# 自身にその操作権限が要る。付与範囲は coder namespace 内に限定 (Role)。
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: coder-workspace-perms
+  namespace: coder
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "persistentvolumeclaims"]
+    verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: coder
+  namespace: coder
+subjects:
+  - kind: ServiceAccount
+    name: coder
+    namespace: coder
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: coder-workspace-perms

--- a/apps/coder/service.yaml
+++ b/apps/coder/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: coder
+  namespace: coder
+spec:
+  # chart 既定は LoadBalancer だが、外部公開は Tailscale Ingress が担うため ClusterIP。
+  type: ClusterIP
+  selector:
+    app: coder
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP

--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - tailscale-operator/application.yaml
   - immich/application.yaml
   - vaultwarden/application.yaml
+  - coder/application.yaml
 


### PR DESCRIPTION
PR #44 を helm chart 依存から手書きに置き換えたもの。#44 はクローズする。

Terraform 部分（node01 のスケールアップ）は #51 で切り出し済み・適用済みのため、本 PR は manifest のみ。

## ⚠️ マージ前に必須の作業

**Doppler（homelab/prd）に以下 2 つを登録すること。** 現在どちらも未登録で、この状態でマージすると ExternalSecret が解決できず Coder が起動しない。

| キー | 値 |
|---|---|
| `CODER_DB_PASSWORD` | 任意のランダム文字列 |
| `CODER_DB_URL` | `postgres://coder:<上のパスワード>@coder-postgres.coder.svc.cluster.local:5432/coder?sslmode=disable` |

## なぜ書き直したか

chart を使うと生成リソースを制御できず、パラメータ管理が chart の values に縛られる。Coder は新規アプリなので、後から変換するより最初から手書きする方が安い。

Coder 本体（ServiceAccount / Role / RoleBinding / Service / Deployment）を chart 2.34.7 のレンダリング結果を基に手書きした。**postgres・ExternalSecret・Ingress は #44 の時点で既に手書きだったのでそのまま流用**している。

バージョンは #44 の 2.33.2 から最新の **2.34.7** に更新した。

## chart 既定からの意図的な差分

| 項目 | chart 既定 | 本 PR | 理由 |
|---|---|---|---|
| Service | LoadBalancer | ClusterIP | 外部公開は Tailscale Ingress が担う |
| resources | requests/limits とも 2000m / 4096Mi | 100m–1000m / 256Mi–1Gi | node01 は 4c/11.7GiB で既に約 6GiB 使用済み。workspace は別 Pod として起動するので、ここは制御プレーン分のみ |
| podAntiAffinity | あり | 削除 | 単一ノードのため無意味 |
| `CODER_PROMETHEUS_ADDRESS` / `CODER_PPROF_ADDRESS` | あり | 削除 | Prometheus 不在。pprof をポートに晒す必要もない |
| livenessProbe | なし（readiness のみ） | 追加 | ハングしたときに復帰させる |

RBAC は chart と同じ範囲（`coder` namespace 内の pods / pvc / deployments）。Coder は workspace を同 namespace の Pod として払い出すため、この権限が要る。ClusterRole ではなく Role なので影響範囲は namespace 内に閉じている。

## 確認済み

- [x] `kubectl kustomize apps/coder/` が成功（11 リソース生成: SA / Role / RoleBinding / Service ×2 / PVC / Deployment ×2 / ExternalSecret ×2 / Ingress）
- [x] `kubectl kustomize apps/` （App of Apps ルート）が成功
- [x] chart 2.34.7 のレンダリング結果と突き合わせ、意図的な差分以外の取りこぼしがないことを確認
- [x] イメージタグ `ghcr.io/coder/coder:v2.34.7` は chart の appVersion と一致

## マージ後の確認

- [ ] ArgoCD が coder アプリを認識・Sync する
- [ ] ExternalSecret が解決し `coder-db-url` Secret が生成される
- [ ] postgres と coder の Pod が Running
- [ ] `https://coder.tailae6c2.ts.net` にアクセスでき、初回セットアップ画面が出る
- [ ] ワークスペース作成 → VSCode Remote SSH で接続できる

## 既知の制約

- **ワイルドカードアクセス URL 未設定**。Coder の workspace アプリをサブドメインで公開する機能（`CODER_WILDCARD_ACCESS_URL`）は、Tailscale Ingress でワイルドカード証明書を扱うのが難しいため設定していない。パスベースのプロキシで大半は動く
- **メモリの余裕が薄い**。node01 12GiB + syncthing 2GiB に対しホスト物理は約 15.4GiB。制御プレーンは収まるが、実際に開発ワークスペースを走らせる余力は多くない。pbs (112) は現在停止中で、再起動すると 8GiB の割当が戻り破綻する
- **認証は初期状態のまま**。GitHub OAuth の既定プロバイダは無効化してある。dex 経由の OIDC に寄せるかは別途

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vpwwtewofx3gkPELD9RQG