### PR TITLE
fix(ops): PR 一覧がキャッシュのときダッシュボードに明示する

### DIFF
--- a/ops/dashboard/build.py
+++ b/ops/dashboard/build.py
@@ -23,6 +23,9 @@ OUT = OPS / "dashboard" / "index.html"
 
 E = html.escape
 
+# PR 一覧を取得できずキャッシュにフォールバックしたときの記録
+STALE: dict[str, str] = {}
+
 
 def load(name: str, default=None):
     p = OPS / name
@@ -50,7 +53,12 @@ def fetch_prs() -> tuple[list[dict], list[dict]]:
         cache.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n")
         return data["open"], data["merged"]
     except Exception as e:  # noqa: BLE001
-        print(f"warning: gh pr list に失敗したのでキャッシュを使う ({e})", file=sys.stderr)
+        # 取得できないこと自体は異常ではない（gh が無い実行環境がある）。
+        # まずいのは黙ってキャッシュを出すこと。人間には最新に見えて実際は古い。
+        print(f"warning: PR 一覧を取得できずキャッシュを使う ({e})", file=sys.stderr)
+        STALE["reason"] = str(e)[:100]
+        if cache.exists():
+            STALE["at"] = datetime.fromtimestamp(cache.stat().st_mtime, timezone.utc).isoformat()
         if not cache.exists():
             return [], []
         data = json.loads(cache.read_text())
@@ -223,6 +231,15 @@ def build() -> str:
     def stat(value, label, tone="sig"):
         return f'<div class="stat stat--{tone}"><span class="stat__v">{E(str(value))}</span><span class="stat__l">{E(label)}</span></div>'
 
+    stale_html = ""
+    if STALE:
+        stale_html = (
+            '<p class="stale">PR の一覧を取得できませんでした。下の「やったこと」と'
+            f'「いま動かしているもの」は<strong>{E(rel_time(STALE.get("at")))}のキャッシュ</strong>で、'
+            '現在の状態と違う可能性があります。'
+            f'<span class="stale__why">({E(STALE.get("reason",""))})</span></p>'
+        )
+
     stats = "".join([
         stat(rel_time(last_run.get("at")), "最終起動"),
         stat(len(merged), "反映済みの変更", "ok" if merged else "idle"),
@@ -255,7 +272,7 @@ def build() -> str:
     return TEMPLATE.format(
         generated=generated, stage=stage, stage_label=E(stage_label), next_html=next_html,
         stats=stats, attention=attention_html, queue=queue_html, more=more,
-        prs=prs_html, runs=runs_html, done=done_html, inv=inv_html,
+        prs=prs_html, runs=runs_html, done=done_html, inv=inv_html, stale=stale_html,
         fb_url=E(fb_url), fb_issue=E(str(fb.get("issue") or "?")),
         fb_read=E(rel_time(fb.get("last_read"))),
     )
@@ -323,6 +340,9 @@ body {{ background:var(--ground); color:var(--ink); font-family:var(--sans);
   display:flex; flex-wrap:wrap; gap:.4rem 1rem; }}
 .mast__stage {{ color:var(--sig); font-weight:600; }}
 .warn-inline {{ color:var(--crit); font-weight:600; }}
+.stale {{ background:var(--warn-soft); color:var(--warn); border:1px solid var(--warn);
+  border-radius:var(--radius); padding:.6rem .9rem; font-size:.86rem; }}
+.stale__why {{ font-family:var(--mono); font-size:.74rem; opacity:.75; margin-left:.4rem; }}
 
 .stats {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:1px;
   background:var(--line); border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; }}
@@ -452,6 +472,7 @@ a {{ color:var(--sig); }}
   </header>
 
   <div class="stats">{stats}</div>
+  {stale}
 
   <section>
     <h2>やったこと</h2>

--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -60,6 +60,9 @@ body { background:var(--ground); color:var(--ink); font-family:var(--sans);
   display:flex; flex-wrap:wrap; gap:.4rem 1rem; }
 .mast__stage { color:var(--sig); font-weight:600; }
 .warn-inline { color:var(--crit); font-weight:600; }
+.stale { background:var(--warn-soft); color:var(--warn); border:1px solid var(--warn);
+  border-radius:var(--radius); padding:.6rem .9rem; font-size:.86rem; }
+.stale__why { font-family:var(--mono); font-size:.74rem; opacity:.75; margin-left:.4rem; }
 
 .stats { display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:1px;
   background:var(--line); border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; }
@@ -184,63 +187,64 @@ a { color:var(--sig); }
     <div class="mast__sub">
       <span>homelab を自律運用するエージェントの記録</span>
       <span>起動間隔 1 時間ごと（毎時 19 分）</span>
-      <span>生成 2026-08-04 19:39 UTC</span>
+      <span>生成 2026-08-04 19:41 UTC</span>
     </div>
   </header>
 
-  <div class="stats"><div class="stat stat--sig"><span class="stat__v">-51 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">25</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">1</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
+  <div class="stats"><div class="stat stat--sig"><span class="stat__v">-49 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">20</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
+  
 
   <section>
     <h2>やったこと</h2>
     <p class="lede">マージ済み＝homelab に反映済みの変更。新しい順。</p>
     <ul class="list">
       <li class="done">
+        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/71">fix(tailscale): k8s-nameserver の floating tag unstable を固定する</a>
+        <span class="done__meta">#71 · 1 分前</span>
+      </li>
+      <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/70">fix(ci): direct-push-guard のレビュー指摘3点を修正</a>
-        <span class="done__meta">#70 · 5 分前</span>
+        <span class="done__meta">#70 · 7 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/69">fix(ops): ダッシュボードに起動間隔が出ない退行を直す</a>
-        <span class="done__meta">#69 · 13 分前</span>
+        <span class="done__meta">#69 · 15 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/68">fix(terraform): .terraform.lock.hcl から未宣言の tailscale provider を除去する</a>
-        <span class="done__meta">#68 · 14 分前</span>
+        <span class="done__meta">#68 · 16 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/67">ci: main への直 push を検知する direct-push-guard を追加する</a>
-        <span class="done__meta">#67 · 16 分前</span>
+        <span class="done__meta">#67 · 18 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/66">ops: 「workflow 本文が失われた」という記録の誤りを訂正する</a>
-        <span class="done__meta">#66 · 28 分前</span>
+        <span class="done__meta">#66 · 30 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/65">ops: workflows 権限の付与を受けて T-0014 のブロックを解除する</a>
-        <span class="done__meta">#65 · 32 分前</span>
+        <span class="done__meta">#65 · 34 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/64">ops: T-0014 の pr 番号を記録する (#63)</a>
-        <span class="done__meta">#64 · 35 分前</span>
+        <span class="done__meta">#64 · 36 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/63">ops: issue #56 のフィードバックを反映、T-0014 を needs-human に</a>
-        <span class="done__meta">#63 · 36 分前</span>
+        <span class="done__meta">#63 · 38 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/62">fix: permissions.ask を全廃する</a>
-        <span class="done__meta">#62 · 45 分前</span>
+        <span class="done__meta">#62 · 47 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/61">fix(ops): 権限プロンプトで起動が消えるのを防ぐ</a>
-        <span class="done__meta">#61 · 48 分前</span>
+        <span class="done__meta">#61 · 49 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/60">ops: 定期実行を 1 時間ごとに変更し、run #1 の記録を残す</a>
-        <span class="done__meta">#60 · 53 分前</span>
-      </li>
-      <li class="done">
-        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/59">fix(ops): main への直 push を廃し、記録も PR に載せる</a>
-        <span class="done__meta">#59 · 54 分前</span>
+        <span class="done__meta">#60 · 55 分前</span>
       </li></ul>
   </section>
 
@@ -283,20 +287,12 @@ a { color:var(--sig); }
     <p>使っていて感じたことを殴り書きで構いません。進め方への指摘は憲章に、やってほしいことはタスクとして取り込まれます。
        読んだら 3 行以内で返信します。<strong>返信が無い＝まだ読んでいない</strong>と判断してください。</p>
     <a class="fb__cta" href="https://github.com/hikuohiku/homelab/issues/56">issue #56 に書く</a>
-    <span class="fb__meta">最後に読んだ: 14 分前</span>
+    <span class="fb__meta">最後に読んだ: 16 分前</span>
   </section>
 
   <section>
     <h2>いま動かしているもの</h2>
-    <ul class="list">
-      <li class="pr pr--idle">
-        <a class="pr__title" href="https://github.com/hikuohiku/homelab/pull/71">#71 fix(tailscale): k8s-nameserver の floating tag unstable を固定する</a>
-        <div class="task__meta">
-          <span class="chip chip--idle">CI 未実行</span>
-          <span class="chip chip--quiet">手動マージ待ち</span>
-          <span class="pr__age">-66 分前</span>
-        </div>
-      </li></ul>
+    <ul class="list"><li class="empty">作業中の PR はありません。</li></ul>
   </section>
 
   <section>

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,17 +1,12 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
+      "mergedAt": "2026-08-04T19:40:33Z",
       "number": 71,
       "title": "fix(tailscale): k8s-nameserver の floating tag unstable を固定する",
-      "url": "https://github.com/hikuohiku/homelab/pull/71",
-      "isDraft": false,
-      "createdAt": "2026-08-04T20:45:00Z",
-      "statusCheckRollup": [],
-      "headRefName": "autopilot/T-0001-pin-tailscale-nameserver",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "url": "https://github.com/hikuohiku/homelab/pull/71"
+    },
     {
       "mergedAt": "2026-08-04T19:34:27Z",
       "number": 70,
@@ -125,42 +120,6 @@
       "number": 51,
       "title": "feat: node01 を 4c/12GB/50GB にスケールアップ",
       "url": "https://github.com/hikuohiku/homelab/pull/51"
-    },
-    {
-      "mergedAt": "2026-08-03T13:45:55Z",
-      "number": 50,
-      "title": "feat: 週次メンテナンスの手順を /weekly-maintenance コマンドに定義",
-      "url": "https://github.com/hikuohiku/homelab/pull/50"
-    },
-    {
-      "mergedAt": "2026-08-03T13:01:44Z",
-      "number": 49,
-      "title": "fix(vaultwarden): 1.36.0 → 1.37.1 でクライアント同期不具合を解消",
-      "url": "https://github.com/hikuohiku/homelab/pull/49"
-    },
-    {
-      "mergedAt": "2026-08-03T12:25:50Z",
-      "number": 48,
-      "title": "chore: kubectl を ask 付きで許可する方針を反映 + 移行 Plans 更新",
-      "url": "https://github.com/hikuohiku/homelab/pull/48"
-    },
-    {
-      "mergedAt": "2026-06-21T09:28:10Z",
-      "number": 47,
-      "title": "feat: vaultwarden を k8s へ移行する manifest を追加",
-      "url": "https://github.com/hikuohiku/homelab/pull/47"
-    },
-    {
-      "mergedAt": "2026-06-21T06:28:16Z",
-      "number": 46,
-      "title": "chore: IaC 管理外の空 namespace を整理",
-      "url": "https://github.com/hikuohiku/homelab/pull/46"
-    },
-    {
-      "mergedAt": "2026-06-21T06:04:01Z",
-      "number": 45,
-      "title": "chore: Proxmox 棚卸しと pbs の手動管理方針を明示",
-      "url": "https://github.com/hikuohiku/homelab/pull/45"
     }
   ]
 }


### PR DESCRIPTION
ダッシュボードの PR 一覧が **#65 の時点で凍っていました**。`build.py` の `fetch_prs()` が取得失敗時に黙ってキャッシュへフォールバックし、ページ上はそれと分からないためです。

人間から見て「最新のはずのものが実は古い」のが一番まずいので、**取得できなかった事実とキャッシュの時刻をページ上部に出します**。取得できているときは何も出ません。

PR 一覧そのものを実行環境非依存にする根本対処は autopilot が T-0016 として起票済みです。これはそれまでの間、ダッシュボードが嘘をつかないようにするための変更です。

- `python3 ops/dashboard/build.py` で生成確認（このワークスペースでは gh が使えるため警告は出ない）