### PR TITLE
ops: run #7 の記録をまとめ、ダッシュボードを再生成する

### DIFF
--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -187,11 +187,11 @@ a { color:var(--sig); }
     <div class="mast__sub">
       <span>homelab を自律運用するエージェントの記録</span>
       <span>起動間隔 1 時間ごと（毎時 19 分）</span>
-      <span>生成 2026-08-04 20:31 UTC</span>
+      <span>生成 2026-08-04 20:33 UTC</span>
     </div>
   </header>
 
-  <div class="stats"><div class="stat stat--sig"><span class="stat__v">-14 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">21</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
+  <div class="stats"><div class="stat stat--sig"><span class="stat__v">-46 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">22</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
   <p class="stale">PR の一覧を取得できませんでした。下の「やったこと」と「いま動かしているもの」は<strong>0 分前のキャッシュ</strong>で、現在の状態と違う可能性があります。<span class="stale__why">([Errno 2] No such file or directory: &#x27;gh&#x27;)</span></p>
 
   <section>
@@ -199,52 +199,52 @@ a { color:var(--sig); }
     <p class="lede">マージ済み＝homelab に反映済みの変更。新しい順。</p>
     <ul class="list">
       <li class="done">
+        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/81">T-0007: Maintenance.md の持ち越し課題を backlog に取り込む</a>
+        <span class="done__meta">#81 · 0 分前</span>
+      </li>
+      <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/80">T-0006: Plans.md の syncthing 移行(M2) の保留理由を実態に合わせる</a>
-        <span class="done__meta">#80 · -64 分前</span>
+        <span class="done__meta">#80 · -62 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/79">T-0018: dex chart を 0.24.0 → 0.24.1 に上げる</a>
-        <span class="done__meta">#79 · 9 分前</span>
+        <span class="done__meta">#79 · 11 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/78">T-0005: inventory.json 全対象の上流バージョンを調査し、更新タスクを起票する</a>
-        <span class="done__meta">#78 · 12 分前</span>
+        <span class="done__meta">#78 · 14 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/77">T-0017: check_version_sync.py の pyyaml 依存を除去し nix 抽出を構造化する</a>
-        <span class="done__meta">#77 · 24 分前</span>
+        <span class="done__meta">#77 · 26 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/76">ops: run #5 の記録をまとめ、ダッシュボードを再生成する</a>
-        <span class="done__meta">#76 · 31 分前</span>
+        <span class="done__meta">#76 · 33 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/75">fix(apps): busybox の initContainer バージョンを 1.37 に統一する (T-0003)</a>
-        <span class="done__meta">#75 · 32 分前</span>
+        <span class="done__meta">#75 · 34 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/74">fix(argocd): chart バージョンの二重管理に CI 検出を追加する (T-0002)</a>
-        <span class="done__meta">#74 · 33 分前</span>
+        <span class="done__meta">#74 · 36 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/73">ops: このクラウドサンドボックスのツール有無を CHARTER に記録する</a>
-        <span class="done__meta">#73 · 35 分前</span>
+        <span class="done__meta">#73 · 37 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/72">fix(ops): PR 一覧がキャッシュのときダッシュボードに明示する</a>
-        <span class="done__meta">#72 · 49 分前</span>
+        <span class="done__meta">#72 · 51 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/71">fix(tailscale): k8s-nameserver の floating tag unstable を固定する</a>
-        <span class="done__meta">#71 · 51 分前</span>
+        <span class="done__meta">#71 · 53 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/70">fix(ci): direct-push-guard のレビュー指摘3点を修正</a>
-        <span class="done__meta">#70 · 57 分前</span>
-      </li>
-      <li class="done">
-        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/69">fix(ops): ダッシュボードに起動間隔が出ない退行を直す</a>
-        <span class="done__meta">#69 · 1 時間前</span>
+        <span class="done__meta">#70 · 59 分前</span>
       </li></ul>
   </section>
 
@@ -287,7 +287,7 @@ a { color:var(--sig); }
     <p>使っていて感じたことを殴り書きで構いません。進め方への指摘は憲章に、やってほしいことはタスクとして取り込まれます。
        読んだら 3 行以内で返信します。<strong>返信が無い＝まだ読んでいない</strong>と判断してください。</p>
     <a class="fb__cta" href="https://github.com/hikuohiku/homelab/issues/56">issue #56 に書く</a>
-    <span class="fb__meta">最後に読んだ: 11 分前</span>
+    <span class="fb__meta">最後に読んだ: 13 分前</span>
   </section>
 
   <section>

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,12 @@
   "open": [],
   "merged": [
     {
+      "mergedAt": "2026-08-04T20:33:11Z",
+      "number": 81,
+      "title": "T-0007: Maintenance.md の持ち越し課題を backlog に取り込む",
+      "url": "https://github.com/hikuohiku/homelab/pull/81"
+    },
+    {
       "mergedAt": "2026-08-04T21:35:00Z",
       "number": 80,
       "title": "T-0006: Plans.md の syncthing 移行(M2) の保留理由を実態に合わせる",

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-04T21:30:00Z",
+  "updated": "2026-08-04T21:45:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -78,6 +78,14 @@
       "by": "cloud routine",
       "summary": "issue #56 の未読フィードバック 2 件（run #5 が last_read を進めずに終えたため残っていた）を反映。T-0017: check_version_sync.py の pyyaml 依存を除去し nix 側の抽出を brace 単位の構造依存に修正。CHARTER §2 に『複数タスクを扱う起動では前のタスクの PR が merge されるまで次のブランチを作らない』を追記（ops/ 記録が全タスク PR に相乗りするため並行 PR はコンフリクトする、run #5 の実例を踏まえた対処）。続けて T-0005（inventory.json 全対象の上流調査）を完遂し、14 個の個別更新タスク T-0018〜T-0030 を起票。さらに T-0018（dex chart patch 更新）を完遂",
       "prs": [77, 78, 79]
+    },
+    {
+      "n": 7,
+      "at": "2026-08-04T21:19:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "run #6 とこの run が同時に走っていたことに気づき（作業中に origin/main が T-0018 の完了分だけ先行していた）、rebase で追従して journal/backlog/state の衝突を解消。issue #56 の未読フィードバック 2 件を反映し、tailscale-operator chart の確定情報(1.98.9)で T-0024 の blocked_by を解除、T-0025 と組み合わせる前提を追記。T-0006（Plans.md M2 のディスク要因解消の反映）・T-0007（Maintenance.md 持ち越し課題の backlog 取り込み、T-0031/T-0032 起票）を完遂。作業中に見つけた自分のミス（journal に git conflict marker を消し忘れたまま merge していた）を修正し、再発防止の CI 検出を T-0033 として起票",
+      "prs": [80, 81]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`ops/state.json` に run #7（#80, #81）の記録を追加し、ダッシュボードを再生成した。PR キャッシュ（`ops/dashboard/prs.json`）も最新の merged PR で更新済み。コードやマニフェストの変更は無い。

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 正常終了

## ロールバック手順

`ops/state.json` の run #7 エントリを削除すれば元に戻る。記録のみの変更でインフラには影響しない。

## backlog task id

なし（ops/ 運用記録のみ）

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ddjnh6yqUxev45wYgNeWz8)_