### PR TITLE
ops: run #5 の記録をまとめ、ダッシュボードを再生成する

### DIFF
--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -187,12 +187,12 @@ a { color:var(--sig); }
     <div class="mast__sub">
       <span>homelab を自律運用するエージェントの記録</span>
       <span>起動間隔 1 時間ごと（毎時 19 分）</span>
-      <span>生成 2026-08-04 19:58 UTC</span>
+      <span>生成 2026-08-04 19:59 UTC</span>
     </div>
   </header>
 
-  <div class="stats"><div class="stat stat--sig"><span class="stat__v">13 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">20</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
-  <p class="stale">PR の一覧を取得できませんでした。下の「やったこと」と「いま動かしているもの」は<strong>8 分前のキャッシュ</strong>で、現在の状態と違う可能性があります。<span class="stale__why">([Errno 2] No such file or directory: &#x27;gh&#x27;)</span></p>
+  <div class="stats"><div class="stat stat--sig"><span class="stat__v">14 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">20</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
+  <p class="stale">PR の一覧を取得できませんでした。下の「やったこと」と「いま動かしているもの」は<strong>9 分前のキャッシュ</strong>で、現在の状態と違う可能性があります。<span class="stale__why">([Errno 2] No such file or directory: &#x27;gh&#x27;)</span></p>
 
   <section>
     <h2>やったこと</h2>
@@ -200,39 +200,39 @@ a { color:var(--sig); }
     <ul class="list">
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/71">fix(tailscale): k8s-nameserver の floating tag unstable を固定する</a>
-        <span class="done__meta">#71 · 17 分前</span>
+        <span class="done__meta">#71 · 18 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/70">fix(ci): direct-push-guard のレビュー指摘3点を修正</a>
-        <span class="done__meta">#70 · 23 分前</span>
+        <span class="done__meta">#70 · 25 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/69">fix(ops): ダッシュボードに起動間隔が出ない退行を直す</a>
-        <span class="done__meta">#69 · 31 分前</span>
+        <span class="done__meta">#69 · 33 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/68">fix(terraform): .terraform.lock.hcl から未宣言の tailscale provider を除去する</a>
-        <span class="done__meta">#68 · 32 分前</span>
+        <span class="done__meta">#68 · 34 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/67">ci: main への直 push を検知する direct-push-guard を追加する</a>
-        <span class="done__meta">#67 · 34 分前</span>
+        <span class="done__meta">#67 · 36 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/66">ops: 「workflow 本文が失われた」という記録の誤りを訂正する</a>
-        <span class="done__meta">#66 · 46 分前</span>
+        <span class="done__meta">#66 · 48 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/65">ops: workflows 権限の付与を受けて T-0014 のブロックを解除する</a>
-        <span class="done__meta">#65 · 50 分前</span>
+        <span class="done__meta">#65 · 51 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/64">ops: T-0014 の pr 番号を記録する (#63)</a>
-        <span class="done__meta">#64 · 53 分前</span>
+        <span class="done__meta">#64 · 54 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/63">ops: issue #56 のフィードバックを反映、T-0014 を needs-human に</a>
-        <span class="done__meta">#63 · 54 分前</span>
+        <span class="done__meta">#63 · 55 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/62">fix: permissions.ask を全廃する</a>
@@ -287,7 +287,7 @@ a { color:var(--sig); }
     <p>使っていて感じたことを殴り書きで構いません。進め方への指摘は憲章に、やってほしいことはタスクとして取り込まれます。
        読んだら 3 行以内で返信します。<strong>返信が無い＝まだ読んでいない</strong>と判断してください。</p>
     <a class="fb__cta" href="https://github.com/hikuohiku/homelab/issues/56">issue #56 に書く</a>
-    <span class="fb__meta">最後に読んだ: 24 分前</span>
+    <span class="fb__meta">最後に読んだ: 26 分前</span>
   </section>
 
   <section>

--- a/ops/state.json
+++ b/ops/state.json
@@ -68,8 +68,8 @@
       "at": "2026-08-04T19:45:00Z",
       "kind": "scheduled",
       "by": "cloud routine",
-      "summary": "issue #56 の未読フィードバックを反映: このクラウドサンドボックスのツール有無を実測し CHARTER §5.2 として記録（terraform/kustomize は無い。run #0 の人間セッションとは環境が違う）。続けて T-0002（argo-cd chart バージョン二重管理）に着手し CI 検出を追加",
-      "prs": [73, 74]
+      "summary": "issue #56 の未読フィードバックを反映: このクラウドサンドボックスのツール有無を実測し CHARTER §5.2 として記録（terraform/kustomize は無い。run #0 の人間セッションとは環境が違う）。T-0002（argo-cd chart バージョン二重管理に CI 検出を追加）・T-0003（busybox バージョン統一）を完遂。途中 git checkout の事故があったが commit 前だったため復旧し、CHARTER に教訓を追記",
+      "prs": [73, 74, 75]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

run #5（このクラウド定期実行）で出した PR #73・#74・#75 がすべてマージされたので、`ops/state.json` の `runs[5]` に最終的な PR 一覧とサマリを反映し、ダッシュボードを再生成した。運用記録のみで、アプリケーション側の変更は無い。

## 検証したこと

- `python3 ops/validate.py` → 0 error
- CI（kustomize build / terraform validate / ops state validate）の結果を確認

## ロールバック手順

`ops/state.json` と `ops/dashboard/index.html` を revert すれば元に戻る。記録のみのため実インフラへの影響はない。

## backlog task id

なし（ops/ の運用記録更新。CHARTER §4 の例外規定）

---
_Generated by [Claude Code](https://claude.ai/code/session_019bKQUEBArSDZydPKDAz87q)_