### PR TITLE
ops/validate.py: git のコンフリクトマーカー残留を検出する (T-0033)

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 34,
-  "updated": "2026-08-04T21:40:00Z",
+  "updated": "2026-08-04T22:05:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）",
   "tasks": [
     {
@@ -523,13 +523,14 @@
       "title": "ops/validate.py に git の conflict marker (<<<<<<< / ======= / >>>>>>>) の検出を追加する",
       "kind": "ci",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 8,
       "why": "run #7 で origin/main が同時進行中の別 run に進んでいたため rebase で journal のコンフリクトを手で解消したが、末尾の `>>>>>>> ...` マーカー行を消し忘れたまま push・CI green・merge まで通ってしまった（#80）。ops/validate.py も kustomize build も markdown の中身までは見ないため検出できなかった",
       "dod": "ops/ 配下（少なくとも journal/*.md, *.json, *.md 全般）を conflict marker（行頭 `<<<<<<<` / `=======` / `>>>>>>>`）でスキャンし、見つかれば error にする。次に同じミスをしたら CI が落ちること",
       "refs": ["ops/validate.py"],
       "created": "2026-08-04",
-      "pr": null
+      "pr": null,
+      "notes": "run #8: ops/validate.py に check_conflict_markers() を追加（.md / .json を対象、行頭一致）。わざと journal にコンフリクトマーカーを混ぜて 3 件検出 → 復元後 0 error に戻ることを手元で確認してから PR を出した（#56 の教訓『検出器はわざと壊して確かめる』を踏襲）"
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -529,7 +529,7 @@
       "dod": "ops/ 配下（少なくとも journal/*.md, *.json, *.md 全般）を conflict marker（行頭 `<<<<<<<` / `=======` / `>>>>>>>`）でスキャンし、見つかれば error にする。次に同じミスをしたら CI が落ちること",
       "refs": ["ops/validate.py"],
       "created": "2026-08-04",
-      "pr": null,
+      "pr": 84,
       "notes": "run #8: ops/validate.py に check_conflict_markers() を追加（.md / .json を対象、行頭一致）。わざと journal にコンフリクトマーカーを混ぜて 3 件検出 → 復元後 0 error に戻ることを手元で確認してから PR を出した（#56 の教訓『検出器はわざと壊して確かめる』を踏襲）"
     }
   ]

--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -212,15 +212,15 @@ a { color:var(--sig); }
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/78">T-0005: inventory.json 全対象の上流バージョンを調査し、更新タスクを起票する</a>
-        <span class="done__meta">#78 · 33 分前</span>
+        <span class="done__meta">#78 · 34 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/77">T-0017: check_version_sync.py の pyyaml 依存を除去し nix 抽出を構造化する</a>
-        <span class="done__meta">#77 · 45 分前</span>
+        <span class="done__meta">#77 · 46 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/76">ops: run #5 の記録をまとめ、ダッシュボードを再生成する</a>
-        <span class="done__meta">#76 · 52 分前</span>
+        <span class="done__meta">#76 · 53 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/75">fix(apps): busybox の initContainer バージョンを 1.37 に統一する (T-0003)</a>
@@ -228,11 +228,11 @@ a { color:var(--sig); }
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/74">fix(argocd): chart バージョンの二重管理に CI 検出を追加する (T-0002)</a>
-        <span class="done__meta">#74 · 55 分前</span>
+        <span class="done__meta">#74 · 56 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/73">ops: このクラウドサンドボックスのツール有無を CHARTER に記録する</a>
-        <span class="done__meta">#73 · 56 分前</span>
+        <span class="done__meta">#73 · 57 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/72">fix(ops): PR 一覧がキャッシュのときダッシュボードに明示する</a>

--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -187,56 +187,52 @@ a { color:var(--sig); }
     <div class="mast__sub">
       <span>homelab を自律運用するエージェントの記録</span>
       <span>起動間隔 1 時間ごと（毎時 19 分）</span>
-      <span>生成 2026-08-04 20:50 UTC</span>
+      <span>生成 2026-08-04 20:53 UTC</span>
     </div>
   </header>
 
-  <div class="stats"><div class="stat stat--sig"><span class="stat__v">たった今</span><span class="stat__l">最終起動</span></div><div class="stat stat--ok"><span class="stat__v">26</span><span class="stat__l">autopilot が反映した変更</span></div><div class="stat stat--sig"><span class="stat__v">1</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
-  
+  <div class="stats"><div class="stat stat--sig"><span class="stat__v">たった今</span><span class="stat__l">最終起動</span></div><div class="stat stat--idle"><span class="stat__v">0</span><span class="stat__l">autopilot が反映した変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
+  <p class="stale">PR の一覧を取得できませんでした。下の「やったこと」と「いま動かしているもの」は<strong>2 分前のキャッシュ</strong>で、現在の状態と違う可能性があります。<span class="stale__why">([Errno 2] No such file or directory: &#x27;gh&#x27;)</span></p>
 
   <section>
     <h2>やったこと</h2>
     <p class="lede">マージ済み＝homelab に反映済みの変更。新しい順。</p>
     <ul class="list">
       <li class="done">
-        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/82">ops: run #7 の記録をまとめ、ダッシュボードを再生成する</a>
-        <span class="done__meta">#82 · 15 分前</span>
-      </li>
-      <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/81">T-0007: Maintenance.md の持ち越し課題を backlog に取り込む</a>
-        <span class="done__meta">#81 · 17 分前</span>
+        <span class="done__meta">#81 · 20 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/80">T-0006: Plans.md の syncthing 移行(M2) の保留理由を実態に合わせる</a>
-        <span class="done__meta">#80 · 21 分前</span>
+        <span class="done__meta">#80 · たった今</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/79">T-0018: dex chart を 0.24.0 → 0.24.1 に上げる</a>
-        <span class="done__meta">#79 · 28 分前</span>
+        <span class="done__meta">#79 · 31 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/78">T-0005: inventory.json 全対象の上流バージョンを調査し、更新タスクを起票する</a>
-        <span class="done__meta">#78 · 30 分前</span>
+        <span class="done__meta">#78 · 33 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/77">T-0017: check_version_sync.py の pyyaml 依存を除去し nix 抽出を構造化する</a>
-        <span class="done__meta">#77 · 42 分前</span>
+        <span class="done__meta">#77 · 45 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/76">ops: run #5 の記録をまとめ、ダッシュボードを再生成する</a>
-        <span class="done__meta">#76 · 50 分前</span>
+        <span class="done__meta">#76 · 52 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/75">fix(apps): busybox の initContainer バージョンを 1.37 に統一する (T-0003)</a>
-        <span class="done__meta">#75 · 51 分前</span>
+        <span class="done__meta">#75 · 54 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/74">fix(argocd): chart バージョンの二重管理に CI 検出を追加する (T-0002)</a>
-        <span class="done__meta">#74 · 52 分前</span>
+        <span class="done__meta">#74 · 55 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/73">ops: このクラウドサンドボックスのツール有無を CHARTER に記録する</a>
-        <span class="done__meta">#73 · 53 分前</span>
+        <span class="done__meta">#73 · 56 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/72">fix(ops): PR 一覧がキャッシュのときダッシュボードに明示する</a>
@@ -245,6 +241,10 @@ a { color:var(--sig); }
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/71">fix(tailscale): k8s-nameserver の floating tag unstable を固定する</a>
         <span class="done__meta">#71 · 1 時間前</span>
+      </li>
+      <li class="done">
+        <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/70">fix(ci): direct-push-guard のレビュー指摘3点を修正</a>
+        <span class="done__meta">#70 · 1 時間前</span>
       </li></ul>
   </section>
 
@@ -287,20 +287,12 @@ a { color:var(--sig); }
     <p>使っていて感じたことを殴り書きで構いません。進め方への指摘は憲章に、やってほしいことはタスクとして取り込まれます。
        読んだら 3 行以内で返信します。<strong>返信が無い＝まだ読んでいない</strong>と判断してください。</p>
     <a class="fb__cta" href="https://github.com/hikuohiku/homelab/issues/56">issue #56 に書く</a>
-    <span class="fb__meta">最後に読んだ: 30 分前</span>
+    <span class="fb__meta">最後に読んだ: 33 分前</span>
   </section>
 
   <section>
     <h2>いま動かしているもの</h2>
-    <ul class="list">
-      <li class="pr pr--ok">
-        <a class="pr__title" href="https://github.com/hikuohiku/homelab/pull/83">#83 fix(ops): ダッシュボードの数字が嘘をつかないようにする</a>
-        <div class="task__meta">
-          <span class="chip chip--ok">CI green</span>
-          <span class="chip chip--quiet">auto-merge 予約済</span>
-          <span class="pr__age">14 分前</span>
-        </div>
-      </li></ul>
+    <ul class="list"><li class="empty">作業中の PR はありません。</li></ul>
   </section>
 
   <section>
@@ -319,20 +311,6 @@ a { color:var(--sig); }
           <span class="chip chip--quiet">CI</span>
           <span class="chip chip--quiet">リスク 低</span>
           <span class="task__refs"><code>.github/workflows/ci.yml</code></span>
-        </div>
-      </li>
-      <li class="task task--idle">
-        <div class="task__head">
-          <span class="task__id">T-0033</span>
-          <h3 class="task__title">ops/validate.py に git の conflict marker (&lt;&lt;&lt;&lt;&lt;&lt;&lt; / ======= / &gt;&gt;&gt;&gt;&gt;&gt;&gt;) の検出を追加する</h3>
-        </div>
-        <p class="task__why">run #7 で origin/main が同時進行中の別 run に進んでいたため rebase で journal のコンフリクトを手で解消したが、末尾の `&gt;&gt;&gt;&gt;&gt;&gt;&gt; ...` マーカー行を消し忘れたまま push・CI green・merge まで通ってしまった（#80）。ops/validate.py も kustomize build も markdown の中身までは見ないため検出できなかった</p>
-        
-        <div class="task__meta">
-          <span class="chip chip--idle">待ち</span>
-          <span class="chip chip--quiet">CI</span>
-          <span class="chip chip--quiet">リスク 低</span>
-          <span class="task__refs"><code>ops/validate.py</code></span>
         </div>
       </li>
       <li class="task task--idle">
@@ -474,8 +452,22 @@ a { color:var(--sig); }
           <span class="chip chip--quiet">リスク 高</span>
           <span class="task__refs"><code>apps/tailscale-operator/dns-config.yaml</code><code>ops/inventory.json</code></span>
         </div>
+      </li>
+      <li class="task task--idle">
+        <div class="task__head">
+          <span class="task__id">T-0028</span>
+          <h3 class="task__title">argo-cd chart を 9.1.6 → 10.2.3 に上げる（メジャー更新、ArgoCD 自身）</h3>
+        </div>
+        <p class="task__why">T-0005 の調査 (run #6) で判明。9→10 で server.additionalApplications/additionalProjects が別 chart (argocd-apps) に分離、redis-ha の selector-label immutability により手動 Pod 削除が必要になる場合があるなど breaking change を含む。ArgoCD 自身なので壊れると全アプリのデプロイ経路が止まる（ops/inventory.json の policy=manual の理由そのもの）</p>
+        
+        <div class="task__meta">
+          <span class="chip chip--idle">待ち</span>
+          <span class="chip chip--quiet">更新</span>
+          <span class="chip chip--quiet">リスク 高</span>
+          <span class="task__refs"><code>apps/argocd/kustomization.yaml</code><code>nix/images/proxmox-cloud/k3s-manifests.nix</code><code>ops/inventory.json</code></span>
+        </div>
       </li></ul>
-    <p class="more">ほか 8 件</p>
+    <p class="more">ほか 7 件</p>
   </section>
 
   <section>

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -203,3 +203,12 @@
 - 次の起動へ: backlog は T-0008（priority 8, nix flake check CI）または T-0033（conflict marker 検出）
   から順に。手でコンフリクトを解消したときは push 前に `grep -rn '<<<<<<<\|>>>>>>>' <変更ファイル>`
   で確認する（T-0033 が入るまでの暫定対処）
+
+## 2026-08-04 22:05 UTC — run #8
+
+- 前回の中断確認: オープン PR 無し、`autopilot/*` ブランチ無し。中断なし
+- 読んだフィードバック: issue #56 に前回 `last_read` (20:20:15) より新しいコメントなし（20:28:53 は自分の返信）
+- やったこと: T-0033（`ops/validate.py` に conflict marker 検出を追加）を完遂。`check_conflict_markers()` で
+  `ops/` 配下の `.md`/`.json` を行頭一致でスキャン。わざと journal にマーカーを混ぜて 3 件検出 →
+  復元後 0 error に戻ることを手元で確認してから PR を出した（#56 の教訓『検出器はわざと壊して確かめる』を踏襲）
+- 次の起動へ: backlog は T-0008（priority 8, nix flake check CI）から順に

--- a/ops/state.json
+++ b/ops/state.json
@@ -86,6 +86,14 @@
       "by": "cloud routine",
       "summary": "run #6 とこの run が同時に走っていたことに気づき（作業中に origin/main が T-0018 の完了分だけ先行していた）、rebase で追従して journal/backlog/state の衝突を解消。issue #56 の未読フィードバック 2 件を反映し、tailscale-operator chart の確定情報(1.98.9)で T-0024 の blocked_by を解除、T-0025 と組み合わせる前提を追記。T-0006（Plans.md M2 のディスク要因解消の反映）・T-0007（Maintenance.md 持ち越し課題の backlog 取り込み、T-0031/T-0032 起票）を完遂。作業中に見つけた自分のミス（journal に git conflict marker を消し忘れたまま merge していた）を修正し、再発防止の CI 検出を T-0033 として起票",
       "prs": [80, 81]
+    },
+    {
+      "n": 8,
+      "at": "2026-08-04T22:05:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0033（ops/validate.py に conflict marker 検出を追加）を完遂。わざと journal にマーカーを混ぜて検出できることを確認してから PR を出した",
+      "prs": []
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -93,7 +93,7 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0033（ops/validate.py に conflict marker 検出を追加）を完遂。わざと journal にマーカーを混ぜて検出できることを確認してから PR を出した",
-      "prs": []
+      "prs": [84]
     }
   ]
 }

--- a/ops/validate.py
+++ b/ops/validate.py
@@ -134,6 +134,28 @@ def check_inventory(inv) -> None:
             err(f"{where}: file {f} が存在しない")
 
 
+CONFLICT_MARKER_PATTERNS = [
+    re.compile(r"^<{7}(?:\s|$)"),
+    re.compile(r"^={7}$"),
+    re.compile(r"^>{7}(?:\s|$)"),
+]
+
+
+def check_conflict_markers() -> None:
+    # run #7 (#80): journal のコンフリクト解消で `>>>>>>> ...` の消し忘れをそのまま merge してしまった。
+    # kustomize build / terraform validate は markdown/json の中身までは見ないので、ここで拾う。
+    for path in sorted(OPS.rglob("*")):
+        if not path.is_file() or path.suffix not in (".md", ".json"):
+            continue
+        try:
+            text = path.read_text()
+        except UnicodeDecodeError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if any(pat.match(line) for pat in CONFLICT_MARKER_PATTERNS):
+                err(f"{path.relative_to(ROOT)}:{lineno}: git の conflict marker が残っている ({line!r})")
+
+
 def check_state(s) -> None:
     for k in ("updated", "runs", "feedback"):
         if k not in s:
@@ -158,6 +180,8 @@ def main() -> int:
         check_inventory(inventory)
     if state:
         check_state(state)
+
+    check_conflict_markers()
 
     for w in warnings:
         print(f"warning: {w}")


### PR DESCRIPTION
## 変更点

`ops/validate.py` に `check_conflict_markers()` を追加。`ops/` 配下の `.md` / `.json` を行頭一致
（`<<<<<<<` / `=======` / `>>>>>>>`）でスキャンし、見つかれば CI を落とす。

run #7（#80）で journal のコンフリクトを手で解消した際、末尾の `>>>>>>> ...` マーカー行を消し忘れたまま
push・CI green・merge まで通ってしまった。`ops/validate.py` も `kustomize build` も markdown/json の中身
までは見ないため検出できていなかった。

## 検証したこと

- 現状（クリーンな状態）で `python3 ops/validate.py` が 0 error であることを確認
- `ops/journal/2026-08.md` にわざとコンフリクトマーカー（`<<<<<<<` / `=======` / `>>>>>>>`）を混ぜて
  3 件検出されることを確認（誤って通ってしまわないことの確認。#56 で受けた「検出器はわざと壊して
  確かめる」というフィードバックに沿った）
- 元に戻して再度 0 error に戻ることを確認

## ロールバック手順

`ops/validate.py` の `check_conflict_markers()` の呼び出しと関数定義を revert すれば元に戻る。
検証専用ロジックの追加のみで、既存の検証項目やスキーマには影響しない。

## backlog task id

T-0033

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThURoNQbyntEtVj2DKnRjC)_