### PR TITLE
ops: issue #56 のフィードバックを反映、T-0014 を needs-human に

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 14,
-  "updated": "2026-08-04T18:20:00Z",
+  "next_id": 15,
+  "updated": "2026-08-04T18:59:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）",
   "tasks": [
     {
@@ -224,6 +224,24 @@
       ],
       "created": "2026-08-04",
       "pr": null
+    },
+    {
+      "id": "T-0014",
+      "domain": "homelab",
+      "title": "main への直 push を検知する CI (direct-push-guard) を追加する",
+      "kind": "ci",
+      "risk": "low",
+      "status": "needs-human",
+      "priority": 0,
+      "why": "main の ruleset『CI 必須』は PR 経由のマージだけを対象にし、main への直 push は CI を経ずに素通りする。issue #56 で人間から指摘を受けた",
+      "dod": "push: branches: [main] で走る workflow が、マージされた PR に紐付かないコミットで ops/ 以外のファイルが変更された場合に失敗し、issue #56 にコメントする",
+      "needs_human_reason": "workflow の内容は書けたが、この環境の GitHub App credential に workflows 権限が無く `.github/workflows/` 配下への push が git push・API 経由のどちらも 403 (\"Resource not accessible by integration\") で拒否される。GitHub App の Settings → Permissions で Workflows を Read and write にするか、下記の内容を人間が直接コミットしてほしい。ファイル本体は branch `autopilot/T-0014-direct-push-guard` には無い（push できなかったため）。issue #56 のコメントに全文を貼った",
+      "refs": [
+        ".github/workflows/direct-push-guard.yml"
+      ],
+      "created": "2026-08-04",
+      "pr": null,
+      "notes": "issue #56 のフィードバックを受けて起票、同じ回で着手したが GitHub App の権限不足で push できず needs-human に変更"
     }
   ]
 }

--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -183,11 +183,11 @@ a { color:var(--sig); }
     <div class="mast__sub">
       <span>homelab を自律運用するエージェントの記録</span>
       <span>定期実行 未設定</span>
-      <span>生成 2026-08-04 18:54 UTC</span>
+      <span>生成 2026-08-04 19:03 UTC</span>
     </div>
   </header>
 
-  <div class="stats"><div class="stat stat--sig"><span class="stat__v">30 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">20</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">1</span><span class="stat__l">あなた待ち</span></div></div>
+  <div class="stats"><div class="stat stat--sig"><span class="stat__v">4 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">20</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
 
   <section>
     <h2>やったこと</h2>
@@ -195,23 +195,23 @@ a { color:var(--sig); }
     <ul class="list">
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/61">fix(ops): 権限プロンプトで起動が消えるのを防ぐ</a>
-        <span class="done__meta">#61 · 2 分前</span>
+        <span class="done__meta">#61 · 11 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/60">ops: 定期実行を 1 時間ごとに変更し、run #1 の記録を残す</a>
-        <span class="done__meta">#60 · 7 分前</span>
+        <span class="done__meta">#60 · 16 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/59">fix(ops): main への直 push を廃し、記録も PR に載せる</a>
-        <span class="done__meta">#59 · 9 分前</span>
+        <span class="done__meta">#59 · 17 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/58">feat(ops): 判断を人間に渡さない方針へ憲章を改める</a>
-        <span class="done__meta">#58 · 21 分前</span>
+        <span class="done__meta">#58 · 30 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/57">feat(ops): homelab を自律運用する autopilot の器を作る</a>
-        <span class="done__meta">#57 · 31 分前</span>
+        <span class="done__meta">#57 · 39 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/55">fix(coder): secure workspace SSH key before clone</a>
@@ -249,6 +249,20 @@ a { color:var(--sig); }
     <ul class="list">
       <li class="task task--crit">
         <div class="task__head">
+          <span class="task__id">T-0014</span>
+          <h3 class="task__title">main への直 push を検知する CI (direct-push-guard) を追加する</h3>
+        </div>
+        <p class="task__why">main の ruleset『CI 必須』は PR 経由のマージだけを対象にし、main への直 push は CI を経ずに素通りする。issue #56 で人間から指摘を受けた</p>
+        <p class="task__note">workflow の内容は書けたが、この環境の GitHub App credential に workflows 権限が無く `.github/workflows/` 配下への push が git push・API 経由のどちらも 403 (&quot;Resource not accessible by integration&quot;) で拒否される。GitHub App の Settings → Permissions で Workflows を Read and write にするか、下記の内容を人間が直接コミットしてほしい。ファイル本体は branch `autopilot/T-0014-direct-push-guard` には無い（push できなかったため）。issue #56 のコメントに全文を貼った</p>
+        <div class="task__meta">
+          <span class="chip chip--crit">要判断</span>
+          <span class="chip chip--quiet">CI</span>
+          <span class="chip chip--quiet">リスク 低</span>
+          <span class="task__refs"><code>.github/workflows/direct-push-guard.yml</code></span>
+        </div>
+      </li>
+      <li class="task task--crit">
+        <div class="task__head">
           <span class="task__id">T-0011</span>
           <h3 class="task__title">vaultwarden の ADMIN_TOKEN を Argon2 ハッシュ化する（Doppler への登録をお願いしたい）</h3>
         </div>
@@ -268,7 +282,7 @@ a { color:var(--sig); }
     <p>使っていて感じたことを殴り書きで構いません。進め方への指摘は憲章に、やってほしいことはタスクとして取り込まれます。
        読んだら 3 行以内で返信します。<strong>返信が無い＝まだ読んでいない</strong>と判断してください。</p>
     <a class="fb__cta" href="https://github.com/hikuohiku/homelab/issues/56">issue #56 に書く</a>
-    <span class="fb__meta">最後に読んだ: —</span>
+    <span class="fb__meta">最後に読んだ: 36 分前</span>
   </section>
 
   <section>
@@ -461,6 +475,10 @@ a { color:var(--sig); }
       <li class="run">
         <h3 class="run__head">2026-08-04 18:24 UTC — run #1（消失）</h3>
         <ul class="run__body"><li>`main` への push はできた（T-0001 を in_progress にする commit）。認証は通っている</li><li>**`kubectl` を実行して権限プロンプトで停止した。** ヘッドレス実行では誰も答えられないため、そのまま何も残さず終了</li><li>原因は `.claude/settings.json` の `permissions.ask` に `Bash(kubectl:*)` があること。</li><li>対処: CHARTER §5.1 を新設し、`ask` / `deny` 対象のコマンドと代替手段を明記した。</li><li>*`kubectl` は使わない。マニフェストの検証は CI に任せる**</li><li>あわせて ruleset により `main` への直 push が不可能になったため、記録も含めて全部 PR 経由に変更した</li></ul>
+      </li>
+      <li class="run">
+        <h3 class="run__head">2026-08-04 18:59 UTC — run #2</h3>
+        <ul class="run__body"><li>読んだフィードバック: issue #56（人間ではなく構築セッションからの疎通確認コメント）。</li><li>やったこと: T-0014 を起票し着手。`.github/workflows/direct-push-guard.yml` の中身は書けた</li><li>**重要な発見**: この環境の GitHub App credential には `workflows` 権限が無い。</li><li>次の起動へ: T-0014 は `needs-human`。GitHub App に workflows 権限（Read and write）が付与されたら</li></ul>
       </li></ul>
   </section>
 

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -30,3 +30,20 @@
 - 対処: CHARTER §5.1 を新設し、`ask` / `deny` 対象のコマンドと代替手段を明記した。
   **`kubectl` は使わない。マニフェストの検証は CI に任せる**
 - あわせて ruleset により `main` への直 push が不可能になったため、記録も含めて全部 PR 経由に変更した
+
+## 2026-08-04 18:59 UTC — run #2
+
+- 読んだフィードバック: issue #56（人間ではなく構築セッションからの疎通確認コメント）。
+  「main の ruleset は PR マージだけを止める。`main` への直 push は素通りする」という指摘
+- やったこと: T-0014 を起票し着手。`.github/workflows/direct-push-guard.yml` の中身は書けた
+  （`push: branches: [main]` で走り、マージ済み PR に紐付かないコミットで `ops/` 以外が変更されて
+  いたら失敗させ issue #56 にコメントする。防止ではなく検知）が、**push できずに `needs-human` へ**
+- **重要な発見**: この環境の GitHub App credential には `workflows` 権限が無い。
+  `.github/workflows/` 配下への書き込みは `git push`（ローカルの http proxy）・
+  `mcp__github__push_files` のどちらを使っても `403 Resource not accessible by integration` で拒否される。
+  git 側のエラーメッセージは "refusing to allow a GitHub App to create or update workflow ... without
+  workflows permission" と明示していた。**回避策は無い**（GitHub 側のサーバーサイド制約）。
+  今後 `.github/workflows/*.yml` を触るタスクは同じ壁に当たるので、着手前にこのメモを思い出すこと
+- 次の起動へ: T-0014 は `needs-human`。GitHub App に workflows 権限（Read and write）が付与されたら
+  再着手する。ファイル本体は issue #56 のコメントに全文を貼った
+- 前回の中断: オープン PR・`autopilot/*` ブランチともに無し。拾うものは無かった

--- a/ops/state.json
+++ b/ops/state.json
@@ -6,7 +6,7 @@
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": null
+    "last_read": "2026-08-04T18:26:42Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -37,6 +37,14 @@
       "kind": "scheduled(manual trigger)",
       "by": "cloud routine",
       "summary": "疎通確認。main への push は成功したが PR 作成前に終了。ruleset 導入後は直 push 不可のため運用を PR 経由へ変更",
+      "prs": []
+    },
+    {
+      "n": 2,
+      "at": "2026-08-04T18:59:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "issue #56 のフィードバックを反映し T-0014 起票。workflow の中身は書けたが GitHub App に workflows 権限が無く push 不可と判明、needs-human に変更",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

issue #56 のフィードバック（main の ruleset は PR マージだけを対象にし、`main` への直 push は CI を経ずに素通りする）を反映しました。

- backlog に T-0014「main への直 push を検知する CI (direct-push-guard) を追加する」を起票
- workflow の中身（`push: branches: [main]` で走り、マージ済み PR に紐付かないコミットで `ops/` 以外が変更されていたら失敗させ issue にコメントする）は用意しましたが、**この環境の GitHub App credential に `workflows` 権限が無く `.github/workflows/` 配下への push が拒否されるため、着手できませんでした**。T-0014 は `needs-human` にしています
- journal・dashboard を更新

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 生成成功

## ロールバック手順

このコミットを revert すれば元に戻ります（`ops/` 配下の記録のみで実インフラへの影響なし）。

## backlog task id

T-0014（`needs-human` に変更。詳細は issue #56 のコメント参照）

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6z7pyhQt8xAtvM5Mdpojt)_