### PR TITLE
ops: workflows 権限の付与を受けて T-0014 のブロックを解除する

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -231,17 +231,16 @@
       "title": "main への直 push を検知する CI (direct-push-guard) を追加する",
       "kind": "ci",
       "risk": "low",
-      "status": "needs-human",
+      "status": "todo",
       "priority": 0,
       "why": "main の ruleset『CI 必須』は PR 経由のマージだけを対象にし、main への直 push は CI を経ずに素通りする。issue #56 で人間から指摘を受けた",
       "dod": "push: branches: [main] で走る workflow が、マージされた PR に紐付かないコミットで ops/ 以外のファイルが変更された場合に失敗し、issue #56 にコメントする",
-      "needs_human_reason": "workflow の内容は書けたが、この環境の GitHub App credential に workflows 権限が無く `.github/workflows/` 配下への push が git push・API 経由のどちらも 403 (\"Resource not accessible by integration\") で拒否される。GitHub App の Settings → Permissions で Workflows を Read and write にするか、下記の内容を人間が直接コミットしてほしい。ファイル本体は branch `autopilot/T-0014-direct-push-guard` には無い（push できなかったため）。issue #56 のコメントに全文を貼った",
       "refs": [
         ".github/workflows/direct-push-guard.yml"
       ],
       "created": "2026-08-04",
       "pr": 63,
-      "notes": "issue #56 のフィードバックを受けて起票、同じ回で着手したが GitHub App の権限不足で push できず needs-human に変更"
+      "notes": "2026-08-04: GitHub App に workflows 権限が付与され、.github/workflows/ への push が可能になった。着手時にまず小さな workflow の push で権限を実地確認すること。run #2 で書いた workflow 本文は失われているので書き直しになる"
     }
   ]
 }

--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -183,35 +183,47 @@ a { color:var(--sig); }
     <div class="mast__sub">
       <span>homelab を自律運用するエージェントの記録</span>
       <span>定期実行 未設定</span>
-      <span>生成 2026-08-04 19:04 UTC</span>
+      <span>生成 2026-08-04 19:07 UTC</span>
     </div>
   </header>
 
-  <div class="stats"><div class="stat stat--sig"><span class="stat__v">5 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">20</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
+  <div class="stats"><div class="stat stat--sig"><span class="stat__v">8 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">20</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">1</span><span class="stat__l">あなた待ち</span></div></div>
 
   <section>
     <h2>やったこと</h2>
     <p class="lede">マージ済み＝homelab に反映済みの変更。新しい順。</p>
     <ul class="list">
       <li class="done">
+        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/64">ops: T-0014 の pr 番号を記録する (#63)</a>
+        <span class="done__meta">#64 · 2 分前</span>
+      </li>
+      <li class="done">
+        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/63">ops: issue #56 のフィードバックを反映、T-0014 を needs-human に</a>
+        <span class="done__meta">#63 · 3 分前</span>
+      </li>
+      <li class="done">
+        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/62">fix: permissions.ask を全廃する</a>
+        <span class="done__meta">#62 · 12 分前</span>
+      </li>
+      <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/61">fix(ops): 権限プロンプトで起動が消えるのを防ぐ</a>
-        <span class="done__meta">#61 · 12 分前</span>
+        <span class="done__meta">#61 · 15 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/60">ops: 定期実行を 1 時間ごとに変更し、run #1 の記録を残す</a>
-        <span class="done__meta">#60 · 17 分前</span>
+        <span class="done__meta">#60 · 20 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/59">fix(ops): main への直 push を廃し、記録も PR に載せる</a>
-        <span class="done__meta">#59 · 19 分前</span>
+        <span class="done__meta">#59 · 22 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/58">feat(ops): 判断を人間に渡さない方針へ憲章を改める</a>
-        <span class="done__meta">#58 · 31 分前</span>
+        <span class="done__meta">#58 · 34 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/57">feat(ops): homelab を自律運用する autopilot の器を作る</a>
-        <span class="done__meta">#57 · 40 分前</span>
+        <span class="done__meta">#57 · 44 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/55">fix(coder): secure workspace SSH key before clone</a>
@@ -228,18 +240,6 @@ a { color:var(--sig); }
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/52">feat: Coder 開発サーバーを手書き manifest で追加</a>
         <span class="done__meta">#52 · 1 日前</span>
-      </li>
-      <li class="done">
-        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/51">feat: node01 を 4c/12GB/50GB にスケールアップ</a>
-        <span class="done__meta">#51 · 1 日前</span>
-      </li>
-      <li class="done">
-        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/50">feat: 週次メンテナンスの手順を /weekly-maintenance コマンドに定義</a>
-        <span class="done__meta">#50 · 1 日前</span>
-      </li>
-      <li class="done">
-        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/49">fix(vaultwarden): 1.36.0 → 1.37.1 でクライアント同期不具合を解消</a>
-        <span class="done__meta">#49 · 1 日前</span>
       </li></ul>
   </section>
 
@@ -247,20 +247,6 @@ a { color:var(--sig); }
     <h2>あなたに手を動かしてほしいこと</h2>
     <p class="lede">権限や認証まわりなど、こちらでは手が届かない作業だけを出します。判断を頼むことはありません。</p>
     <ul class="list">
-      <li class="task task--crit">
-        <div class="task__head">
-          <span class="task__id">T-0014</span>
-          <h3 class="task__title">main への直 push を検知する CI (direct-push-guard) を追加する <a class="prlink" href="63">PR</a></h3>
-        </div>
-        <p class="task__why">main の ruleset『CI 必須』は PR 経由のマージだけを対象にし、main への直 push は CI を経ずに素通りする。issue #56 で人間から指摘を受けた</p>
-        <p class="task__note">workflow の内容は書けたが、この環境の GitHub App credential に workflows 権限が無く `.github/workflows/` 配下への push が git push・API 経由のどちらも 403 (&quot;Resource not accessible by integration&quot;) で拒否される。GitHub App の Settings → Permissions で Workflows を Read and write にするか、下記の内容を人間が直接コミットしてほしい。ファイル本体は branch `autopilot/T-0014-direct-push-guard` には無い（push できなかったため）。issue #56 のコメントに全文を貼った</p>
-        <div class="task__meta">
-          <span class="chip chip--crit">要判断</span>
-          <span class="chip chip--quiet">CI</span>
-          <span class="chip chip--quiet">リスク 低</span>
-          <span class="task__refs"><code>.github/workflows/direct-push-guard.yml</code></span>
-        </div>
-      </li>
       <li class="task task--crit">
         <div class="task__head">
           <span class="task__id">T-0011</span>
@@ -282,7 +268,7 @@ a { color:var(--sig); }
     <p>使っていて感じたことを殴り書きで構いません。進め方への指摘は憲章に、やってほしいことはタスクとして取り込まれます。
        読んだら 3 行以内で返信します。<strong>返信が無い＝まだ読んでいない</strong>と判断してください。</p>
     <a class="fb__cta" href="https://github.com/hikuohiku/homelab/issues/56">issue #56 に書く</a>
-    <span class="fb__meta">最後に読んだ: 37 分前</span>
+    <span class="fb__meta">最後に読んだ: 40 分前</span>
   </section>
 
   <section>
@@ -294,6 +280,20 @@ a { color:var(--sig); }
     <h2>これからやること</h2>
     <p class="lede">上から順に着手します。1 タスク = 1 PR。</p>
     <ul class="list">
+      <li class="task task--idle">
+        <div class="task__head">
+          <span class="task__id">T-0014</span>
+          <h3 class="task__title">main への直 push を検知する CI (direct-push-guard) を追加する <a class="prlink" href="63">PR</a></h3>
+        </div>
+        <p class="task__why">main の ruleset『CI 必須』は PR 経由のマージだけを対象にし、main への直 push は CI を経ずに素通りする。issue #56 で人間から指摘を受けた</p>
+        
+        <div class="task__meta">
+          <span class="chip chip--idle">待ち</span>
+          <span class="chip chip--quiet">CI</span>
+          <span class="chip chip--quiet">リスク 低</span>
+          <span class="task__refs"><code>.github/workflows/direct-push-guard.yml</code></span>
+        </div>
+      </li>
       <li class="task task--idle">
         <div class="task__head">
           <span class="task__id">T-0001</span>
@@ -447,22 +447,8 @@ a { color:var(--sig); }
           <span class="chip chip--quiet">リスク 低</span>
           <span class="task__refs"><code>ops/CHARTER.md</code><code>ops/journal/</code></span>
         </div>
-      </li>
-      <li class="task task--warn">
-        <div class="task__head">
-          <span class="task__id">T-0010</span>
-          <h3 class="task__title">ArgoCD の Health / Sync 状態を autopilot が確認できる経路を作る</h3>
-        </div>
-        <p class="task__why">auto-merge した変更が実際に反映されて健全かを、次の起動で確認したい。クラウド実行環境からは Tailscale 越しの homelab に届かない</p>
-        <p class="task__note">クラウド実行環境から homelab への到達経路が無い。設計から必要</p>
-        <div class="task__meta">
-          <span class="chip chip--warn">詰まり</span>
-          <span class="chip chip--quiet">機能</span>
-          <span class="chip chip--quiet">リスク 低</span>
-          <span class="task__refs"><code>ops/CHARTER.md</code></span>
-        </div>
       </li></ul>
-    
+    <p class="more">ほか 1 件</p>
   </section>
 
   <section>
@@ -479,6 +465,10 @@ a { color:var(--sig); }
       <li class="run">
         <h3 class="run__head">2026-08-04 18:59 UTC — run #2</h3>
         <ul class="run__body"><li>読んだフィードバック: issue #56（人間ではなく構築セッションからの疎通確認コメント）。</li><li>やったこと: T-0014 を起票し着手。`.github/workflows/direct-push-guard.yml` の中身は書けた</li><li>**重要な発見**: この環境の GitHub App credential には `workflows` 権限が無い。</li><li>次の起動へ: T-0014 は `needs-human`。GitHub App に workflows 権限（Read and write）が付与されたら</li></ul>
+      </li>
+      <li class="run">
+        <h3 class="run__head">2026-08-04 19:30 UTC — 人間による権限付与</h3>
+        <ul class="run__body"><li>**GitHub App に `workflows` 権限が付与された。** `.github/workflows/` への push が可能になったはず</li><li>T-0014（直 push 検知の CI）を `needs-human` から `todo` に戻した。優先度 0</li><li>着手するときは、まず小さな変更を push して権限が実際に効いているか確かめること。</li><li>run #2 で書いた workflow の本文はどこにも残っていない（issue にも貼れていなかった）。書き直しになる</li></ul>
       </li></ul>
   </section>
 

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,24 @@
   "open": [],
   "merged": [
     {
+      "mergedAt": "2026-08-04T19:04:54Z",
+      "number": 64,
+      "title": "ops: T-0014 の pr 番号を記録する (#63)",
+      "url": "https://github.com/hikuohiku/homelab/pull/64"
+    },
+    {
+      "mergedAt": "2026-08-04T19:03:50Z",
+      "number": 63,
+      "title": "ops: issue #56 のフィードバックを反映、T-0014 を needs-human に",
+      "url": "https://github.com/hikuohiku/homelab/pull/63"
+    },
+    {
+      "mergedAt": "2026-08-04T18:54:48Z",
+      "number": 62,
+      "title": "fix: permissions.ask を全廃する",
+      "url": "https://github.com/hikuohiku/homelab/pull/62"
+    },
+    {
       "mergedAt": "2026-08-04T18:51:52Z",
       "number": 61,
       "title": "fix(ops): 権限プロンプトで起動が消えるのを防ぐ",
@@ -102,24 +120,6 @@
       "number": 43,
       "title": "feat: GitHub Copilot PR レビューを日本語化",
       "url": "https://github.com/hikuohiku/homelab/pull/43"
-    },
-    {
-      "mergedAt": "2026-05-20T15:10:25Z",
-      "number": 41,
-      "title": "feat: ArgoCD preview deploy commands + PVC data protection",
-      "url": "https://github.com/hikuohiku/homelab/pull/41"
-    },
-    {
-      "mergedAt": "2026-05-20T13:42:27Z",
-      "number": 39,
-      "title": "feat(immich): add Immich K8s manifests for LXC migration",
-      "url": "https://github.com/hikuohiku/homelab/pull/39"
-    },
-    {
-      "mergedAt": "2025-12-17T13:57:38Z",
-      "number": 33,
-      "title": "feat(nextcloud): add Nextcloud Helm chart configuration",
-      "url": "https://github.com/hikuohiku/homelab/pull/33"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -47,3 +47,11 @@
 - 次の起動へ: T-0014 は `needs-human`。GitHub App に workflows 権限（Read and write）が付与されたら
   再着手する。ファイル本体は issue #56 のコメントに全文を貼った
 - 前回の中断: オープン PR・`autopilot/*` ブランチともに無し。拾うものは無かった
+
+## 2026-08-04 19:30 UTC — 人間による権限付与
+
+- **GitHub App に `workflows` 権限が付与された。** `.github/workflows/` への push が可能になったはず
+- T-0014（直 push 検知の CI）を `needs-human` から `todo` に戻した。優先度 0
+- 着手するときは、まず小さな変更を push して権限が実際に効いているか確かめること。
+  run #2 の時点では git push も API も 403 だった
+- run #2 で書いた workflow の本文はどこにも残っていない（issue にも貼れていなかった）。書き直しになる


### PR DESCRIPTION
GitHub App に `workflows` 権限が付与されたので、`.github/workflows/` への push ができるようになりました。T-0014（`main` への直 push を検知する CI）を `needs-human` から `todo` に戻します。

着手時はまず小さな変更を push して、権限が実際に効いているかを確かめてください。run #2 の時点では git push も API も 403 でした。

run #2 で書いた workflow の本文はどこにも残っていないため書き直しになります。