### PR TITLE
fix(ops): ダッシュボードの数字が嘘をつかないようにする

### DIFF
--- a/ops/dashboard/build.py
+++ b/ops/dashboard/build.py
@@ -34,6 +34,9 @@ def load(name: str, default=None):
     return json.loads(p.read_text())
 
 
+MERGED_LIMIT = 60  # 取得上限。到達したら件数表示に "+" を付けて頭打ちを隠さない
+
+
 def _gh_prs(state: str, fields: str, limit: int) -> list[dict]:
     out = subprocess.run(
         ["gh", "pr", "list", "--state", state, "--limit", str(limit), "--json", fields],
@@ -48,7 +51,7 @@ def fetch_prs() -> tuple[list[dict], list[dict]]:
     try:
         data = {
             "open": _gh_prs("open", "number,title,url,isDraft,createdAt,statusCheckRollup,headRefName,autoMergeRequest", 30),
-            "merged": _gh_prs("merged", "number,title,url,mergedAt", 20),
+            "merged": _gh_prs("merged", "number,title,url,mergedAt,headRefName", MERGED_LIMIT),
         }
         cache.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n")
         return data["open"], data["merged"]
@@ -98,8 +101,10 @@ def rel_time(iso: str | None) -> str:
         t = datetime.fromisoformat(iso.replace("Z", "+00:00"))
     except ValueError:
         return iso
-    d = datetime.now(timezone.utc) - t
-    s = int(d.total_seconds())
+    s = int((datetime.now(timezone.utc) - t).total_seconds())
+    if s < 0:
+        # 記録側が実際より先の時刻を書くことがある。負の「◯分前」は読み手を混乱させる
+        return "たった今"
     if s < 3600:
         return f"{s // 60} 分前"
     if s < 86400:
@@ -226,6 +231,8 @@ def build() -> str:
         cadence = r.get("cron_human") or r.get("cron")
 
     failing = [p for p in prs if ci_state(p)[0] == "crit"]
+    # 取得上限に引っかかった件数をそのまま出すと、上限値を実績として見せてしまう
+    auto_merged = [p for p in merged if str(p.get("headRefName", "")).startswith("autopilot/")]
 
     # ---- 一番上の要約。人間が朝 5 秒で読む部分
     def stat(value, label, tone="sig"):
@@ -242,7 +249,8 @@ def build() -> str:
 
     stats = "".join([
         stat(rel_time(last_run.get("at")), "最終起動"),
-        stat(len(merged), "反映済みの変更", "ok" if merged else "idle"),
+        stat(f"{len(auto_merged)}+" if len(merged) >= MERGED_LIMIT else len(auto_merged),
+             "autopilot が反映した変更", "ok" if auto_merged else "idle"),
         stat(len(prs), "作業中の PR", "crit" if failing else "sig"),
         stat(len(by_status["needs-human"]), "あなた待ち", "crit" if by_status["needs-human"] else "idle"),
     ])
@@ -260,7 +268,7 @@ def build() -> str:
 
     prs_html = "".join(pr_row(p) for p in prs) or '<li class="empty">作業中の PR はありません。</li>'
     runs_html = "".join(journal_row(e) for e in journal[:4]) or '<li class="empty">まだ記録がありません。</li>'
-    done_html = "".join(done_row(p) for p in merged[:12]) or '<li class="empty">まだ反映された変更はありません。</li>'
+    done_html = "".join(done_row(p) for p in (auto_merged or merged)[:12]) or '<li class="empty">まだ反映された変更はありません。</li>'
     inv_html = "".join(inv_row(t) for t in inventory["targets"])
 
     generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")

--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -187,64 +187,64 @@ a { color:var(--sig); }
     <div class="mast__sub">
       <span>homelab を自律運用するエージェントの記録</span>
       <span>起動間隔 1 時間ごと（毎時 19 分）</span>
-      <span>生成 2026-08-04 20:31 UTC</span>
+      <span>生成 2026-08-04 20:35 UTC</span>
     </div>
   </header>
 
-  <div class="stats"><div class="stat stat--sig"><span class="stat__v">-14 分前</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">21</span><span class="stat__l">反映済みの変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
-  <p class="stale">PR の一覧を取得できませんでした。下の「やったこと」と「いま動かしているもの」は<strong>0 分前のキャッシュ</strong>で、現在の状態と違う可能性があります。<span class="stale__why">([Errno 2] No such file or directory: &#x27;gh&#x27;)</span></p>
+  <div class="stats"><div class="stat stat--sig"><span class="stat__v">たった今</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">26</span><span class="stat__l">autopilot が反映した変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
+  
 
   <section>
     <h2>やったこと</h2>
     <p class="lede">マージ済み＝homelab に反映済みの変更。新しい順。</p>
     <ul class="list">
       <li class="done">
+        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/82">ops: run #7 の記録をまとめ、ダッシュボードを再生成する</a>
+        <span class="done__meta">#82 · 0 分前</span>
+      </li>
+      <li class="done">
+        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/81">T-0007: Maintenance.md の持ち越し課題を backlog に取り込む</a>
+        <span class="done__meta">#81 · 2 分前</span>
+      </li>
+      <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/80">T-0006: Plans.md の syncthing 移行(M2) の保留理由を実態に合わせる</a>
-        <span class="done__meta">#80 · -64 分前</span>
+        <span class="done__meta">#80 · 6 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/79">T-0018: dex chart を 0.24.0 → 0.24.1 に上げる</a>
-        <span class="done__meta">#79 · 9 分前</span>
+        <span class="done__meta">#79 · 13 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/78">T-0005: inventory.json 全対象の上流バージョンを調査し、更新タスクを起票する</a>
-        <span class="done__meta">#78 · 12 分前</span>
+        <span class="done__meta">#78 · 16 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/77">T-0017: check_version_sync.py の pyyaml 依存を除去し nix 抽出を構造化する</a>
-        <span class="done__meta">#77 · 24 分前</span>
+        <span class="done__meta">#77 · 28 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/76">ops: run #5 の記録をまとめ、ダッシュボードを再生成する</a>
-        <span class="done__meta">#76 · 31 分前</span>
+        <span class="done__meta">#76 · 35 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/75">fix(apps): busybox の initContainer バージョンを 1.37 に統一する (T-0003)</a>
-        <span class="done__meta">#75 · 32 分前</span>
+        <span class="done__meta">#75 · 36 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/74">fix(argocd): chart バージョンの二重管理に CI 検出を追加する (T-0002)</a>
-        <span class="done__meta">#74 · 33 分前</span>
+        <span class="done__meta">#74 · 37 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/73">ops: このクラウドサンドボックスのツール有無を CHARTER に記録する</a>
-        <span class="done__meta">#73 · 35 分前</span>
+        <span class="done__meta">#73 · 39 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/72">fix(ops): PR 一覧がキャッシュのときダッシュボードに明示する</a>
-        <span class="done__meta">#72 · 49 分前</span>
+        <span class="done__meta">#72 · 52 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/71">fix(tailscale): k8s-nameserver の floating tag unstable を固定する</a>
-        <span class="done__meta">#71 · 51 分前</span>
-      </li>
-      <li class="done">
-        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/70">fix(ci): direct-push-guard のレビュー指摘3点を修正</a>
-        <span class="done__meta">#70 · 57 分前</span>
-      </li>
-      <li class="done">
-        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/69">fix(ops): ダッシュボードに起動間隔が出ない退行を直す</a>
-        <span class="done__meta">#69 · 1 時間前</span>
+        <span class="done__meta">#71 · 54 分前</span>
       </li></ul>
   </section>
 
@@ -287,7 +287,7 @@ a { color:var(--sig); }
     <p>使っていて感じたことを殴り書きで構いません。進め方への指摘は憲章に、やってほしいことはタスクとして取り込まれます。
        読んだら 3 行以内で返信します。<strong>返信が無い＝まだ読んでいない</strong>と判断してください。</p>
     <a class="fb__cta" href="https://github.com/hikuohiku/homelab/issues/56">issue #56 に書く</a>
-    <span class="fb__meta">最後に読んだ: 11 分前</span>
+    <span class="fb__meta">最後に読んだ: 15 分前</span>
   </section>
 
   <section>


### PR DESCRIPTION
人間が朝に見る画面で、数字が 2 つ嘘をついていました。

- **「反映済みの変更 20」** は実績ではなく **PR 取得の上限値** でした。autopilot 由来の PR だけを数えるようにし、取得上限に達したときは `60+` のように表示して頭打ちを隠しません
- **「最終起動 -11 分前」** — 記録側が実際より先の時刻を書くと負の相対時刻が出ていました。未来の時刻は「たった今」に丸めます

数字が実態より良く見えるのが一番まずいので、そこを塞ぐ変更です。