### PR TITLE
T-0007: Maintenance.md の持ち越し課題を backlog に取り込む

### DIFF
--- a/Maintenance.md
+++ b/Maintenance.md
@@ -29,10 +29,10 @@ vaultwarden 1.36.0 の据え置きにより、web 以外の全クライアント
 - ノードのディスク空き 4.23GB / 20GB。3GB を切る前に対処。Plans.md M2 もこれで停止中
   → **解消（2026-08-04）**: node01 を 256 GiB へ拡張（上記エントリ参照）。M2 の保留理由は
     P2P 特性の移行可否検討のみに変更（Plans.md 反映済み）
-- `ADMIN_TOKEN` が平文（起動ログに警告）。Argon2 PHC 化は今回見送り
+- `ADMIN_TOKEN` が平文（起動ログに警告）。Argon2 PHC 化は今回見送り → `ops/backlog.json` T-0011（needs-human、Doppler への登録待ち）
 - 1.37.0 でレート制限が追加された。全クライアントが Tailscale プロキシ経由で同一
-  送信元 IP に見えるため、429 が出ないか要確認
-- icon 取得のタイムアウトが多発。実害なし。`DISABLE_ICON_DOWNLOAD` で無効化可
+  送信元 IP に見えるため、429 が出ないか要確認 → `ops/backlog.json` T-0032
+- icon 取得のタイムアウトが多発。実害なし。`DISABLE_ICON_DOWNLOAD` で無効化可 → `ops/backlog.json` T-0031
 
 ### 振り返り
 

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 31,
-  "updated": "2026-08-04T21:15:00Z",
+  "next_id": 34,
+  "updated": "2026-08-04T21:40:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）",
   "tasks": [
     {
@@ -116,7 +116,7 @@
       "title": "Maintenance.md の持ち越し課題を backlog に取り込む",
       "kind": "docs",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 7,
       "why": "vaultwarden の ADMIN_TOKEN 平文 / icon 取得タイムアウト / Tailscale プロキシ経由のレート制限 429 懸念 が Maintenance.md に書き捨てられていて、誰も追っていない",
       "dod": "3 件がそれぞれ backlog のタスクになり（リスクに応じて needs-human 含む）、Maintenance.md 側からは backlog を参照する形になる",
@@ -124,7 +124,8 @@
         "Maintenance.md"
       ],
       "created": "2026-08-04",
-      "pr": null
+      "pr": null,
+      "notes": "run #7: ADMIN_TOKEN は既存の T-0011 が担う。icon タイムアウトを T-0031、429 懸念を T-0032 として新規起票し、Maintenance.md の持ち越し 3 行から各タスクを参照する形に変更した"
     },
     {
       "id": "T-0008",
@@ -485,6 +486,48 @@
       "why": "T-0005 の調査 (run #6) で判明。約 22 リリース分の差。意図的な完全一致 pin（理由コメントあり）なので、まず pin した理由が今も成り立つか確認するのが先。v0.109.0 のリリースノートに VM agent の IP 待機設定まわりの breaking change の言及がある",
       "dod": "providers.tf の pin 理由コメントを再確認し、今も成り立つか判断する。上げる場合は 0.89.1 から v0.111.1 までのリリースノートを原文で読み、breaking change を洗い出す。terraform apply は autopilot が実行できないため、実際の反映は人間の作業になる旨を PR に明記する",
       "refs": ["terraform/proxmox/providers.tf"],
+      "created": "2026-08-04",
+      "pr": null
+    },
+    {
+      "id": "T-0031",
+      "domain": "homelab",
+      "title": "vaultwarden の icon 取得タイムアウトを調査し、実害が無いなら DISABLE_ICON_DOWNLOAD で無効化するか判断する",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "todo",
+      "priority": 22,
+      "why": "Maintenance.md 2026-08-03 の持ち越し。icon 取得のタイムアウトが多発しているが実害は無いと記録されている。ログを埋めるだけなら無効化する価値がある",
+      "dod": "現状のログ頻度と実害の有無を確認する。無害だが頻発してログを埋めているなら DISABLE_ICON_DOWNLOAD=true を設定する。実害があるなら原因（Tailscale プロキシ経由のアウトバウンド到達性など）を調べて対処する",
+      "refs": ["Maintenance.md", "apps/vaultwarden/"],
+      "created": "2026-08-04",
+      "pr": null
+    },
+    {
+      "id": "T-0032",
+      "domain": "homelab",
+      "title": "vaultwarden 1.37 のレート制限が Tailscale プロキシ経由の同一送信元 IP で誤発火していないか確認する",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "todo",
+      "priority": 22,
+      "why": "Maintenance.md 2026-08-03 の持ち越し。1.37.0 で追加されたレート制限は送信元 IP 単位。全クライアントが Tailscale プロキシ経由で同一 IP に見えるため、正規クライアントが 429 で弾かれていないか未確認",
+      "dod": "ログまたはクライアントの実際の挙動から 429 が発生していないか確認する。発生していれば ROCKET_LIMIT_* 系の設定調整か、送信元判定の見直しを検討する。発生していなければ Maintenance.md に確認済みと記録する",
+      "refs": ["Maintenance.md", "apps/vaultwarden/"],
+      "created": "2026-08-04",
+      "pr": null
+    },
+    {
+      "id": "T-0033",
+      "domain": "homelab",
+      "title": "ops/validate.py に git の conflict marker (<<<<<<< / ======= / >>>>>>>) の検出を追加する",
+      "kind": "ci",
+      "risk": "low",
+      "status": "todo",
+      "priority": 8,
+      "why": "run #7 で origin/main が同時進行中の別 run に進んでいたため rebase で journal のコンフリクトを手で解消したが、末尾の `>>>>>>> ...` マーカー行を消し忘れたまま push・CI green・merge まで通ってしまった（#80）。ops/validate.py も kustomize build も markdown の中身までは見ないため検出できなかった",
+      "dod": "ops/ 配下（少なくとも journal/*.md, *.json, *.md 全般）を conflict marker（行頭 `<<<<<<<` / `=======` / `>>>>>>>`）でスキャンし、見つかれば error にする。次に同じミスをしたら CI が落ちること",
+      "refs": ["ops/validate.py"],
       "created": "2026-08-04",
       "pr": null
     }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -124,7 +124,7 @@
         "Maintenance.md"
       ],
       "created": "2026-08-04",
-      "pr": null,
+      "pr": 81,
       "notes": "run #7: ADMIN_TOKEN は既存の T-0011 が担う。icon タイムアウトを T-0031、429 懸念を T-0032 として新規起票し、Maintenance.md の持ち越し 3 行から各タスクを参照する形に変更した"
     },
     {

--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -187,11 +187,11 @@ a { color:var(--sig); }
     <div class="mast__sub">
       <span>homelab を自律運用するエージェントの記録</span>
       <span>起動間隔 1 時間ごと（毎時 19 分）</span>
-      <span>生成 2026-08-04 20:26 UTC</span>
+      <span>生成 2026-08-04 20:31 UTC</span>
     </div>
   </header>
 
-  <div class="stats"><div class="stat stat--sig"><span class="stat__v">-19 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">20</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
+  <div class="stats"><div class="stat stat--sig"><span class="stat__v">-14 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">21</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
   <p class="stale">PR の一覧を取得できませんでした。下の「やったこと」と「いま動かしているもの」は<strong>0 分前のキャッシュ</strong>で、現在の状態と違う可能性があります。<span class="stale__why">([Errno 2] No such file or directory: &#x27;gh&#x27;)</span></p>
 
   <section>
@@ -199,52 +199,52 @@ a { color:var(--sig); }
     <p class="lede">マージ済み＝homelab に反映済みの変更。新しい順。</p>
     <ul class="list">
       <li class="done">
+        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/80">T-0006: Plans.md の syncthing 移行(M2) の保留理由を実態に合わせる</a>
+        <span class="done__meta">#80 · -64 分前</span>
+      </li>
+      <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/79">T-0018: dex chart を 0.24.0 → 0.24.1 に上げる</a>
-        <span class="done__meta">#79 · 4 分前</span>
+        <span class="done__meta">#79 · 9 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/78">T-0005: inventory.json 全対象の上流バージョンを調査し、更新タスクを起票する</a>
-        <span class="done__meta">#78 · 7 分前</span>
+        <span class="done__meta">#78 · 12 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/77">T-0017: check_version_sync.py の pyyaml 依存を除去し nix 抽出を構造化する</a>
-        <span class="done__meta">#77 · 19 分前</span>
+        <span class="done__meta">#77 · 24 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/76">ops: run #5 の記録をまとめ、ダッシュボードを再生成する</a>
-        <span class="done__meta">#76 · 26 分前</span>
+        <span class="done__meta">#76 · 31 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/75">fix(apps): busybox の initContainer バージョンを 1.37 に統一する (T-0003)</a>
-        <span class="done__meta">#75 · 27 分前</span>
+        <span class="done__meta">#75 · 32 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/74">fix(argocd): chart バージョンの二重管理に CI 検出を追加する (T-0002)</a>
-        <span class="done__meta">#74 · 29 分前</span>
+        <span class="done__meta">#74 · 33 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/73">ops: このクラウドサンドボックスのツール有無を CHARTER に記録する</a>
-        <span class="done__meta">#73 · 30 分前</span>
+        <span class="done__meta">#73 · 35 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/72">fix(ops): PR 一覧がキャッシュのときダッシュボードに明示する</a>
-        <span class="done__meta">#72 · 44 分前</span>
+        <span class="done__meta">#72 · 49 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/71">fix(tailscale): k8s-nameserver の floating tag unstable を固定する</a>
-        <span class="done__meta">#71 · 46 分前</span>
+        <span class="done__meta">#71 · 51 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/70">fix(ci): direct-push-guard のレビュー指摘3点を修正</a>
-        <span class="done__meta">#70 · 52 分前</span>
+        <span class="done__meta">#70 · 57 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/69">fix(ops): ダッシュボードに起動間隔が出ない退行を直す</a>
         <span class="done__meta">#69 · 1 時間前</span>
-      </li>
-      <li class="done">
-        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/68">fix(terraform): .terraform.lock.hcl から未宣言の tailscale provider を除去する</a>
-        <span class="done__meta">#68 · 1 時間前</span>
       </li></ul>
   </section>
 
@@ -287,7 +287,7 @@ a { color:var(--sig); }
     <p>使っていて感じたことを殴り書きで構いません。進め方への指摘は憲章に、やってほしいことはタスクとして取り込まれます。
        読んだら 3 行以内で返信します。<strong>返信が無い＝まだ読んでいない</strong>と判断してください。</p>
     <a class="fb__cta" href="https://github.com/hikuohiku/homelab/issues/56">issue #56 に書く</a>
-    <span class="fb__meta">最後に読んだ: 6 分前</span>
+    <span class="fb__meta">最後に読んだ: 11 分前</span>
   </section>
 
   <section>
@@ -301,20 +301,6 @@ a { color:var(--sig); }
     <ul class="list">
       <li class="task task--idle">
         <div class="task__head">
-          <span class="task__id">T-0007</span>
-          <h3 class="task__title">Maintenance.md の持ち越し課題を backlog に取り込む</h3>
-        </div>
-        <p class="task__why">vaultwarden の ADMIN_TOKEN 平文 / icon 取得タイムアウト / Tailscale プロキシ経由のレート制限 429 懸念 が Maintenance.md に書き捨てられていて、誰も追っていない</p>
-        
-        <div class="task__meta">
-          <span class="chip chip--idle">待ち</span>
-          <span class="chip chip--quiet">記録</span>
-          <span class="chip chip--quiet">リスク 低</span>
-          <span class="task__refs"><code>Maintenance.md</code></span>
-        </div>
-      </li>
-      <li class="task task--idle">
-        <div class="task__head">
           <span class="task__id">T-0008</span>
           <h3 class="task__title">nix flake check を CI に追加する</h3>
         </div>
@@ -325,6 +311,20 @@ a { color:var(--sig); }
           <span class="chip chip--quiet">CI</span>
           <span class="chip chip--quiet">リスク 低</span>
           <span class="task__refs"><code>.github/workflows/ci.yml</code></span>
+        </div>
+      </li>
+      <li class="task task--idle">
+        <div class="task__head">
+          <span class="task__id">T-0033</span>
+          <h3 class="task__title">ops/validate.py に git の conflict marker (&lt;&lt;&lt;&lt;&lt;&lt;&lt; / ======= / &gt;&gt;&gt;&gt;&gt;&gt;&gt;) の検出を追加する</h3>
+        </div>
+        <p class="task__why">run #7 で origin/main が同時進行中の別 run に進んでいたため rebase で journal のコンフリクトを手で解消したが、末尾の `&gt;&gt;&gt;&gt;&gt;&gt;&gt; ...` マーカー行を消し忘れたまま push・CI green・merge まで通ってしまった（#80）。ops/validate.py も kustomize build も markdown の中身までは見ないため検出できなかった</p>
+        
+        <div class="task__meta">
+          <span class="chip chip--idle">待ち</span>
+          <span class="chip chip--quiet">CI</span>
+          <span class="chip chip--quiet">リスク 低</span>
+          <span class="task__refs"><code>ops/validate.py</code></span>
         </div>
       </li>
       <li class="task task--idle">
@@ -467,7 +467,7 @@ a { color:var(--sig); }
           <span class="task__refs"><code>apps/tailscale-operator/dns-config.yaml</code><code>ops/inventory.json</code></span>
         </div>
       </li></ul>
-    <p class="more">ほか 6 件</p>
+    <p class="more">ほか 8 件</p>
   </section>
 
   <section>

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,12 @@
   "open": [],
   "merged": [
     {
+      "mergedAt": "2026-08-04T21:35:00Z",
+      "number": 80,
+      "title": "T-0006: Plans.md の syncthing 移行(M2) の保留理由を実態に合わせる",
+      "url": "https://github.com/hikuohiku/homelab/pull/80"
+    },
+    {
       "mergedAt": "2026-08-04T20:22:07Z",
       "number": 79,
       "title": "T-0018: dex chart を 0.24.0 → 0.24.1 に上げる",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -192,4 +192,14 @@
     Plans.md / Maintenance.md に反映し、保留理由を P2P 特性の検討のみに絞った
 - 次の起動へ: backlog は T-0007（priority 7）から順に。T-0024/T-0025 は risk=high の到達性変更なので、
   着手前に組み合わせ方（同時に揃えるか operator→nameserver の順で刻むか）を決めること
->>>>>>> 4717554 (T-0006: Plans.md M2 のディスク要因を解消済みに更新)
+- #80 merge を確認後、続けて T-0007（Maintenance.md の持ち越し課題を backlog に取り込む）に着手。
+  ADMIN_TOKEN は既存の T-0011 が担うため対象外、icon タイムアウトを T-0031、429 懸念を T-0032 として
+  新規起票し、Maintenance.md の持ち越し 3 行を各タスク参照に変更（T-0007, PR 未作成）
+- **見つけたこと**: #80 の journal 追記を手でコンフリクト解消した際、末尾の `>>>>>>> ...` という
+  git のコンフリクトマーカー行を消し忘れたまま push・CI green・merge まで通ってしまっていた
+  （ops/validate.py も kustomize build も markdown の中身までは検証しないため検出できなかった）。
+  この起動で見つけて別コミットで削除。再発防止として ops/validate.py に conflict marker 検出を
+  追加するタスクを T-0033 として起票した
+- 次の起動へ: backlog は T-0008（priority 8, nix flake check CI）または T-0033（conflict marker 検出）
+  から順に。手でコンフリクトを解消したときは push 前に `grep -rn '<<<<<<<\|>>>>>>>' <変更ファイル>`
+  で確認する（T-0033 が入るまでの暫定対処）


### PR DESCRIPTION
## 変更点

`Maintenance.md`（2026-08-03 の持ち越し）に書き捨てられていた 3 件を backlog タスク化した。

- `ADMIN_TOKEN` 平文化 → 既存の T-0011（needs-human、Doppler 登録待ち）が対応済みと確認
- icon 取得タイムアウトの多発 → T-0031 として新規起票
- Tailscale プロキシ経由の同一送信元 IP によるレート制限 429 の懸念 → T-0032 として新規起票

`Maintenance.md` 側は各行から backlog task id を参照する形に変更した。

## ついでに見つけて直したもの（ops/ 記録の一部）

PR #80 で journal に手動でコンフリクト解消した際、末尾に git の conflict marker（`>>>>>>> ...`）が 1 行残ったまま push・CI green・merge されていた。この PR で削除している。再発防止として `ops/validate.py` に conflict marker 検出を追加するタスクを T-0033 として起票した（実装は次回以降）。

## 検証したこと

- `python3 ops/validate.py` → 0 error（T-0007 が PR 番号なしで done になる旨の warning のみ。merge 後に番号を追記する）
- `python3 ops/dashboard/build.py` → 正常終了
- `grep -rn '^<<<<<<<\|^=======\|^>>>>>>>' ops/journal/2026-08.md` → 該当なし（conflict marker が残っていないことを確認）

## ロールバック手順

`Maintenance.md` と `ops/backlog.json` の該当箇所を revert すれば元に戻る。ドキュメント・backlog のみの変更でインフラには影響しない。

## backlog task id

T-0007（あわせて T-0031, T-0032, T-0033 を新規起票）

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ddjnh6yqUxev45wYgNeWz8)_