### PR TITLE
ops: T-0014 の pr 番号を記録する (#63)

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -240,7 +240,7 @@
         ".github/workflows/direct-push-guard.yml"
       ],
       "created": "2026-08-04",
-      "pr": null,
+      "pr": 63,
       "notes": "issue #56 のフィードバックを受けて起票、同じ回で着手したが GitHub App の権限不足で push できず needs-human に変更"
     }
   ]

--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -183,11 +183,11 @@ a { color:var(--sig); }
     <div class="mast__sub">
       <span>homelab を自律運用するエージェントの記録</span>
       <span>定期実行 未設定</span>
-      <span>生成 2026-08-04 19:03 UTC</span>
+      <span>生成 2026-08-04 19:04 UTC</span>
     </div>
   </header>
 
-  <div class="stats"><div class="stat stat--sig"><span class="stat__v">4 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">20</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
+  <div class="stats"><div class="stat stat--sig"><span class="stat__v">5 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">20</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
 
   <section>
     <h2>やったこと</h2>
@@ -195,23 +195,23 @@ a { color:var(--sig); }
     <ul class="list">
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/61">fix(ops): 権限プロンプトで起動が消えるのを防ぐ</a>
-        <span class="done__meta">#61 · 11 分前</span>
+        <span class="done__meta">#61 · 12 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/60">ops: 定期実行を 1 時間ごとに変更し、run #1 の記録を残す</a>
-        <span class="done__meta">#60 · 16 分前</span>
+        <span class="done__meta">#60 · 17 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/59">fix(ops): main への直 push を廃し、記録も PR に載せる</a>
-        <span class="done__meta">#59 · 17 分前</span>
+        <span class="done__meta">#59 · 19 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/58">feat(ops): 判断を人間に渡さない方針へ憲章を改める</a>
-        <span class="done__meta">#58 · 30 分前</span>
+        <span class="done__meta">#58 · 31 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/57">feat(ops): homelab を自律運用する autopilot の器を作る</a>
-        <span class="done__meta">#57 · 39 分前</span>
+        <span class="done__meta">#57 · 40 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/55">fix(coder): secure workspace SSH key before clone</a>
@@ -250,7 +250,7 @@ a { color:var(--sig); }
       <li class="task task--crit">
         <div class="task__head">
           <span class="task__id">T-0014</span>
-          <h3 class="task__title">main への直 push を検知する CI (direct-push-guard) を追加する</h3>
+          <h3 class="task__title">main への直 push を検知する CI (direct-push-guard) を追加する <a class="prlink" href="63">PR</a></h3>
         </div>
         <p class="task__why">main の ruleset『CI 必須』は PR 経由のマージだけを対象にし、main への直 push は CI を経ずに素通りする。issue #56 で人間から指摘を受けた</p>
         <p class="task__note">workflow の内容は書けたが、この環境の GitHub App credential に workflows 権限が無く `.github/workflows/` 配下への push が git push・API 経由のどちらも 403 (&quot;Resource not accessible by integration&quot;) で拒否される。GitHub App の Settings → Permissions で Workflows を Read and write にするか、下記の内容を人間が直接コミットしてほしい。ファイル本体は branch `autopilot/T-0014-direct-push-guard` には無い（push できなかったため）。issue #56 のコメントに全文を貼った</p>
@@ -282,7 +282,7 @@ a { color:var(--sig); }
     <p>使っていて感じたことを殴り書きで構いません。進め方への指摘は憲章に、やってほしいことはタスクとして取り込まれます。
        読んだら 3 行以内で返信します。<strong>返信が無い＝まだ読んでいない</strong>と判断してください。</p>
     <a class="fb__cta" href="https://github.com/hikuohiku/homelab/issues/56">issue #56 に書く</a>
-    <span class="fb__meta">最後に読んだ: 36 分前</span>
+    <span class="fb__meta">最後に読んだ: 37 分前</span>
   </section>
 
   <section>

--- a/ops/state.json
+++ b/ops/state.json
@@ -45,7 +45,7 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "issue #56 のフィードバックを反映し T-0014 起票。workflow の中身は書けたが GitHub App に workflows 権限が無く push 不可と判明、needs-human に変更",
-      "prs": []
+      "prs": [63]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

PR #63 が CI green で即マージされ、backlog/state に PR 番号を記録する追記コミットが間に合いませんでした。記録のみ合わせます。

## 検証したこと

- `python3 ops/validate.py` → 0 error

## ロールバック手順

このコミットを revert すれば元に戻ります（`ops/` 配下の記録のみで実インフラへの影響なし）。

## backlog task id

T-0014

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6z7pyhQt8xAtvM5Mdpojt)_