### PR TITLE
fix(argocd): chart バージョンの二重管理に CI 検出を追加する (T-0002)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,3 +105,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: validate
         run: python3 ops/validate.py
+      - name: check duplicated version pins are in sync
+        run: pip install --quiet pyyaml && python3 ops/check_version_sync.py

--- a/apps/argocd/kustomization.yaml
+++ b/apps/argocd/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 helmCharts:
   - name: argo-cd
     repo: https://argoproj.github.io/argo-helm
+    # bootstrap 用の nix/images/proxmox-cloud/k3s-manifests.nix の version と必ず同時に更新する。
+    # 揃っていることは ops/check_version_sync.py が CI で検証する（T-0002）。
     version: 9.1.6
     releaseName: argocd
     namespace: argocd

--- a/nix/images/proxmox-cloud/k3s-manifests.nix
+++ b/nix/images/proxmox-cloud/k3s-manifests.nix
@@ -40,6 +40,8 @@
         spec = {
           repo = "https://argoproj.github.io/argo-helm";
           chart = "argo-cd";
+          # apps/argocd/kustomization.yaml の version と必ず同時に更新する。
+          # 揃っていることは ops/check_version_sync.py が CI で検証する（T-0002）。
           version = "9.1.6";
           targetNamespace = "argocd";
           valuesContent = builtins.toJSON {

--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -174,6 +174,7 @@ high に該当するのは、失敗したときに元へ戻せないもの。**�
 | `sudo` | `deny` 対象。使わない |
 | `git push --force` | 使わない。やり直したいならブランチを作り直す |
 | `gh`（GitHub CLI） | この実行環境には入っていない（`command not found`）。GitHub 操作は `mcp__github__*` ツールで代替する（[§4](#4-pr-の作り方) 参照）。`api.github.com` への直接 HTTPS リクエスト（`curl`/`urllib` 等）も組織の egress ポリシーで 403 になり使えない。`ghcr.io` など GitHub 以外のレジストリは到達できる（2026-08-04 run #4 で確認） |
+| `git checkout <ref> -- .` / `git checkout <ref> -- <path>` | **使わない。** untracked ファイル以外の全 tracked ファイルを `<ref>` の内容で working tree ごと上書きする破壊的操作。ローカルの `main` ブランチは `git fetch` しても自動更新されず、`origin/main` とは別物として古いまま残ることがある（2026-08-04 run #5 で `git checkout main -- .` が stale なローカル `main` の内容で CHARTER/journal/state/backlog を上書きする事故を起こした。commit 前だったので `git reset --hard HEAD` で復旧）。ブランチの現在地を確認したいだけなら `git log -1 --format=%H origin/main` や `git status` / `git diff` を使う |
 
 ルールを増やすときは、ここに「なぜ踏めないか」と「代わりに何をするか」をセットで書く。
 禁止だけ並べると、次の自分が回避策を探して時間を溶かす。

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -26,8 +26,8 @@
       "domain": "homelab",
       "title": "argo-cd chart バージョンの二重管理を解消する",
       "kind": "refactor",
-      "risk": "medium",
-      "status": "todo",
+      "risk": "low",
+      "status": "done",
       "priority": 2,
       "why": "9.1.6 が apps/argocd/kustomization.yaml と nix/images/proxmox-cloud/k3s-manifests.nix の 2 箇所に書かれている。片方だけ上げると bootstrap と実運用がずれる",
       "dod": "どちらか一方が単一の情報源になる。統一が難しい場合は、両方を必ず同時に更新すべき旨をコメントで両ファイルに明記し、CI で不一致を検出する",
@@ -36,7 +36,8 @@
         "nix/images/proxmox-cloud/k3s-manifests.nix"
       ],
       "created": "2026-08-04",
-      "pr": null
+      "pr": null,
+      "notes": "run #5: 単一情報源への統合は nix の bootstrap 用 HelmChart CR と kustomize の helmCharts が構造的に別物のため見送り、DoD の代替案（コメント明記 + CI 検出）を採用。ops/check_version_sync.py を追加し CI (ops job) に組み込んだ。risk は実装した内容（コメント + CI 設定のみ、manifest 自体の値は不変）に合わせて low に見直した"
     },
     {
       "id": "T-0003",

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -36,7 +36,7 @@
         "nix/images/proxmox-cloud/k3s-manifests.nix"
       ],
       "created": "2026-08-04",
-      "pr": null,
+      "pr": 74,
       "notes": "run #5: 単一情報源への統合は nix の bootstrap 用 HelmChart CR と kustomize の helmCharts が構造的に別物のため見送り、DoD の代替案（コメント明記 + CI 検出）を採用。ops/check_version_sync.py を追加し CI (ops job) に組み込んだ。risk は実装した内容（コメント + CI 設定のみ、manifest 自体の値は不変）に合わせて low に見直した"
     },
     {

--- a/ops/check_version_sync.py
+++ b/ops/check_version_sync.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+リポジトリ内で二重管理されているバージョン pin が揃っているか検証する。
+CI (ops job) から実行する。不一致があれば非 0 で終了する。
+
+新しく二重管理の pin が見つかったら PAIRS にエントリを追加する（ops/CHARTER.md T-0002）。
+"""
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text()
+
+
+def extract_yaml_helm_chart_version(path: str, chart_name: str) -> str:
+    import yaml
+
+    doc = yaml.safe_load(read(path))
+    for chart in doc.get("helmCharts", []):
+        if chart.get("name") == chart_name:
+            return str(chart["version"])
+    raise ValueError(f"{path}: helmCharts に {chart_name} が見つからない")
+
+
+def extract_nix_helmchart_version(path: str, chart_name: str) -> str:
+    text = read(path)
+    m = re.search(rf'chart\s*=\s*"{re.escape(chart_name)}"\s*;', text)
+    if not m:
+        raise ValueError(f"{path}: chart = \"{chart_name}\" が見つからない")
+    rest = text[m.end() : m.end() + 500]
+    v = re.search(r'version\s*=\s*"([^"]+)"\s*;', rest)
+    if not v:
+        raise ValueError(f"{path}: {chart_name} の直後に version が見つからない")
+    return v.group(1)
+
+
+PAIRS = [
+    {
+        "name": "argo-cd chart version (T-0002)",
+        "a": ("apps/argocd/kustomization.yaml", lambda: extract_yaml_helm_chart_version(
+            "apps/argocd/kustomization.yaml", "argo-cd"
+        )),
+        "b": ("nix/images/proxmox-cloud/k3s-manifests.nix", lambda: extract_nix_helmchart_version(
+            "nix/images/proxmox-cloud/k3s-manifests.nix", "argo-cd"
+        )),
+    },
+]
+
+
+def main() -> int:
+    fail = False
+    for pair in PAIRS:
+        a_path, a_fn = pair["a"]
+        b_path, b_fn = pair["b"]
+        try:
+            a_ver = a_fn()
+            b_ver = b_fn()
+        except Exception as e:
+            print(f"::error::{pair['name']}: 抽出に失敗しました: {e}")
+            fail = True
+            continue
+        if a_ver != b_ver:
+            print(
+                f"::error::{pair['name']}: バージョンが一致しません "
+                f"({a_path}={a_ver} != {b_path}={b_ver})"
+            )
+            fail = True
+        else:
+            print(f"ok: {pair['name']} = {a_ver}")
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -187,12 +187,12 @@ a { color:var(--sig); }
     <div class="mast__sub">
       <span>homelab を自律運用するエージェントの記録</span>
       <span>起動間隔 1 時間ごと（毎時 19 分）</span>
-      <span>生成 2026-08-04 19:41 UTC</span>
+      <span>生成 2026-08-04 19:53 UTC</span>
     </div>
   </header>
 
-  <div class="stats"><div class="stat stat--sig"><span class="stat__v">-49 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">20</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
-  
+  <div class="stats"><div class="stat stat--sig"><span class="stat__v">-37 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">20</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
+  <p class="stale">PR の一覧を取得できませんでした。下の「やったこと」と「いま動かしているもの」は<strong>3 分前のキャッシュ</strong>で、現在の状態と違う可能性があります。<span class="stale__why">([Errno 2] No such file or directory: &#x27;gh&#x27;)</span></p>
 
   <section>
     <h2>やったこと</h2>
@@ -200,51 +200,51 @@ a { color:var(--sig); }
     <ul class="list">
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/71">fix(tailscale): k8s-nameserver の floating tag unstable を固定する</a>
-        <span class="done__meta">#71 · 1 分前</span>
+        <span class="done__meta">#71 · 13 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/70">fix(ci): direct-push-guard のレビュー指摘3点を修正</a>
-        <span class="done__meta">#70 · 7 分前</span>
+        <span class="done__meta">#70 · 19 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/69">fix(ops): ダッシュボードに起動間隔が出ない退行を直す</a>
-        <span class="done__meta">#69 · 15 分前</span>
+        <span class="done__meta">#69 · 27 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/68">fix(terraform): .terraform.lock.hcl から未宣言の tailscale provider を除去する</a>
-        <span class="done__meta">#68 · 16 分前</span>
+        <span class="done__meta">#68 · 28 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/67">ci: main への直 push を検知する direct-push-guard を追加する</a>
-        <span class="done__meta">#67 · 18 分前</span>
+        <span class="done__meta">#67 · 30 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/66">ops: 「workflow 本文が失われた」という記録の誤りを訂正する</a>
-        <span class="done__meta">#66 · 30 分前</span>
+        <span class="done__meta">#66 · 42 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/65">ops: workflows 権限の付与を受けて T-0014 のブロックを解除する</a>
-        <span class="done__meta">#65 · 34 分前</span>
+        <span class="done__meta">#65 · 46 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/64">ops: T-0014 の pr 番号を記録する (#63)</a>
-        <span class="done__meta">#64 · 36 分前</span>
+        <span class="done__meta">#64 · 48 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/63">ops: issue #56 のフィードバックを反映、T-0014 を needs-human に</a>
-        <span class="done__meta">#63 · 38 分前</span>
+        <span class="done__meta">#63 · 49 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/62">fix: permissions.ask を全廃する</a>
-        <span class="done__meta">#62 · 47 分前</span>
+        <span class="done__meta">#62 · 59 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/61">fix(ops): 権限プロンプトで起動が消えるのを防ぐ</a>
-        <span class="done__meta">#61 · 49 分前</span>
+        <span class="done__meta">#61 · 1 時間前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/60">ops: 定期実行を 1 時間ごとに変更し、run #1 の記録を残す</a>
-        <span class="done__meta">#60 · 55 分前</span>
+        <span class="done__meta">#60 · 1 時間前</span>
       </li></ul>
   </section>
 
@@ -287,7 +287,7 @@ a { color:var(--sig); }
     <p>使っていて感じたことを殴り書きで構いません。進め方への指摘は憲章に、やってほしいことはタスクとして取り込まれます。
        読んだら 3 行以内で返信します。<strong>返信が無い＝まだ読んでいない</strong>と判断してください。</p>
     <a class="fb__cta" href="https://github.com/hikuohiku/homelab/issues/56">issue #56 に書く</a>
-    <span class="fb__meta">最後に読んだ: 16 分前</span>
+    <span class="fb__meta">最後に読んだ: 28 分前</span>
   </section>
 
   <section>
@@ -299,20 +299,6 @@ a { color:var(--sig); }
     <h2>これからやること</h2>
     <p class="lede">上から順に着手します。1 タスク = 1 PR。</p>
     <ul class="list">
-      <li class="task task--idle">
-        <div class="task__head">
-          <span class="task__id">T-0002</span>
-          <h3 class="task__title">argo-cd chart バージョンの二重管理を解消する</h3>
-        </div>
-        <p class="task__why">9.1.6 が apps/argocd/kustomization.yaml と nix/images/proxmox-cloud/k3s-manifests.nix の 2 箇所に書かれている。片方だけ上げると bootstrap と実運用がずれる</p>
-        
-        <div class="task__meta">
-          <span class="chip chip--idle">待ち</span>
-          <span class="chip chip--quiet">整理</span>
-          <span class="chip chip--quiet">リスク 中</span>
-          <span class="task__refs"><code>apps/argocd/kustomization.yaml</code><code>nix/images/proxmox-cloud/k3s-manifests.nix</code></span>
-        </div>
-      </li>
       <li class="task task--idle">
         <div class="task__head">
           <span class="task__id">T-0003</span>

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -103,3 +103,19 @@
     書き換えるタスクを起票すること（`api.github.com` 直叩きは 403 で不可なので、build.py 単体では解決できない。
     起動のたびに agent が `mcp__github__list_pull_requests` で取得して `ops/dashboard/prs.json` を直接更新してから
     `build.py` を実行する運用にするか、build.py に「事前に用意された prs.json をそのまま使う」前提を明記するかを検討）
+
+## 2026-08-04 19:45 UTC — run #5（続き）
+
+- T-0002（argo-cd chart バージョンの二重管理）に着手。`apps/argocd/kustomization.yaml`
+  （kustomize helmCharts）と `nix/images/proxmox-cloud/k3s-manifests.nix`（bootstrap 用 HelmChart CR）は
+  構造が別物で単一の情報源に統合するのは大掛かりになるため、DoD の代替案を採用: 両ファイルに
+  「同時に更新する」コメントを追記し、`ops/check_version_sync.py` を新設して CI (`ops` job) で
+  不一致を検出するようにした。手元で一致検出・不一致検出（意図的にずらして確認）の両方を確認済み。
+  risk は実装内容（コメント + CI 設定のみ、manifest の値自体は不変）に合わせて medium → low に見直した
+- **事故と回復**: この回の途中で `git checkout main -- .` を実行し、ローカルの古い（stale な）`main` ブランチ
+  参照から全ファイルが working tree に上書きされ、CHARTER/journal/state/backlog 等が古い内容に巻き戻る事故が
+  起きた。まだ commit していなかったため `git reset --hard HEAD` で復旧できた。教訓: `git checkout <ref> -- .`
+  は untracked ファイル以外の全 tracked ファイルをそのブランチの内容で上書きする破壊的操作であり、ローカルの
+  `main` ブランチは fetch しても自動更新されない（`origin/main` とは別物）。状態確認には
+  `git log -1 --format=%H origin/main` や `git status` を使い、`checkout <ref> -- .` は使わない
+- 次の起動へ: backlog は T-0003（priority 3, busybox バージョン統一）から順に


### PR DESCRIPTION
## 変更点

`apps/argocd/kustomization.yaml`（kustomize の helmCharts）と `nix/images/proxmox-cloud/k3s-manifests.nix`（bootstrap 用の HelmChart CR）の両方に argo-cd chart のバージョン `9.1.6` が別々に書かれており、片方だけ上げると bootstrap 時と実運用時のバージョンがずれる懸念があった（backlog T-0002）。

両ファイルは構造が別物（kustomize の helmCharts と、nix が生成する k3s HelmChart CR）で、単一の情報源に統合するのは大掛かりな変更になるため、今回は次の対応にとどめた:

- 両ファイルに「もう一方と必ず同時に更新する」旨のコメントを追加
- `ops/check_version_sync.py` を新設し、CI（`ops` job）で両ファイルのバージョンが一致しているかを検証するようにした
- バージョンの値自体は変更していない（`9.1.6` のまま）

## 検証したこと

- `python3 ops/check_version_sync.py` で一致検出（成功）・不一致検出（バージョンを意図的にずらして失敗することを確認）の両方を手元で確認
- `python3 ops/validate.py` → 0 error
- CI（kustomize build / terraform validate / ops state validate）の結果を確認

## ロールバック手順

`ops/check_version_sync.py` の削除、CI の追加ステップと両ファイルのコメント行を revert すれば元に戻る。バージョンの値自体は変えていないため、revert してもクラスタの状態に影響しない。

## backlog task id

T-0002

---
_Generated by [Claude Code](https://claude.ai/code/session_019bKQUEBArSDZydPKDAz87q)_