### PR TITLE
CI に nix flake check を追加する (T-0008)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,19 @@ jobs:
         run: python3 ops/validate.py
       - name: check duplicated version pins are in sync
         run: python3 ops/check_version_sync.py
+
+  nix:
+    name: nix flake check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      # ビルド（qcow2 イメージの実体化）は重いので評価のみ。--no-build は今のところ no-op
+      # （このフレークに checks 出力が無いため）だが、将来 checks が足された事故を防ぐ保険として付ける。
+      - name: flake check (evaluation only)
+        working-directory: nix/images/proxmox-cloud
+        run: nix flake check --no-build --print-build-logs

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -141,7 +141,7 @@
         ".github/workflows/ci.yml"
       ],
       "created": "2026-08-04",
-      "pr": null,
+      "pr": 85,
       "notes": "run #8: subagent に調査を投げた。`nix flake check` は `checks.*` 以外に `nixosConfigurations.<name>.config.system.build.toplevel` / `packages.<system>.<name>` も評価対象に含む仕様（ビルドされるのは checks.* のみ）と Nix 公式マニュアル(2.19.1〜2.30.2)で確認済みのため、追加のコマンドなしで nix/images/proxmox-cloud のフレークを評価できる。`cachix/install-nix-action@v31` を使用（`DeterminateSystems/nix-installer-action` は既定で Determinate Nix + FlakeHub 連携に寄っているため見送り）。手元に nix が無いため実行検証はできず、CI 任せ（CHARTER §5.2）。ruleset の required checks には未追加（3 つ固定のまま）。必要なら別タスクで検討"
     },
     {

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 34,
-  "updated": "2026-08-04T22:05:00Z",
+  "updated": "2026-08-04T22:20:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）",
   "tasks": [
     {
@@ -133,7 +133,7 @@
       "title": "nix flake check を CI に追加する",
       "kind": "ci",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 8,
       "why": "初期 CI は kustomize / terraform / ops のみ。nix 側の変更が機械検証されていない",
       "dod": "nix/ 配下の変更で CI が nix の評価エラーを検出できる。ビルドは重いので評価のみでよい。Cachix を使うなら secrets の扱いに注意",
@@ -141,7 +141,8 @@
         ".github/workflows/ci.yml"
       ],
       "created": "2026-08-04",
-      "pr": null
+      "pr": null,
+      "notes": "run #8: subagent に調査を投げた。`nix flake check` は `checks.*` 以外に `nixosConfigurations.<name>.config.system.build.toplevel` / `packages.<system>.<name>` も評価対象に含む仕様（ビルドされるのは checks.* のみ）と Nix 公式マニュアル(2.19.1〜2.30.2)で確認済みのため、追加のコマンドなしで nix/images/proxmox-cloud のフレークを評価できる。`cachix/install-nix-action@v31` を使用（`DeterminateSystems/nix-installer-action` は既定で Determinate Nix + FlakeHub 連携に寄っているため見送り）。手元に nix が無いため実行検証はできず、CI 任せ（CHARTER §5.2）。ruleset の required checks には未追加（3 つ固定のまま）。必要なら別タスクで検討"
     },
     {
       "id": "T-0009",

--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -200,7 +200,7 @@ a { color:var(--sig); }
     <ul class="list">
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/81">T-0007: Maintenance.md の持ち越し課題を backlog に取り込む</a>
-        <span class="done__meta">#81 · 30 分前</span>
+        <span class="done__meta">#81 · 31 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/80">T-0006: Plans.md の syncthing 移行(M2) の保留理由を実態に合わせる</a>
@@ -208,15 +208,15 @@ a { color:var(--sig); }
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/79">T-0018: dex chart を 0.24.0 → 0.24.1 に上げる</a>
-        <span class="done__meta">#79 · 41 分前</span>
+        <span class="done__meta">#79 · 42 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/78">T-0005: inventory.json 全対象の上流バージョンを調査し、更新タスクを起票する</a>
-        <span class="done__meta">#78 · 44 分前</span>
+        <span class="done__meta">#78 · 45 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/77">T-0017: check_version_sync.py の pyyaml 依存を除去し nix 抽出を構造化する</a>
-        <span class="done__meta">#77 · 56 分前</span>
+        <span class="done__meta">#77 · 57 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/76">ops: run #5 の記録をまとめ、ダッシュボードを再生成する</a>
@@ -287,7 +287,7 @@ a { color:var(--sig); }
     <p>使っていて感じたことを殴り書きで構いません。進め方への指摘は憲章に、やってほしいことはタスクとして取り込まれます。
        読んだら 3 行以内で返信します。<strong>返信が無い＝まだ読んでいない</strong>と判断してください。</p>
     <a class="fb__cta" href="https://github.com/hikuohiku/homelab/issues/56">issue #56 に書く</a>
-    <span class="fb__meta">最後に読んだ: 43 分前</span>
+    <span class="fb__meta">最後に読んだ: 44 分前</span>
   </section>
 
   <section>

--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -187,12 +187,12 @@ a { color:var(--sig); }
     <div class="mast__sub">
       <span>homelab を自律運用するエージェントの記録</span>
       <span>起動間隔 1 時間ごと（毎時 19 分）</span>
-      <span>生成 2026-08-04 20:53 UTC</span>
+      <span>生成 2026-08-04 21:04 UTC</span>
     </div>
   </header>
 
   <div class="stats"><div class="stat stat--sig"><span class="stat__v">たった今</span><span class="stat__l">最終起動</span></div><div class="stat stat--idle"><span class="stat__v">0</span><span class="stat__l">autopilot が反映した変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
-  <p class="stale">PR の一覧を取得できませんでした。下の「やったこと」と「いま動かしているもの」は<strong>2 分前のキャッシュ</strong>で、現在の状態と違う可能性があります。<span class="stale__why">([Errno 2] No such file or directory: &#x27;gh&#x27;)</span></p>
+  <p class="stale">PR の一覧を取得できませんでした。下の「やったこと」と「いま動かしているもの」は<strong>9 分前のキャッシュ</strong>で、現在の状態と違う可能性があります。<span class="stale__why">([Errno 2] No such file or directory: &#x27;gh&#x27;)</span></p>
 
   <section>
     <h2>やったこと</h2>
@@ -200,7 +200,7 @@ a { color:var(--sig); }
     <ul class="list">
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/81">T-0007: Maintenance.md の持ち越し課題を backlog に取り込む</a>
-        <span class="done__meta">#81 · 20 分前</span>
+        <span class="done__meta">#81 · 30 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/80">T-0006: Plans.md の syncthing 移行(M2) の保留理由を実態に合わせる</a>
@@ -208,31 +208,31 @@ a { color:var(--sig); }
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/79">T-0018: dex chart を 0.24.0 → 0.24.1 に上げる</a>
-        <span class="done__meta">#79 · 31 分前</span>
+        <span class="done__meta">#79 · 41 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/78">T-0005: inventory.json 全対象の上流バージョンを調査し、更新タスクを起票する</a>
-        <span class="done__meta">#78 · 34 分前</span>
+        <span class="done__meta">#78 · 44 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/77">T-0017: check_version_sync.py の pyyaml 依存を除去し nix 抽出を構造化する</a>
-        <span class="done__meta">#77 · 46 分前</span>
+        <span class="done__meta">#77 · 56 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/76">ops: run #5 の記録をまとめ、ダッシュボードを再生成する</a>
-        <span class="done__meta">#76 · 53 分前</span>
+        <span class="done__meta">#76 · 1 時間前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/75">fix(apps): busybox の initContainer バージョンを 1.37 に統一する (T-0003)</a>
-        <span class="done__meta">#75 · 54 分前</span>
+        <span class="done__meta">#75 · 1 時間前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/74">fix(argocd): chart バージョンの二重管理に CI 検出を追加する (T-0002)</a>
-        <span class="done__meta">#74 · 56 分前</span>
+        <span class="done__meta">#74 · 1 時間前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/73">ops: このクラウドサンドボックスのツール有無を CHARTER に記録する</a>
-        <span class="done__meta">#73 · 57 分前</span>
+        <span class="done__meta">#73 · 1 時間前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/72">fix(ops): PR 一覧がキャッシュのときダッシュボードに明示する</a>
@@ -287,7 +287,7 @@ a { color:var(--sig); }
     <p>使っていて感じたことを殴り書きで構いません。進め方への指摘は憲章に、やってほしいことはタスクとして取り込まれます。
        読んだら 3 行以内で返信します。<strong>返信が無い＝まだ読んでいない</strong>と判断してください。</p>
     <a class="fb__cta" href="https://github.com/hikuohiku/homelab/issues/56">issue #56 に書く</a>
-    <span class="fb__meta">最後に読んだ: 33 分前</span>
+    <span class="fb__meta">最後に読んだ: 43 分前</span>
   </section>
 
   <section>
@@ -299,20 +299,6 @@ a { color:var(--sig); }
     <h2>これからやること</h2>
     <p class="lede">上から順に着手します。1 タスク = 1 PR。</p>
     <ul class="list">
-      <li class="task task--idle">
-        <div class="task__head">
-          <span class="task__id">T-0008</span>
-          <h3 class="task__title">nix flake check を CI に追加する</h3>
-        </div>
-        <p class="task__why">初期 CI は kustomize / terraform / ops のみ。nix 側の変更が機械検証されていない</p>
-        
-        <div class="task__meta">
-          <span class="chip chip--idle">待ち</span>
-          <span class="chip chip--quiet">CI</span>
-          <span class="chip chip--quiet">リスク 低</span>
-          <span class="task__refs"><code>.github/workflows/ci.yml</code></span>
-        </div>
-      </li>
       <li class="task task--idle">
         <div class="task__head">
           <span class="task__id">T-0009</span>
@@ -466,8 +452,22 @@ a { color:var(--sig); }
           <span class="chip chip--quiet">リスク 高</span>
           <span class="task__refs"><code>apps/argocd/kustomization.yaml</code><code>nix/images/proxmox-cloud/k3s-manifests.nix</code><code>ops/inventory.json</code></span>
         </div>
+      </li>
+      <li class="task task--idle">
+        <div class="task__head">
+          <span class="task__id">T-0012</span>
+          <h3 class="task__title">この autopilot 自身の運用を journal から振り返り、CHARTER を改訂する</h3>
+        </div>
+        <p class="task__why">定期的に自分の運用を点検しないと、無駄な手順や抜けた観点が固定化する</p>
+        
+        <div class="task__meta">
+          <span class="chip chip--idle">待ち</span>
+          <span class="chip chip--quiet">自己点検</span>
+          <span class="chip chip--quiet">リスク 低</span>
+          <span class="task__refs"><code>ops/CHARTER.md</code><code>ops/journal/</code></span>
+        </div>
       </li></ul>
-    <p class="more">ほか 7 件</p>
+    <p class="more">ほか 6 件</p>
   </section>
 
   <section>

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -211,4 +211,11 @@
 - やったこと: T-0033（`ops/validate.py` に conflict marker 検出を追加）を完遂。`check_conflict_markers()` で
   `ops/` 配下の `.md`/`.json` を行頭一致でスキャン。わざと journal にマーカーを混ぜて 3 件検出 →
   復元後 0 error に戻ることを手元で確認してから PR を出した（#56 の教訓『検出器はわざと壊して確かめる』を踏襲）
-- 次の起動へ: backlog は T-0008（priority 8, nix flake check CI）から順に
+  (#84, merged)
+- #84 merge を確認後、続けて T-0008（nix flake check を CI に追加）に着手。手元に nix が無く検証できないため
+  （CHARTER §5.2）、subagent に `nix flake check` の評価範囲・`--no-build` の挙動・IFD ガチャの有無・
+  インストール Action の選定を調査させた。結論: `nix flake check` は `checks.*` を明示していなくても
+  `nixosConfigurations.<name>.config.system.build.toplevel` / `packages.<system>.<name>` を評価対象に含む
+  （ビルドされるのは `checks.*` のみ）とマニュアルで確認済み。`cachix/install-nix-action@v31` で導入し、
+  `.github/workflows/ci.yml` に `nix` job を追加した
+- 次の起動へ: backlog は T-0009（priority 9, weekly-maintenance コマンドの役割分担）から順に

--- a/ops/state.json
+++ b/ops/state.json
@@ -92,7 +92,7 @@
       "at": "2026-08-04T22:05:00Z",
       "kind": "scheduled",
       "by": "cloud routine",
-      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0033（ops/validate.py に conflict marker 検出を追加）を完遂。わざと journal にマーカーを混ぜて検出できることを確認してから PR を出した",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0033（ops/validate.py に conflict marker 検出を追加、#84 merged）を完遂。続けて T-0008（nix flake check を CI に追加）に着手。subagent の調査で nix flake check が nixosConfigurations も評価対象に含むことを確認し、cachix/install-nix-action@v31 で CI job を追加",
       "prs": [84]
     }
   ]

--- a/ops/state.json
+++ b/ops/state.json
@@ -93,7 +93,7 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0033（ops/validate.py に conflict marker 検出を追加、#84 merged）を完遂。続けて T-0008（nix flake check を CI に追加）に着手。subagent の調査で nix flake check が nixosConfigurations も評価対象に含むことを確認し、cachix/install-nix-action@v31 で CI job を追加",
-      "prs": [84]
+      "prs": [84, 85]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`.github/workflows/ci.yml` に `nix flake check`（評価のみ、ビルドなし）を実行する `nix` job を追加。
`nix/images/proxmox-cloud` のフレーク（`nixosConfigurations.proxmox-cloud` / `packages.qcow2`）の変更が
機械検証されていなかった（kustomize / terraform / ops のみだった）。

## 検証したこと

手元に `nix` が無いため（`ops/CHARTER.md` §5.2）実行検証はできず、CI に任せている。事前に subagent へ
仕様面の調査を依頼し、以下を Nix 公式マニュアル（2.19.1〜2.30.2 で同一の記述）で確認した:

- `nix flake check` は `checks.<system>.<name>` を明示しなくても、`nixosConfigurations.<name>.config.system.build.toplevel`
  や `packages.<system>.<name>` を評価対象に含む（**ビルドされるのは `checks.*` のみ**、他は評価が通ることの確認のみ）。
  このフレークには `checks` 出力が無いため、追加のコマンドなしで `nixosConfigurations.proxmox-cloud` と
  `packages.qcow2` の評価が通る
- `--no-build` は現状 no-op（`checks` が無いため）だが、将来 `checks` が足されて重いビルドが CI に紛れ込む事故を防ぐ保険として付けた
- `configuration.nix` を目視確認し、IFD（import-from-derivation）などの評価コストが跳ね上がる要因は見当たらなかった
- インストール Action は `cachix/install-nix-action@v31`（既定で upstream Nix、flakes 有効）を採用。
  `DeterminateSystems/nix-installer-action` は既定で Determinate Nix + FlakeHub 連携に寄っているため見送った

## ロールバック手順

`.github/workflows/ci.yml` の `nix` job を削除すれば元に戻る。既存の 3 job（kustomize build / terraform validate /
ops state validate）には影響しない。main の ruleset の required checks は変更していない（この job は現状 required
ではなく、CI 上の追加シグナルという位置付け）。

## backlog task id

T-0008

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThURoNQbyntEtVj2DKnRjC)_