### PR TITLE
weekly-maintenance と CHARTER の役割を分ける (T-0009)

### DIFF
--- a/.claude/commands/weekly-maintenance.md
+++ b/.claude/commands/weekly-maintenance.md
@@ -1,19 +1,34 @@
-homelab の週次メンテナンス。vaultwarden のバージョン据え置きと異常を検知し、更新 PR を作る。
+homelab の週次メンテナンス。vaultwarden の実機健全性を確認し、必要なら更新 PR を作る。
 
 pin したバージョンは誰も上げなければ据え置かれる。2026-08-03、vaultwarden 1.36.0 の
 放置でクライアント同期が全停止した（#49）。その再発防止。
 
+## この手順と ops/CHARTER.md の関係
+
+バージョン監視は `ops/inventory.json` の全対象（vaultwarden を含む）を autopilot が
+クラウドの定期実行で担っている（`ops/CHARTER.md` §3）。バージョン更新時の判断基準
+（上流最新＝最善ではない、リリースノートは原文を読む、1 PR 1 コンポーネント等）も
+`ops/CHARTER.md` §4「バージョン更新の作法」が一次情報源。ここには重複して書かない。
+
+この手順に固有の価値は、**実機（ArgoCD / kubectl / ノード）に到達できる人間の対話
+セッションでしかできない健全性確認**。autopilot はクラウドサンドボックスから
+homelab に到達できないため（`ops/CHARTER.md` §5.2）、この確認は autopilot では代替できない。
+
 ## 対象
 
-vaultwarden のみ。手順が固まる前に広げない。
+vaultwarden のみ。理由は「対象を広げる」計画ではなく、**実機確認が必要な対象がまだ
+vaultwarden しかない**こと（#49 の再発対象）。他の対象のバージョン監視はすでに
+autopilot が担っているので、ここで扱う対象を機械的に増やす必要はない。実機確認が
+要る別の懸念が出たら、そのときに対象を検討する。
 
 ## 手順
 
 0. `Maintenance.md` の前回エントリを読む（持ち越しと申し送り）
 1. `just preflight` で疎通確認。到達できない層はレポートに明記してスキップする
 2. バージョン点検。現在値は `apps/vaultwarden/deployment.yaml` から読む。上流は
-   `mcp__github__list_releases`。差があれば間の全リリースノートを読み、セキュリティ
-   修正・breaking change・クライアント互換要件を抽出する
+   `mcp__github__list_releases`。autopilot がすでに調査済みなら `ops/backlog.json` /
+   `ops/journal/` を先に確認し、二重調査を避ける。差があれば間の全リリースノートを
+   読む（判断基準は `ops/CHARTER.md` §4）
 3. 健全性点検。ArgoCD の Sync/Health、Pod、起動ログ、ノードのディスク空き
    （20GB しかない。3GB 未満なら警告をレポート先頭に）
 4. レポート。異常なしならそう書いて終わる。無理に作業を作らない
@@ -33,12 +48,10 @@ vaultwarden のみ。手順が固まる前に広げない。
 2. 意味がなかった項目はあるか → 削る。長い手順は実行されなくなる
 3. 見逃し・誤検知はあったか → 閾値を調整する
 
-「変更なし」が 3 回続いたら対象を 1 つ増やす。候補は immich / dex /
-external-secrets / tailscale-operator / argocd。argocd は self-management なので最後。
-
 ## 落とし穴
 
-- 上流の最新を鵜呑みにしない。1.37.0 は alpine のビルドが壊れており 1.37.1 が必要だった
-- リリースノートは要約させず原文を読む
+実機確認（ArgoCD / kubectl / ノード）に固有のもののみ。バージョン更新一般の落とし穴は
+`ops/CHARTER.md` §4 を参照。
+
 - `local-path` は容量を強制しない。PVC の requests は実容量ではない
 - 脆弱性の多くは組織機能。単一ユーザーでは該当しないが、確認した記録は残す

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -159,7 +159,7 @@
         "ops/CHARTER.md"
       ],
       "created": "2026-08-04",
-      "pr": null,
+      "pr": 86,
       "notes": "run #8: 役割を分けた（統合ではなく分離）。バージョン監視・更新判断の一次情報源は ops/CHARTER.md §3/§4（autopilot が inventory.json の全対象を担当）。weekly-maintenance.md 固有の価値は実機（ArgoCD/kubectl/ノード）に到達できる人間の対話セッションでしかできない健全性確認に絞り、重複していた『落とし穴』の版更新一般の項目・対象拡大計画（3 回変更なしで対象を増やす）を削除して CHARTER 参照に置き換えた"
     },
     {

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 34,
-  "updated": "2026-08-04T22:20:00Z",
+  "updated": "2026-08-04T22:35:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）",
   "tasks": [
     {
@@ -150,7 +150,7 @@
       "title": "/weekly-maintenance コマンドを CHARTER に統合するか、役割を分ける",
       "kind": "refactor",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 9,
       "why": "vaultwarden の更新手順が .claude/commands/weekly-maintenance.md と ops/CHARTER.md の両方に書かれつつある。二重管理の芽",
       "dod": "どちらが情報源かが明確になっている。weekly-maintenance に残す価値がある部分（人間が手で回すときの手順）だけが残る",
@@ -159,7 +159,8 @@
         "ops/CHARTER.md"
       ],
       "created": "2026-08-04",
-      "pr": null
+      "pr": null,
+      "notes": "run #8: 役割を分けた（統合ではなく分離）。バージョン監視・更新判断の一次情報源は ops/CHARTER.md §3/§4（autopilot が inventory.json の全対象を担当）。weekly-maintenance.md 固有の価値は実機（ArgoCD/kubectl/ノード）に到達できる人間の対話セッションでしかできない健全性確認に絞り、重複していた『落とし穴』の版更新一般の項目・対象拡大計画（3 回変更なしで対象を増やす）を削除して CHARTER 参照に置き換えた"
     },
     {
       "id": "T-0010",

--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -187,12 +187,12 @@ a { color:var(--sig); }
     <div class="mast__sub">
       <span>homelab を自律運用するエージェントの記録</span>
       <span>起動間隔 1 時間ごと（毎時 19 分）</span>
-      <span>生成 2026-08-04 21:07 UTC</span>
+      <span>生成 2026-08-04 21:08 UTC</span>
     </div>
   </header>
 
   <div class="stats"><div class="stat stat--sig"><span class="stat__v">たった今</span><span class="stat__l">最終起動</span></div><div class="stat stat--idle"><span class="stat__v">0</span><span class="stat__l">autopilot が反映した変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
-  <p class="stale">PR の一覧を取得できませんでした。下の「やったこと」と「いま動かしているもの」は<strong>12 分前のキャッシュ</strong>で、現在の状態と違う可能性があります。<span class="stale__why">([Errno 2] No such file or directory: &#x27;gh&#x27;)</span></p>
+  <p class="stale">PR の一覧を取得できませんでした。下の「やったこと」と「いま動かしているもの」は<strong>13 分前のキャッシュ</strong>で、現在の状態と違う可能性があります。<span class="stale__why">([Errno 2] No such file or directory: &#x27;gh&#x27;)</span></p>
 
   <section>
     <h2>やったこと</h2>
@@ -208,7 +208,7 @@ a { color:var(--sig); }
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/79">T-0018: dex chart を 0.24.0 → 0.24.1 に上げる</a>
-        <span class="done__meta">#79 · 45 分前</span>
+        <span class="done__meta">#79 · 46 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/78">T-0005: inventory.json 全対象の上流バージョンを調査し、更新タスクを起票する</a>

--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -187,12 +187,12 @@ a { color:var(--sig); }
     <div class="mast__sub">
       <span>homelab を自律運用するエージェントの記録</span>
       <span>起動間隔 1 時間ごと（毎時 19 分）</span>
-      <span>生成 2026-08-04 21:04 UTC</span>
+      <span>生成 2026-08-04 21:07 UTC</span>
     </div>
   </header>
 
   <div class="stats"><div class="stat stat--sig"><span class="stat__v">たった今</span><span class="stat__l">最終起動</span></div><div class="stat stat--idle"><span class="stat__v">0</span><span class="stat__l">autopilot が反映した変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
-  <p class="stale">PR の一覧を取得できませんでした。下の「やったこと」と「いま動かしているもの」は<strong>9 分前のキャッシュ</strong>で、現在の状態と違う可能性があります。<span class="stale__why">([Errno 2] No such file or directory: &#x27;gh&#x27;)</span></p>
+  <p class="stale">PR の一覧を取得できませんでした。下の「やったこと」と「いま動かしているもの」は<strong>12 分前のキャッシュ</strong>で、現在の状態と違う可能性があります。<span class="stale__why">([Errno 2] No such file or directory: &#x27;gh&#x27;)</span></p>
 
   <section>
     <h2>やったこと</h2>
@@ -200,7 +200,7 @@ a { color:var(--sig); }
     <ul class="list">
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/81">T-0007: Maintenance.md の持ち越し課題を backlog に取り込む</a>
-        <span class="done__meta">#81 · 31 分前</span>
+        <span class="done__meta">#81 · 34 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/80">T-0006: Plans.md の syncthing 移行(M2) の保留理由を実態に合わせる</a>
@@ -208,15 +208,15 @@ a { color:var(--sig); }
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/79">T-0018: dex chart を 0.24.0 → 0.24.1 に上げる</a>
-        <span class="done__meta">#79 · 42 分前</span>
+        <span class="done__meta">#79 · 45 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/78">T-0005: inventory.json 全対象の上流バージョンを調査し、更新タスクを起票する</a>
-        <span class="done__meta">#78 · 45 分前</span>
+        <span class="done__meta">#78 · 48 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/77">T-0017: check_version_sync.py の pyyaml 依存を除去し nix 抽出を構造化する</a>
-        <span class="done__meta">#77 · 57 分前</span>
+        <span class="done__meta">#77 · 1 時間前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/76">ops: run #5 の記録をまとめ、ダッシュボードを再生成する</a>
@@ -287,7 +287,7 @@ a { color:var(--sig); }
     <p>使っていて感じたことを殴り書きで構いません。進め方への指摘は憲章に、やってほしいことはタスクとして取り込まれます。
        読んだら 3 行以内で返信します。<strong>返信が無い＝まだ読んでいない</strong>と判断してください。</p>
     <a class="fb__cta" href="https://github.com/hikuohiku/homelab/issues/56">issue #56 に書く</a>
-    <span class="fb__meta">最後に読んだ: 44 分前</span>
+    <span class="fb__meta">最後に読んだ: 47 分前</span>
   </section>
 
   <section>
@@ -299,20 +299,6 @@ a { color:var(--sig); }
     <h2>これからやること</h2>
     <p class="lede">上から順に着手します。1 タスク = 1 PR。</p>
     <ul class="list">
-      <li class="task task--idle">
-        <div class="task__head">
-          <span class="task__id">T-0009</span>
-          <h3 class="task__title">/weekly-maintenance コマンドを CHARTER に統合するか、役割を分ける</h3>
-        </div>
-        <p class="task__why">vaultwarden の更新手順が .claude/commands/weekly-maintenance.md と ops/CHARTER.md の両方に書かれつつある。二重管理の芽</p>
-        
-        <div class="task__meta">
-          <span class="chip chip--idle">待ち</span>
-          <span class="chip chip--quiet">整理</span>
-          <span class="chip chip--quiet">リスク 低</span>
-          <span class="task__refs"><code>.claude/commands/weekly-maintenance.md</code><code>ops/CHARTER.md</code></span>
-        </div>
-      </li>
       <li class="task task--idle">
         <div class="task__head">
           <span class="task__id">T-0013</span>
@@ -466,8 +452,22 @@ a { color:var(--sig); }
           <span class="chip chip--quiet">リスク 低</span>
           <span class="task__refs"><code>ops/CHARTER.md</code><code>ops/journal/</code></span>
         </div>
+      </li>
+      <li class="task task--idle">
+        <div class="task__head">
+          <span class="task__id">T-0026</span>
+          <h3 class="task__title">external-secrets chart を 1.1.1 → 2.8.0 に上げる（メジャー更新、全リリースノートを読む）</h3>
+        </div>
+        <p class="task__why">T-0005 の調査 (run #6) で判明。1.1.1 → 2.8.0 は大きなメジャー更新の飛び。External Secrets Operator は secrets/ の実体を supply する基盤なので、壊れると全アプリのシークレット取得が止まりうる</p>
+        
+        <div class="task__meta">
+          <span class="chip chip--idle">待ち</span>
+          <span class="chip chip--quiet">更新</span>
+          <span class="chip chip--quiet">リスク 高</span>
+          <span class="task__refs"><code>apps/external-secrets/kustomization.yaml</code><code>ops/inventory.json</code></span>
+        </div>
       </li></ul>
-    <p class="more">ほか 6 件</p>
+    <p class="more">ほか 5 件</p>
   </section>
 
   <section>

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -217,5 +217,10 @@
   インストール Action の選定を調査させた。結論: `nix flake check` は `checks.*` を明示していなくても
   `nixosConfigurations.<name>.config.system.build.toplevel` / `packages.<system>.<name>` を評価対象に含む
   （ビルドされるのは `checks.*` のみ）とマニュアルで確認済み。`cachix/install-nix-action@v31` で導入し、
-  `.github/workflows/ci.yml` に `nix` job を追加した
-- 次の起動へ: backlog は T-0009（priority 9, weekly-maintenance コマンドの役割分担）から順に
+  `.github/workflows/ci.yml` に `nix` job を追加した (#85, merged)
+- #85 merge を確認後、続けて T-0009（weekly-maintenance と CHARTER の役割分担）に着手・完遂。統合ではなく
+  分離を選択: バージョン監視・更新判断の一次情報源は CHARTER §3/§4（autopilot が inventory.json 全対象を
+  担当）とし、`.claude/commands/weekly-maintenance.md` は実機（ArgoCD/kubectl/ノード）に到達できる人間の
+  対話セッションでしかできない健全性確認に絞った。重複していた『落とし穴』の版更新一般項目と、対象拡大計画
+  （3 回変更なしで対象を増やす — autopilot が既に全対象を見ているため不要になっていた）を削除
+- 次の起動へ: backlog は T-0013（priority 12, pbs バックアップ体制の調査）から順に

--- a/ops/state.json
+++ b/ops/state.json
@@ -92,7 +92,7 @@
       "at": "2026-08-04T22:05:00Z",
       "kind": "scheduled",
       "by": "cloud routine",
-      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0033（ops/validate.py に conflict marker 検出を追加、#84 merged）を完遂。続けて T-0008（nix flake check を CI に追加）に着手。subagent の調査で nix flake check が nixosConfigurations も評価対象に含むことを確認し、cachix/install-nix-action@v31 で CI job を追加",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0033（conflict marker 検出、#84 merged）・T-0008（nix flake check を CI に追加、#85 merged）を完遂。続けて T-0009（weekly-maintenance と CHARTER の役割分担）に着手。統合ではなく分離を選択し、バージョン監視・更新判断の一次情報源を CHARTER に一本化、weekly-maintenance は実機健全性確認に絞った",
       "prs": [84, 85]
     }
   ]

--- a/ops/state.json
+++ b/ops/state.json
@@ -93,7 +93,7 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0033（conflict marker 検出、#84 merged）・T-0008（nix flake check を CI に追加、#85 merged）を完遂。続けて T-0009（weekly-maintenance と CHARTER の役割分担）に着手。統合ではなく分離を選択し、バージョン監視・更新判断の一次情報源を CHARTER に一本化、weekly-maintenance は実機健全性確認に絞った",
-      "prs": [84, 85]
+      "prs": [84, 85, 86]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`.claude/commands/weekly-maintenance.md` と `ops/CHARTER.md` に vaultwarden の更新手順が二重に
書かれつつあった（T-0005 の完遂で autopilot が inventory.json の全 15 対象を扱うようになり、二重化が
進みやすい状態だった）。統合ではなく役割分離で解消:

- バージョン監視・更新判断の一次情報源は `ops/CHARTER.md` §3/§4 に一本化（autopilot が
  `ops/inventory.json` の全対象を担当している）
- `.claude/commands/weekly-maintenance.md` は、**実機（ArgoCD / kubectl / ノード）に到達できる
  人間の対話セッションでしかできない健全性確認**に役割を絞った
- 重複していた「落とし穴」の版更新一般項目（上流最新を鵜呑みにしない、リリースノートは原文を読む）を削除し、
  CHARTER §4 を参照する形にした
- 「変更なしが 3 回続いたら対象を 1 つ増やす」という対象拡大計画を削除した。autopilot が既に
  inventory.json の全対象を見ているため、この計画は目的を失っていた

## 検証したこと

ドキュメントのみの変更（コード・manifest への影響なし）。CI（kustomize build / terraform validate /
ops state validate / nix flake check）はいずれも対象外の変更で、green になることを確認する

## ロールバック手順

`.claude/commands/weekly-maintenance.md` を revert すれば元に戻る。実インフラへの変更は無い

## backlog task id

T-0009

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThURoNQbyntEtVj2DKnRjC)_