### PR TITLE
fix(tailscale): k8s-nameserver の floating tag unstable を固定する

### DIFF
--- a/apps/tailscale-operator/dns-config.yaml
+++ b/apps/tailscale-operator/dns-config.yaml
@@ -6,4 +6,6 @@ spec:
   nameserver:
     image:
       repo: tailscale/k8s-nameserver
-      tag: unstable
+      # unstable が 2026-08-04 時点で指していたビルドと同一（digest 一致確認済み）。
+      # 中身は変えずに floating tag だけを固定した（backlog T-0001）
+      tag: unstable-v1.91.150

--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -31,7 +31,7 @@ VISION が「何になろうとしているか」、この CHARTER が「どう�
 |---|------|
 | 0 | この CHARTER.md を読む |
 | 1 | **フィードバックを読む**（[§6](#6-人間からのフィードバック)）。未処理があれば最優先で反映する |
-| 2 | **前回の中断を拾う**: `gh pr list` でオープン PR、`git branch -r` で `autopilot/*` の残りブランチを見る。CI 失敗・コンフリクト・書きかけがあれば**新規タスクより先に**片付ける |
+| 2 | **前回の中断を拾う**: `mcp__github__list_pull_requests`（state: open）でオープン PR、`git branch -r` で `autopilot/*` の残りブランチを見る。CI 失敗・コンフリクト・書きかけがあれば**新規タスクより先に**片付ける |
 | 3 | `ops/backlog.json` と 直近の journal（`ops/journal/YYYY-MM.md`）の末尾を読む |
 | 4 | タスクを選ぶ（[§3](#3-タスクの選び方)） |
 | 5 | 実施 → PR（[§4](#4-pr-の作り方)）。**同じ PR に journal・backlog・state・ダッシュボードの更新も載せる**（[§7](#7-記録)） |
@@ -90,7 +90,11 @@ backlog が空、または全部 `blocked` のときは**調査タスクを自�
 | `medium` | 実インフラに影響するが可逆。patch/minor のバージョン更新、manifest の整合性修正、リソース調整 | CI green **かつ** ロールバック手順を PR 本文に明記していれば **auto-merge** |
 | `high` | 不可逆な変更、データを失いうる変更、到達性を失いうる変更、メジャーバージョン更新 | **自分で判断して進める。** ただし着手前に「戻せる形」に落とすこと（下記） |
 
-auto-merge は **`gh pr merge --merge --auto`**（このリポジトリは squash / rebase マージを許可していない）。
+この実行環境に `gh` CLI は無い（command not found）。GitHub 操作はすべて `mcp__github__*` ツールで行う
+（`list_pull_requests` / `create_pull_request` / `add_issue_comment` 等）。auto-merge は
+**`mcp__github__enable_pr_auto_merge`**（このリポジトリは squash / rebase マージを許可していないので `mergeMethod: MERGE`）。
+CI が既に green で PR が clean（pending チェックが無い）状態だと「auto-merge 不要、直接マージ可」のエラーになるので、
+その場合は `mcp__github__merge_pull_request`（`merge_method: merge`）でそのままマージしてよい。
 
 `main` には ruleset「main: CI 必須」が掛かっていて、`kustomize build` / `terraform validate` /
 `ops state validate` の 3 つが green でないとマージできない。**これが auto-merge の安全性の根拠**であり、
@@ -169,6 +173,7 @@ high に該当するのは、失敗したときに元へ戻せないもの。**�
 | `just preflight` / `just preview*` / `just plan` / `just apply` | 内部で `kubectl` や Doppler 認証を使い、homelab への到達を前提にしている |
 | `sudo` | `deny` 対象。使わない |
 | `git push --force` | 使わない。やり直したいならブランチを作り直す |
+| `gh`（GitHub CLI） | この実行環境には入っていない（`command not found`）。GitHub 操作は `mcp__github__*` ツールで代替する（[§4](#4-pr-の作り方) 参照）。`api.github.com` への直接 HTTPS リクエスト（`curl`/`urllib` 等）も組織の egress ポリシーで 403 になり使えない。`ghcr.io` など GitHub 以外のレジストリは到達できる（2026-08-04 run #4 で確認） |
 
 ルールを増やすときは、ここに「なぜ踏めないか」と「代わりに何をするか」をセットで書く。
 禁止だけ並べると、次の自分が回避策を探して時間を溶かす。

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 16,
-  "updated": "2026-08-04T20:00:00Z",
+  "next_id": 17,
+  "updated": "2026-08-04T20:30:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）",
   "tasks": [
     {
@@ -10,7 +10,7 @@
       "title": "tailscale k8s-nameserver の floating tag `unstable` を固定バージョンに変える",
       "kind": "refactor",
       "risk": "medium",
-      "status": "todo",
+      "status": "done",
       "priority": 1,
       "why": "repo 内で唯一バージョンが固定されていない箇所。Pod が再起動するたびに中身が変わりうるので、壊れたときに原因を特定できない",
       "dod": "apps/tailscale-operator/dns-config.yaml が具体的なバージョンタグを指し、ops/inventory.json の該当エントリも更新されている",
@@ -261,6 +261,25 @@
       "created": "2026-08-04",
       "pr": null,
       "notes": "T-0010 を置き換える形の具体案。manifest の設計・実装自体は着手できるので、token 待ちの間に CronJob 用 manifest の下書きを進めてよい"
+    },
+    {
+      "id": "T-0016",
+      "domain": "homelab",
+      "title": "ダッシュボードの PR 一覧を gh CLI 非依存にする",
+      "kind": "ci",
+      "risk": "low",
+      "status": "todo",
+      "priority": 13,
+      "why": "run #4 で判明: この実行環境に `gh` CLI が無く、`ops/dashboard/build.py` の `fetch_prs()` が失敗してキャッシュ（`ops/dashboard/prs.json`）に頼るしかない。`api.github.com` への直接 HTTPS も組織の egress ポリシーで 403 になり build.py 単体では代替できない（`ghcr.io` など他ホストは到達できるので、egress は GitHub API に限定して塞がれている）。結果としてキャッシュが更新されず、ダッシュボードの PR 一覧が数十件古いまま固定化していた",
+      "dod": "毎回の起動でダッシュボードの PR 一覧が実態と一致する。方向性の候補: (a) 起動のたびに agent が `mcp__github__list_pull_requests` で取得して `ops/dashboard/prs.json` を直接更新してから `build.py` を実行する運用にし、CHARTER §7.1 にその手順を明記する (b) build.py に `prs.json` が事前に用意されている前提を明記し、`gh` 実行は human のローカル実行時のみ有効なfallbackと位置付け直す。CI 実行環境（GitHub Actions runner）側は `gh` が使えるはずなので、その差も踏まえること",
+      "refs": [
+        "ops/dashboard/build.py",
+        "ops/dashboard/prs.json",
+        "ops/CHARTER.md"
+      ],
+      "created": "2026-08-04",
+      "pr": null,
+      "notes": "run #4 でその場しのぎの urllib 版を書いて動かなかった（403）ため revert 済み。次に着手するときは build.py 単体で完結させようとせず、agent 側の前処理込みで設計すること"
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -18,7 +18,7 @@
         "apps/tailscale-operator/dns-config.yaml"
       ],
       "created": "2026-08-04",
-      "pr": null,
+      "pr": 71,
       "notes": "run #1 が in_progress にしたが作業ブランチを残さず終了したため todo に戻した"
     },
     {

--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -59,6 +59,7 @@ body { background:var(--ground); color:var(--ink); font-family:var(--sans);
 .mast__sub { color:var(--muted); font-size:.86rem; font-family:var(--mono);
   display:flex; flex-wrap:wrap; gap:.4rem 1rem; }
 .mast__stage { color:var(--sig); font-weight:600; }
+.warn-inline { color:var(--crit); font-weight:600; }
 
 .stats { display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:1px;
   background:var(--line); border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; }
@@ -182,64 +183,64 @@ a { color:var(--sig); }
     </div>
     <div class="mast__sub">
       <span>homelab を自律運用するエージェントの記録</span>
-      <span>定期実行 未設定</span>
-      <span>生成 2026-08-04 19:24 UTC</span>
+      <span>起動間隔 1 時間ごと（毎時 19 分）</span>
+      <span>生成 2026-08-04 19:39 UTC</span>
     </div>
   </header>
 
-  <div class="stats"><div class="stat stat--sig"><span class="stat__v">-36 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">20</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
+  <div class="stats"><div class="stat stat--sig"><span class="stat__v">-51 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">25</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
 
   <section>
     <h2>やったこと</h2>
     <p class="lede">マージ済み＝homelab に反映済みの変更。新しい順。</p>
     <ul class="list">
       <li class="done">
+        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/70">fix(ci): direct-push-guard のレビュー指摘3点を修正</a>
+        <span class="done__meta">#70 · 4 分前</span>
+      </li>
+      <li class="done">
+        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/69">fix(ops): ダッシュボードに起動間隔が出ない退行を直す</a>
+        <span class="done__meta">#69 · 12 分前</span>
+      </li>
+      <li class="done">
+        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/68">fix(terraform): .terraform.lock.hcl から未宣言の tailscale provider を除去する</a>
+        <span class="done__meta">#68 · 13 分前</span>
+      </li>
+      <li class="done">
+        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/67">ci: main への直 push を検知する direct-push-guard を追加する</a>
+        <span class="done__meta">#67 · 15 分前</span>
+      </li>
+      <li class="done">
+        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/66">ops: 「workflow 本文が失われた」という記録の誤りを訂正する</a>
+        <span class="done__meta">#66 · 27 分前</span>
+      </li>
+      <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/65">ops: workflows 権限の付与を受けて T-0014 のブロックを解除する</a>
-        <span class="done__meta">#65 · 16 分前</span>
+        <span class="done__meta">#65 · 31 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/64">ops: T-0014 の pr 番号を記録する (#63)</a>
-        <span class="done__meta">#64 · 19 分前</span>
+        <span class="done__meta">#64 · 34 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/63">ops: issue #56 のフィードバックを反映、T-0014 を needs-human に</a>
-        <span class="done__meta">#63 · 20 分前</span>
+        <span class="done__meta">#63 · 35 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/62">fix: permissions.ask を全廃する</a>
-        <span class="done__meta">#62 · 29 分前</span>
+        <span class="done__meta">#62 · 44 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/61">fix(ops): 権限プロンプトで起動が消えるのを防ぐ</a>
-        <span class="done__meta">#61 · 32 分前</span>
+        <span class="done__meta">#61 · 47 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/60">ops: 定期実行を 1 時間ごとに変更し、run #1 の記録を残す</a>
-        <span class="done__meta">#60 · 37 分前</span>
+        <span class="done__meta">#60 · 52 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/59">fix(ops): main への直 push を廃し、記録も PR に載せる</a>
-        <span class="done__meta">#59 · 39 分前</span>
-      </li>
-      <li class="done">
-        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/58">feat(ops): 判断を人間に渡さない方針へ憲章を改める</a>
-        <span class="done__meta">#58 · 52 分前</span>
-      </li>
-      <li class="done">
-        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/57">feat(ops): homelab を自律運用する autopilot の器を作る</a>
-        <span class="done__meta">#57 · 1 時間前</span>
-      </li>
-      <li class="done">
-        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/55">fix(coder): secure workspace SSH key before clone</a>
-        <span class="done__meta">#55 · 2 時間前</span>
-      </li>
-      <li class="done">
-        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/54">fix(coder): clone private skills over SSH</a>
-        <span class="done__meta">#54 · 3 時間前</span>
-      </li>
-      <li class="done">
-        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/53">feat(coder): use immutable workspace image</a>
-        <span class="done__meta">#53 · 14 時間前</span>
+        <span class="done__meta">#59 · 54 分前</span>
       </li></ul>
   </section>
 
@@ -282,7 +283,7 @@ a { color:var(--sig); }
     <p>使っていて感じたことを殴り書きで構いません。進め方への指摘は憲章に、やってほしいことはタスクとして取り込まれます。
        読んだら 3 行以内で返信します。<strong>返信が無い＝まだ読んでいない</strong>と判断してください。</p>
     <a class="fb__cta" href="https://github.com/hikuohiku/homelab/issues/56">issue #56 に書く</a>
-    <span class="fb__meta">最後に読んだ: 12 分前</span>
+    <span class="fb__meta">最後に読んだ: 14 分前</span>
   </section>
 
   <section>
@@ -294,20 +295,6 @@ a { color:var(--sig); }
     <h2>これからやること</h2>
     <p class="lede">上から順に着手します。1 タスク = 1 PR。</p>
     <ul class="list">
-      <li class="task task--idle">
-        <div class="task__head">
-          <span class="task__id">T-0001</span>
-          <h3 class="task__title">tailscale k8s-nameserver の floating tag `unstable` を固定バージョンに変える</h3>
-        </div>
-        <p class="task__why">repo 内で唯一バージョンが固定されていない箇所。Pod が再起動するたびに中身が変わりうるので、壊れたときに原因を特定できない</p>
-        
-        <div class="task__meta">
-          <span class="chip chip--idle">待ち</span>
-          <span class="chip chip--quiet">整理</span>
-          <span class="chip chip--quiet">リスク 中</span>
-          <span class="task__refs"><code>apps/tailscale-operator/dns-config.yaml</code></span>
-        </div>
-      </li>
       <li class="task task--idle">
         <div class="task__head">
           <span class="task__id">T-0002</span>
@@ -418,6 +405,20 @@ a { color:var(--sig); }
           <span class="chip chip--quiet">調査</span>
           <span class="chip chip--quiet">リスク 低</span>
           <span class="task__refs"><code>terraform/proxmox/pbs.tf.ignore</code><code>CLAUDE.md</code></span>
+        </div>
+      </li>
+      <li class="task task--idle">
+        <div class="task__head">
+          <span class="task__id">T-0016</span>
+          <h3 class="task__title">ダッシュボードの PR 一覧を gh CLI 非依存にする</h3>
+        </div>
+        <p class="task__why">run #4 で判明: この実行環境に `gh` CLI が無く、`ops/dashboard/build.py` の `fetch_prs()` が失敗してキャッシュ（`ops/dashboard/prs.json`）に頼るしかない。`api.github.com` への直接 HTTPS も組織の egress ポリシーで 403 になり build.py 単体では代替できない（`ghcr.io` など他ホストは到達できるので、egress は GitHub API に限定して塞がれている）。結果としてキャッシュが更新されず、ダッシュボードの PR 一覧が数十件古いまま固定化していた</p>
+        
+        <div class="task__meta">
+          <span class="chip chip--idle">待ち</span>
+          <span class="chip chip--quiet">CI</span>
+          <span class="chip chip--quiet">リスク 低</span>
+          <span class="task__refs"><code>ops/dashboard/build.py</code><code>ops/dashboard/prs.json</code><code>ops/CHARTER.md</code></span>
         </div>
       </li>
       <li class="task task--idle">
@@ -545,7 +546,7 @@ a { color:var(--sig); }
       </tr>
       <tr>
         <td class="inv__name">tailscale k8s-nameserver</td>
-        <td><code>unstable</code></td>
+        <td><code>unstable-v1.91.150</code></td>
         <td class="inv__file"><code>apps/tailscale-operator/dns-config.yaml</code></td>
         <td><span class="chip chip--ok">自動可</span></td>
       </tr>

--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -188,7 +188,7 @@ a { color:var(--sig); }
     </div>
   </header>
 
-  <div class="stats"><div class="stat stat--sig"><span class="stat__v">-51 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">25</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
+  <div class="stats"><div class="stat stat--sig"><span class="stat__v">-51 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">25</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">1</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
 
   <section>
     <h2>やったこと</h2>
@@ -196,47 +196,47 @@ a { color:var(--sig); }
     <ul class="list">
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/70">fix(ci): direct-push-guard のレビュー指摘3点を修正</a>
-        <span class="done__meta">#70 · 4 分前</span>
+        <span class="done__meta">#70 · 5 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/69">fix(ops): ダッシュボードに起動間隔が出ない退行を直す</a>
-        <span class="done__meta">#69 · 12 分前</span>
+        <span class="done__meta">#69 · 13 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/68">fix(terraform): .terraform.lock.hcl から未宣言の tailscale provider を除去する</a>
-        <span class="done__meta">#68 · 13 分前</span>
+        <span class="done__meta">#68 · 14 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/67">ci: main への直 push を検知する direct-push-guard を追加する</a>
-        <span class="done__meta">#67 · 15 分前</span>
+        <span class="done__meta">#67 · 16 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/66">ops: 「workflow 本文が失われた」という記録の誤りを訂正する</a>
-        <span class="done__meta">#66 · 27 分前</span>
+        <span class="done__meta">#66 · 28 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/65">ops: workflows 権限の付与を受けて T-0014 のブロックを解除する</a>
-        <span class="done__meta">#65 · 31 分前</span>
+        <span class="done__meta">#65 · 32 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/64">ops: T-0014 の pr 番号を記録する (#63)</a>
-        <span class="done__meta">#64 · 34 分前</span>
+        <span class="done__meta">#64 · 35 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/63">ops: issue #56 のフィードバックを反映、T-0014 を needs-human に</a>
-        <span class="done__meta">#63 · 35 分前</span>
+        <span class="done__meta">#63 · 36 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/62">fix: permissions.ask を全廃する</a>
-        <span class="done__meta">#62 · 44 分前</span>
+        <span class="done__meta">#62 · 45 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/61">fix(ops): 権限プロンプトで起動が消えるのを防ぐ</a>
-        <span class="done__meta">#61 · 47 分前</span>
+        <span class="done__meta">#61 · 48 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/60">ops: 定期実行を 1 時間ごとに変更し、run #1 の記録を残す</a>
-        <span class="done__meta">#60 · 52 分前</span>
+        <span class="done__meta">#60 · 53 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/59">fix(ops): main への直 push を廃し、記録も PR に載せる</a>
@@ -288,7 +288,15 @@ a { color:var(--sig); }
 
   <section>
     <h2>いま動かしているもの</h2>
-    <ul class="list"><li class="empty">作業中の PR はありません。</li></ul>
+    <ul class="list">
+      <li class="pr pr--idle">
+        <a class="pr__title" href="https://github.com/hikuohiku/homelab/pull/71">#71 fix(tailscale): k8s-nameserver の floating tag unstable を固定する</a>
+        <div class="task__meta">
+          <span class="chip chip--idle">CI 未実行</span>
+          <span class="chip chip--quiet">手動マージ待ち</span>
+          <span class="pr__age">-66 分前</span>
+        </div>
+      </li></ul>
   </section>
 
   <section>

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,36 @@
   "open": [],
   "merged": [
     {
+      "mergedAt": "2026-08-04T19:34:27Z",
+      "number": 70,
+      "title": "fix(ci): direct-push-guard のレビュー指摘3点を修正",
+      "url": "https://github.com/hikuohiku/homelab/pull/70"
+    },
+    {
+      "mergedAt": "2026-08-04T19:26:25Z",
+      "number": 69,
+      "title": "fix(ops): ダッシュボードに起動間隔が出ない退行を直す",
+      "url": "https://github.com/hikuohiku/homelab/pull/69"
+    },
+    {
+      "mergedAt": "2026-08-04T19:25:17Z",
+      "number": 68,
+      "title": "fix(terraform): .terraform.lock.hcl から未宣言の tailscale provider を除去する",
+      "url": "https://github.com/hikuohiku/homelab/pull/68"
+    },
+    {
+      "mergedAt": "2026-08-04T19:23:22Z",
+      "number": 67,
+      "title": "ci: main への直 push を検知する direct-push-guard を追加する",
+      "url": "https://github.com/hikuohiku/homelab/pull/67"
+    },
+    {
+      "mergedAt": "2026-08-04T19:11:18Z",
+      "number": 66,
+      "title": "ops: 「workflow 本文が失われた」という記録の誤りを訂正する",
+      "url": "https://github.com/hikuohiku/homelab/pull/66"
+    },
+    {
       "mergedAt": "2026-08-04T19:07:42Z",
       "number": 65,
       "title": "ops: workflows 権限の付与を受けて T-0014 のブロックを解除する",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,5 +1,16 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 71,
+      "title": "fix(tailscale): k8s-nameserver の floating tag unstable を固定する",
+      "url": "https://github.com/hikuohiku/homelab/pull/71",
+      "isDraft": false,
+      "createdAt": "2026-08-04T20:45:00Z",
+      "statusCheckRollup": [],
+      "headRefName": "autopilot/T-0001-pin-tailscale-nameserver",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
     {
       "mergedAt": "2026-08-04T19:34:27Z",

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -149,12 +149,12 @@
       "id": "k8s-nameserver",
       "kind": "image",
       "name": "tailscale k8s-nameserver",
-      "current": "unstable",
+      "current": "unstable-v1.91.150",
       "file": "apps/tailscale-operator/dns-config.yaml",
       "match": "k8s-nameserver",
       "upstream": "github:tailscale/tailscale",
       "policy": "auto",
-      "note": "唯一の floating tag。再起動のたびに中身が変わりうる。固定するのが先 (backlog 参照)"
+      "note": "T-0001 で floating tag (unstable) を固定した。tailscale/k8s-nameserver に「stable」相当のタグは無く、unstable-vX.Y.Z 形式のスナップショットのみ存在する。更新時は ghcr.io の digest を必ず確認する"
     },
     {
       "id": "coder-workspace-image",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -85,4 +85,21 @@
   - CHARTER §6 に「過去の指摘を反映するときは前提が今も成り立つか確かめる」を追記
   - issue #56 に返信、`feedback.last_read` を更新
   - なお前回の中断確認では、オープン PR・`autopilot/*` ブランチともに無かった（`gh` CLI は使えないため `mcp__github__list_pull_requests` と `git branch -r` で確認）
-- 次の起動へ: backlog は T-0001（priority 1）から順に。この回の残り時間があれば続けて着手する
+  - PR #70 は CI green・clean 状態で `enable_pr_auto_merge` が「pending チェックが無いので不要、直接マージ可」と返したため `merge_pull_request` でそのまま merge
+- **重要な発見**: この実行環境には `gh` CLI が無い（`command not found`）。GitHub 操作はすべて `mcp__github__*`
+  で行った。CHARTER 本文の `gh pr list` / `gh pr merge --merge --auto` などの記述は実態と合っていなかったため、
+  §2・§4・§5.1 を MCP ツール前提に書き換えた
+  - ダッシュボード (`ops/dashboard/build.py`) が内部で `gh pr list` を subprocess 実行しており、これも失敗する。
+    `api.github.com` への直接 HTTPS（`urllib`）も組織の egress ポリシーで 403 になり代替できないと確認した
+    （`ghcr.io` は到達できた）。`prs.json` キャッシュは #65 時点で止まっており 5 PR 分古い。
+    その場で urllib 版に書き換えたが実行環境で検証したところ 403 で機能しなかったため revert し、
+    build.py 自体は変更していない。**根本修正は持ち越し**（次の起動へ、下記）
+- 続けて T-0001（tailscale k8s-nameserver の floating tag 固定）に着手。`ghcr.io` の registry API で
+  `unstable` タグの digest を確認したところ `unstable-v1.91.150` と完全一致（中身は変えず tag だけ固定できる）。
+  `apps/tailscale-operator/dns-config.yaml` と `ops/inventory.json` を更新
+- 次の起動へ:
+  - backlog は T-0002（priority 2）から順に
+  - **ダッシュボードの PR 一覧が古いまま。** `ops/dashboard/build.py` の `fetch_prs()` を `gh` に依存しない形へ
+    書き換えるタスクを起票すること（`api.github.com` 直叩きは 403 で不可なので、build.py 単体では解決できない。
+    起動のたびに agent が `mcp__github__list_pull_requests` で取得して `ops/dashboard/prs.json` を直接更新してから
+    `build.py` を実行する運用にするか、build.py に「事前に用意された prs.json をそのまま使う」前提を明記するかを検討）

--- a/ops/state.json
+++ b/ops/state.json
@@ -54,6 +54,14 @@
       "by": "cloud routine",
       "summary": "T-0014 完遂（direct-push-guard.yml push、workflows 権限が実際に効くことを確認）。issue #56 の設計フィードバックを受け T-0010 を T-0015 に具体化（token 待ちで needs-human）。続けて T-0004（terraform lock の残骸除去）も完遂",
       "prs": [67, 68]
+    },
+    {
+      "n": 4,
+      "at": "2026-08-04T20:30:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "issue #56 の未読フィードバック（PR #67 のレビュー3点）を反映（PR #70, auto-merged）。gh CLI がこの環境に無いと判明し CHARTER を MCP ツール前提に修正。T-0001（tailscale k8s-nameserver の floating tag 固定）完遂。ダッシュボードの PR キャッシュ更新の仕組み不足を T-0016 として起票",
+      "prs": [70, 71]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

- `apps/tailscale-operator/dns-config.yaml` の `nameserver.image.tag` を floating tag `unstable` から `unstable-v1.91.150` に固定（T-0001）。`ghcr.io` の registry API で digest を確認し、`unstable` が現時点で指すビルドと完全一致することを確認済み。**中身は変えていない、tag を固定しただけ**
- `ops/inventory.json` の該当エントリを更新。「stable 相当のタグは無く unstable-vX.Y.Z 形式のスナップショットのみ」という調査結果もメモした
- ついでに（`ops/` 運用記録として同 PR に相乗り）:
  - この実行環境に `gh` CLI が無い（`command not found`）ことが分かったため、`ops/CHARTER.md` の該当箇所を `mcp__github__*` ツール前提に修正
  - `ops/dashboard/prs.json`（PR キャッシュ）が #65 時点で止まっていたのを手動で最新化。根本修正は `T-0016` として起票（`gh` 依存の `fetch_prs()` が使えないため、ダッシュボードの PR 一覧が自動更新されない問題）
  - `ops/journal/`・`ops/state.json`・ダッシュボード HTML を更新

## 検証したこと

- `ghcr.io` の token/manifest API で `unstable` と `unstable-v1.91.150` の `docker-content-digest` が一致することを確認（実質的な変更なしを保証）
- `python3 ops/validate.py` → 0 error, 0 warning
- `kustomize build` はこの実行環境に無いため未実施。CI に委ねる

## ロールバック手順

`tag: unstable-v1.91.150` を `tag: unstable` に戻せば元の状態（floating）に戻る。デプロイされるイメージの中身は現時点では同一なので、ロールバックしても実害は無い。

## backlog task id

T-0001（`done`）

---
_Generated by [Claude Code](https://claude.ai/code/session_01FF3t6T43BWGQnUiSP2sh9c)_