### PR TITLE
ops: 定期実行を 1 時間ごとに変更し、run #1 の記録を残す

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -10,7 +10,7 @@
       "title": "tailscale k8s-nameserver の floating tag `unstable` を固定バージョンに変える",
       "kind": "refactor",
       "risk": "medium",
-      "status": "in_progress",
+      "status": "todo",
       "priority": 1,
       "why": "repo 内で唯一バージョンが固定されていない箇所。Pod が再起動するたびに中身が変わりうるので、壊れたときに原因を特定できない",
       "dod": "apps/tailscale-operator/dns-config.yaml が具体的なバージョンタグを指し、ops/inventory.json の該当エントリも更新されている",
@@ -18,7 +18,8 @@
         "apps/tailscale-operator/dns-config.yaml"
       ],
       "created": "2026-08-04",
-      "pr": null
+      "pr": null,
+      "notes": "run #1 が in_progress にしたが作業ブランチを残さず終了したため todo に戻した"
     },
     {
       "id": "T-0002",

--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -182,24 +182,28 @@ a { color:var(--sig); }
     </div>
     <div class="mast__sub">
       <span>homelab を自律運用するエージェントの記録</span>
-      <span>次の起動 2026-08-04 21:19 UTC</span>
-      <span>生成 2026-08-04 18:44 UTC</span>
+      <span>定期実行 未設定</span>
+      <span>生成 2026-08-04 18:46 UTC</span>
     </div>
   </header>
 
-  <div class="stats"><div class="stat stat--sig"><span class="stat__v">44 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">20</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">1</span><span class="stat__l">あなた待ち</span></div></div>
+  <div class="stats"><div class="stat stat--sig"><span class="stat__v">22 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">20</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">1</span><span class="stat__l">あなた待ち</span></div></div>
 
   <section>
     <h2>やったこと</h2>
     <p class="lede">マージ済み＝homelab に反映済みの変更。新しい順。</p>
     <ul class="list">
       <li class="done">
+        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/59">fix(ops): main への直 push を廃し、記録も PR に載せる</a>
+        <span class="done__meta">#59 · 1 分前</span>
+      </li>
+      <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/58">feat(ops): 判断を人間に渡さない方針へ憲章を改める</a>
-        <span class="done__meta">#58 · 12 分前</span>
+        <span class="done__meta">#58 · 14 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/57">feat(ops): homelab を自律運用する autopilot の器を作る</a>
-        <span class="done__meta">#57 · 21 分前</span>
+        <span class="done__meta">#57 · 23 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/55">fix(coder): secure workspace SSH key before clone</a>
@@ -236,10 +240,6 @@ a { color:var(--sig); }
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/47">feat: vaultwarden を k8s へ移行する manifest を追加</a>
         <span class="done__meta">#47 · 44 日前</span>
-      </li>
-      <li class="done">
-        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/46">chore: IaC 管理外の空 namespace を整理</a>
-        <span class="done__meta">#46 · 44 日前</span>
       </li></ul>
   </section>
 
@@ -280,7 +280,7 @@ a { color:var(--sig); }
     <h2>これからやること</h2>
     <p class="lede">上から順に着手します。1 タスク = 1 PR。</p>
     <ul class="list">
-      <li class="task task--sig">
+      <li class="task task--idle">
         <div class="task__head">
           <span class="task__id">T-0001</span>
           <h3 class="task__title">tailscale k8s-nameserver の floating tag `unstable` を固定バージョンに変える</h3>
@@ -288,7 +288,7 @@ a { color:var(--sig); }
         <p class="task__why">repo 内で唯一バージョンが固定されていない箇所。Pod が再起動するたびに中身が変わりうるので、壊れたときに原因を特定できない</p>
         
         <div class="task__meta">
-          <span class="chip chip--sig">作業中</span>
+          <span class="chip chip--idle">待ち</span>
           <span class="chip chip--quiet">整理</span>
           <span class="chip chip--quiet">リスク 中</span>
           <span class="task__refs"><code>apps/tailscale-operator/dns-config.yaml</code></span>

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,12 @@
   "open": [],
   "merged": [
     {
+      "mergedAt": "2026-08-04T18:45:09Z",
+      "number": 59,
+      "title": "fix(ops): main への直 push を廃し、記録も PR に載せる",
+      "url": "https://github.com/hikuohiku/homelab/pull/59"
+    },
+    {
       "mergedAt": "2026-08-04T18:32:23Z",
       "number": 58,
       "title": "feat(ops): 判断を人間に渡さない方針へ憲章を改める",
@@ -114,12 +120,6 @@
       "number": 29,
       "title": "docs: Proxmox local storageのimportコンテンツタイプ設定を前提条件に追加",
       "url": "https://github.com/hikuohiku/homelab/pull/29"
-    },
-    {
-      "mergedAt": "2025-12-14T16:59:57Z",
-      "number": 27,
-      "title": "feat: add custom tailnet hostname for ArgoCD service",
-      "url": "https://github.com/hikuohiku/homelab/pull/27"
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -15,11 +15,11 @@
     {
       "id": "trig_01LyC3zdzPCF8WLSpLpWDVsr",
       "name": "homelab autopilot",
-      "cron": "19 */3 * * * (UTC)",
-      "cron_human": "3 時間ごと",
-      "next": "2026-08-04 21:19 UTC",
+      "cron": "19 * * * * (UTC)",
+      "cron_human": "1 時間ごと（毎時 19 分）",
       "model": "claude-sonnet-5",
-      "url": "https://claude.ai/code/routines/trig_01LyC3zdzPCF8WLSpLpWDVsr"
+      "url": "https://claude.ai/code/routines/trig_01LyC3zdzPCF8WLSpLpWDVsr",
+      "note": "立ち上げ期は頻度を上げて安定性を見る。落ち着いたら間隔を空ける"
     }
   ],
   "runs": [
@@ -29,6 +29,14 @@
       "kind": "bootstrap",
       "by": "human + Claude Code (対話セッション)",
       "summary": "器の初期構築。VISION / CHARTER / backlog / inventory / CI / ダッシュボードを作成",
+      "prs": []
+    },
+    {
+      "n": 1,
+      "at": "2026-08-04T18:24:00Z",
+      "kind": "scheduled(manual trigger)",
+      "by": "cloud routine",
+      "summary": "疎通確認。main への push は成功したが PR 作成前に終了。ruleset 導入後は直 push 不可のため運用を PR 経由へ変更",
       "prs": []
     }
   ]


### PR DESCRIPTION
立ち上げ期は頻度を上げて安定性を見ます（3 時間ごと → 1 時間ごと、毎時 19 分）。

run #1 が `in_progress` にした T-0001 は、作業ブランチを残さずに終了していたため `todo` に戻します。新しい憲章では中断は `autopilot/*` ブランチとオープン PR から拾うので、残っていない以上は未着手扱いが正しい状態です。

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 生成成功