### PR TITLE
PBS バックアップ体制を棚卸しする (T-0013)

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,0 +1,42 @@
+# バックアップ体制の棚卸し (2026-08-04)
+
+`ops/backlog.json` T-0013 の調査記録。**設定変更は行っていない。** リポジトリ内の記録を
+横断的に確認しただけで、実機（Proxmox / PBS）には autopilot のクラウドサンドボックスから
+到達できない（`ops/CHARTER.md` §5.2）ため、この調査だけでは分からないことが多く残る。
+
+## わかっていること（repo から）
+
+- PBS (Proxmox Backup Server) VM が `qemu/112` として稼働中。手動管理
+  （Terraform 管理対象外、`terraform/proxmox/pbs.tf.ignore` に構成を記録）
+- pbs VM 自体のスペック: 4 vCPU / 8GB RAM / 64GB ディスク（SeaBIOS）
+- `terraform/proxmox` は node01 (`qemu/113`) のみ管理。pbs 自身は Proxmox 側で手動運用
+- k3s の永続化は `local-path` provisioner（node01 のローカルディスクを直接使用、PVC の
+  `requests` は実容量を予約しない。`CLAUDE.md` / `docs/node01-storage.md` 参照）。
+  つまり immich / vaultwarden / coder 等のアプリデータは node01 のディスク上に直接存在する。
+  PBS がこれらを保護しているとすれば「VM 単位（node01 のディスクイメージ全体）」の
+  バックアップのはずで、PBS の対象に node01 が含まれていなければアプリデータは
+  一切バックアップされていないことになる
+- リポジトリ内に Kubernetes レベルのバックアップ機構（Velero 等）は導入されていない
+  （`apps/` 配下に該当マニフェストが無い）
+- `Maintenance.md` / `CLAUDE.md` に、バックアップジョブのスケジュール・保持世代数・
+  直近の成功/失敗・リストア検証の記録が無い
+
+## わからないこと（実機アクセスが要る）
+
+1. PBS に node01 (`qemu/113`) を対象にしたバックアップジョブが実際に設定されているか
+2. 設定されている場合、スケジュールと保持世代数
+3. 直近のバックアップジョブが成功しているか（失敗が放置されていないか）
+4. リストアを実際に試したことがあるか（手順が機能する保証があるか）
+5. pbs 自身（PBS VM そのもの）はバックアップ対象外のままで問題ないか。pbs を失うと
+   node01 のバックアップも一緒に失う片系構成になっていないか
+
+これらは `mcp__proxmox__*`（読み取り専用トークン）や PBS の Web UI が使える、Tailscale
+経由で homelab に到達できる環境でしか確認できない。autopilot のクラウドサンドボックスは
+Tailscale に接続できないため、物理的に手が届かない（`ops/CHARTER.md` §5.2）。
+確認は `ops/backlog.json` T-0034（needs-human）で人間にお願いしている。
+
+## これに依存しているタスク
+
+- T-0029（immich postgres/vchord のメジャー更新、データを失いうる変更）は
+  CHARTER §4「データを失いうる変更」の手順どおり、バックアップの存在と復元手順が
+  確かめられるまで着手しない。T-0034 の確認が終わってから再検討する

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -231,7 +231,7 @@
         "CLAUDE.md"
       ],
       "created": "2026-08-04",
-      "pr": null,
+      "pr": 87,
       "notes": "run #8: repo 内の記録（pbs.tf.ignore, CLAUDE.md, local-path の性質）を横断して docs/backup.md に棚卸しをまとめた。実機（PBS のジョブ設定・実行結果・リストア可否）は autopilot のクラウドサンドボックスから到達できないため確認できず、T-0034（needs-human）として切り出した。T-0029 の blocked_by を T-0013 から T-0034 に更新した"
     },
     {

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 34,
-  "updated": "2026-08-04T22:35:00Z",
+  "next_id": 35,
+  "updated": "2026-08-04T22:50:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）",
   "tasks": [
     {
@@ -222,7 +222,7 @@
       "title": "homelab に無い観点を探す — バックアップの健全性",
       "kind": "investigate",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 12,
       "why": "pbs (Proxmox Backup Server) は Terraform 管理外の手動運用。バックアップが実際に取れているか、復元できるかを誰も定期確認していない",
       "dod": "現状のバックアップ体制を調べて文書化し、確認が必要な点を個別タスクとして起票する。この調査では設定を変更しない",
@@ -231,7 +231,8 @@
         "CLAUDE.md"
       ],
       "created": "2026-08-04",
-      "pr": null
+      "pr": null,
+      "notes": "run #8: repo 内の記録（pbs.tf.ignore, CLAUDE.md, local-path の性質）を横断して docs/backup.md に棚卸しをまとめた。実機（PBS のジョブ設定・実行結果・リストア可否）は autopilot のクラウドサンドボックスから到達できないため確認できず、T-0034（needs-human）として切り出した。T-0029 の blocked_by を T-0013 から T-0034 に更新した"
     },
     {
       "id": "T-0014",
@@ -472,7 +473,7 @@
       "priority": 21,
       "why": "T-0005 の調査 (run #6) で判明。postgres 本体は 16.9→16.14 の minor で問題ないが、vchord 拡張が 0.4.3→1.1.1 とメジャー相当の飛びで、ベクタ DB の実データに影響しうる（ops/inventory.json の policy=manual の理由）",
       "dod": "vchord 0.4→1.x の互換性・移行手順を確認する。CHARTER §4『データを失いうる変更』の手順どおり、着手前に immich のバックアップが実際に存在し復元できることを確認する",
-      "blocked_by": "T-0013（pbs バックアップ体制の調査）がまだ todo で、バックアップの健全性が未確認のため着手しない",
+      "blocked_by": "T-0034（PBS バックアップジョブの実機確認、needs-human）が終わっておらず、バックアップの健全性が未確認のため着手しない",
       "refs": ["apps/immich/postgres.yaml", "ops/inventory.json"],
       "created": "2026-08-04",
       "pr": null
@@ -516,6 +517,24 @@
       "why": "Maintenance.md 2026-08-03 の持ち越し。1.37.0 で追加されたレート制限は送信元 IP 単位。全クライアントが Tailscale プロキシ経由で同一 IP に見えるため、正規クライアントが 429 で弾かれていないか未確認",
       "dod": "ログまたはクライアントの実際の挙動から 429 が発生していないか確認する。発生していれば ROCKET_LIMIT_* 系の設定調整か、送信元判定の見直しを検討する。発生していなければ Maintenance.md に確認済みと記録する",
       "refs": ["Maintenance.md", "apps/vaultwarden/"],
+      "created": "2026-08-04",
+      "pr": null
+    },
+    {
+      "id": "T-0034",
+      "domain": "homelab",
+      "title": "PBS のバックアップジョブ設定・実行結果・リストア可否を実機で見てほしい",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "needs-human",
+      "priority": 12,
+      "why": "docs/backup.md（T-0013）の棚卸しで判明。node01 のアプリデータ（immich/vaultwarden/coder 等）は local-path で node01 のディスクに直接乗っており、PBS が node01 を対象にしたバックアップジョブを持っていなければ一切保護されていない。T-0029（immich postgres/vchord のメジャー更新、データを失いうる変更）はこれが確認できるまで着手できない",
+      "dod": "(1) PBS に node01 (qemu/113) を対象にしたバックアップジョブがあるか、(2) スケジュールと保持世代数、(3) 直近のジョブが成功しているか、(4) リストアを実際に試したことがあるか、(5) pbs 自身が片系（pbs を失うと node01 のバックアップも失う構成）になっていないか、の 5 点が docs/backup.md に追記される",
+      "needs_human_reason": "Tailscale 経由で homelab に到達できる環境（対話セッションの mcp__proxmox__* または PBS の Web UI）でしか調べられない。autopilot のクラウドサンドボックスは Tailscale に接続できず、物理的に手が届かない（ops/CHARTER.md §5.2）",
+      "refs": [
+        "docs/backup.md",
+        "terraform/proxmox/pbs.tf.ignore"
+      ],
       "created": "2026-08-04",
       "pr": null
     },

--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -187,12 +187,12 @@ a { color:var(--sig); }
     <div class="mast__sub">
       <span>homelab を自律運用するエージェントの記録</span>
       <span>起動間隔 1 時間ごと（毎時 19 分）</span>
-      <span>生成 2026-08-04 21:08 UTC</span>
+      <span>生成 2026-08-04 21:11 UTC</span>
     </div>
   </header>
 
-  <div class="stats"><div class="stat stat--sig"><span class="stat__v">たった今</span><span class="stat__l">最終起動</span></div><div class="stat stat--idle"><span class="stat__v">0</span><span class="stat__l">autopilot が反映した変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">2</span><span class="stat__l">あなた待ち</span></div></div>
-  <p class="stale">PR の一覧を取得できませんでした。下の「やったこと」と「いま動かしているもの」は<strong>13 分前のキャッシュ</strong>で、現在の状態と違う可能性があります。<span class="stale__why">([Errno 2] No such file or directory: &#x27;gh&#x27;)</span></p>
+  <div class="stats"><div class="stat stat--sig"><span class="stat__v">たった今</span><span class="stat__l">最終起動</span></div><div class="stat stat--idle"><span class="stat__v">0</span><span class="stat__l">autopilot が反映した変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">3</span><span class="stat__l">あなた待ち</span></div></div>
+  <p class="stale">PR の一覧を取得できませんでした。下の「やったこと」と「いま動かしているもの」は<strong>16 分前のキャッシュ</strong>で、現在の状態と違う可能性があります。<span class="stale__why">([Errno 2] No such file or directory: &#x27;gh&#x27;)</span></p>
 
   <section>
     <h2>やったこと</h2>
@@ -200,7 +200,7 @@ a { color:var(--sig); }
     <ul class="list">
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/81">T-0007: Maintenance.md の持ち越し課題を backlog に取り込む</a>
-        <span class="done__meta">#81 · 34 分前</span>
+        <span class="done__meta">#81 · 38 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/80">T-0006: Plans.md の syncthing 移行(M2) の保留理由を実態に合わせる</a>
@@ -208,11 +208,11 @@ a { color:var(--sig); }
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/79">T-0018: dex chart を 0.24.0 → 0.24.1 に上げる</a>
-        <span class="done__meta">#79 · 46 分前</span>
+        <span class="done__meta">#79 · 49 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/78">T-0005: inventory.json 全対象の上流バージョンを調査し、更新タスクを起票する</a>
-        <span class="done__meta">#78 · 48 分前</span>
+        <span class="done__meta">#78 · 52 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/77">T-0017: check_version_sync.py の pyyaml 依存を除去し nix 抽出を構造化する</a>
@@ -279,6 +279,20 @@ a { color:var(--sig); }
           <span class="chip chip--quiet">リスク 中</span>
           <span class="task__refs"><code>ops/CHARTER.md</code><code>apps/</code></span>
         </div>
+      </li>
+      <li class="task task--crit">
+        <div class="task__head">
+          <span class="task__id">T-0034</span>
+          <h3 class="task__title">PBS のバックアップジョブ設定・実行結果・リストア可否を実機で見てほしい</h3>
+        </div>
+        <p class="task__why">docs/backup.md（T-0013）の棚卸しで判明。node01 のアプリデータ（immich/vaultwarden/coder 等）は local-path で node01 のディスクに直接乗っており、PBS が node01 を対象にしたバックアップジョブを持っていなければ一切保護されていない。T-0029（immich postgres/vchord のメジャー更新、データを失いうる変更）はこれが確認できるまで着手できない</p>
+        <p class="task__note">Tailscale 経由で homelab に到達できる環境（対話セッションの mcp__proxmox__* または PBS の Web UI）でしか調べられない。autopilot のクラウドサンドボックスは Tailscale に接続できず、物理的に手が届かない（ops/CHARTER.md §5.2）</p>
+        <div class="task__meta">
+          <span class="chip chip--crit">要判断</span>
+          <span class="chip chip--quiet">調査</span>
+          <span class="chip chip--quiet">リスク 低</span>
+          <span class="task__refs"><code>docs/backup.md</code><code>terraform/proxmox/pbs.tf.ignore</code></span>
+        </div>
       </li></ul>
   </section>
 
@@ -287,7 +301,7 @@ a { color:var(--sig); }
     <p>使っていて感じたことを殴り書きで構いません。進め方への指摘は憲章に、やってほしいことはタスクとして取り込まれます。
        読んだら 3 行以内で返信します。<strong>返信が無い＝まだ読んでいない</strong>と判断してください。</p>
     <a class="fb__cta" href="https://github.com/hikuohiku/homelab/issues/56">issue #56 に書く</a>
-    <span class="fb__meta">最後に読んだ: 47 分前</span>
+    <span class="fb__meta">最後に読んだ: 51 分前</span>
   </section>
 
   <section>
@@ -299,20 +313,6 @@ a { color:var(--sig); }
     <h2>これからやること</h2>
     <p class="lede">上から順に着手します。1 タスク = 1 PR。</p>
     <ul class="list">
-      <li class="task task--idle">
-        <div class="task__head">
-          <span class="task__id">T-0013</span>
-          <h3 class="task__title">homelab に無い観点を探す — バックアップの健全性</h3>
-        </div>
-        <p class="task__why">pbs (Proxmox Backup Server) は Terraform 管理外の手動運用。バックアップが実際に取れているか、復元できるかを誰も定期確認していない</p>
-        
-        <div class="task__meta">
-          <span class="chip chip--idle">待ち</span>
-          <span class="chip chip--quiet">調査</span>
-          <span class="chip chip--quiet">リスク 低</span>
-          <span class="task__refs"><code>terraform/proxmox/pbs.tf.ignore</code><code>CLAUDE.md</code></span>
-        </div>
-      </li>
       <li class="task task--idle">
         <div class="task__head">
           <span class="task__id">T-0016</span>
@@ -466,8 +466,22 @@ a { color:var(--sig); }
           <span class="chip chip--quiet">リスク 高</span>
           <span class="task__refs"><code>apps/external-secrets/kustomization.yaml</code><code>ops/inventory.json</code></span>
         </div>
+      </li>
+      <li class="task task--idle">
+        <div class="task__head">
+          <span class="task__id">T-0027</span>
+          <h3 class="task__title">immich server / machine-learning を v2.6.3 → v3.1.0 に上げる（メジャー更新）</h3>
+        </div>
+        <p class="task__why">T-0005 の調査 (run #6) で判明。v3.0.0 で non-destructive editing・Workflows・バックグラウンドバックアップ変更・HLS トランスコーディングなど大きな変更がある。immich-server と immich-machine-learning は必ず同一バージョンで揃える（ops/inventory.json の mirrors）</p>
+        
+        <div class="task__meta">
+          <span class="chip chip--idle">待ち</span>
+          <span class="chip chip--quiet">更新</span>
+          <span class="chip chip--quiet">リスク 高</span>
+          <span class="task__refs"><code>apps/immich/values.yaml</code><code>ops/inventory.json</code></span>
+        </div>
       </li></ul>
-    <p class="more">ほか 5 件</p>
+    <p class="more">ほか 4 件</p>
   </section>
 
   <section>

--- a/ops/dashboard/index.html
+++ b/ops/dashboard/index.html
@@ -187,12 +187,12 @@ a { color:var(--sig); }
     <div class="mast__sub">
       <span>homelab を自律運用するエージェントの記録</span>
       <span>起動間隔 1 時間ごと（毎時 19 分）</span>
-      <span>生成 2026-08-04 21:11 UTC</span>
+      <span>生成 2026-08-04 21:12 UTC</span>
     </div>
   </header>
 
   <div class="stats"><div class="stat stat--sig"><span class="stat__v">たった今</span><span class="stat__l">最終起動</span></div><div class="stat stat--idle"><span class="stat__v">0</span><span class="stat__l">autopilot が反映した変更</span></div><div class="stat stat--sig"><span class="stat__v">0</span><span class="stat__l">作業中の PR</span></div><div class="stat stat--crit"><span class="stat__v">3</span><span class="stat__l">あなた待ち</span></div></div>
-  <p class="stale">PR の一覧を取得できませんでした。下の「やったこと」と「いま動かしているもの」は<strong>16 分前のキャッシュ</strong>で、現在の状態と違う可能性があります。<span class="stale__why">([Errno 2] No such file or directory: &#x27;gh&#x27;)</span></p>
+  <p class="stale">PR の一覧を取得できませんでした。下の「やったこと」と「いま動かしているもの」は<strong>17 分前のキャッシュ</strong>で、現在の状態と違う可能性があります。<span class="stale__why">([Errno 2] No such file or directory: &#x27;gh&#x27;)</span></p>
 
   <section>
     <h2>やったこと</h2>
@@ -208,7 +208,7 @@ a { color:var(--sig); }
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/79">T-0018: dex chart を 0.24.0 → 0.24.1 に上げる</a>
-        <span class="done__meta">#79 · 49 分前</span>
+        <span class="done__meta">#79 · 50 分前</span>
       </li>
       <li class="done">
         <a class="done__title" href="https://github.com/hikuohiku/homelab/pull/78">T-0005: inventory.json 全対象の上流バージョンを調査し、更新タスクを起票する</a>

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -222,5 +222,11 @@
   分離を選択: バージョン監視・更新判断の一次情報源は CHARTER §3/§4（autopilot が inventory.json 全対象を
   担当）とし、`.claude/commands/weekly-maintenance.md` は実機（ArgoCD/kubectl/ノード）に到達できる人間の
   対話セッションでしかできない健全性確認に絞った。重複していた『落とし穴』の版更新一般項目と、対象拡大計画
-  （3 回変更なしで対象を増やす — autopilot が既に全対象を見ているため不要になっていた）を削除
-- 次の起動へ: backlog は T-0013（priority 12, pbs バックアップ体制の調査）から順に
+  （3 回変更なしで対象を増やす — autopilot が既に全対象を見ているため不要になっていた）を削除 (#86, merged)
+- #86 merge を確認後、続けて T-0013（PBS バックアップ体制の調査）に着手・完遂。repo 内の記録
+  （pbs.tf.ignore、local-path の性質）を横断して `docs/backup.md` に棚卸しをまとめた。実機の
+  ジョブ設定・実行結果・リストア可否は autopilot のクラウドサンドボックスから到達できないため
+  確認できず、T-0034（needs-human）として切り出した。T-0029 の `blocked_by` を T-0013 から
+  T-0034 に更新した
+- 次の起動へ: backlog の todo で優先度が最も低いのは T-0019/T-0020/T-0021（priority 14, immich
+  valkey / busybox / coder-postgres の patch 更新）。T-0034 は needs-human なので人間の対応待ち

--- a/ops/state.json
+++ b/ops/state.json
@@ -92,7 +92,7 @@
       "at": "2026-08-04T22:05:00Z",
       "kind": "scheduled",
       "by": "cloud routine",
-      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0033（conflict marker 検出、#84 merged）・T-0008（nix flake check を CI に追加、#85 merged）を完遂。続けて T-0009（weekly-maintenance と CHARTER の役割分担）に着手。統合ではなく分離を選択し、バージョン監視・更新判断の一次情報源を CHARTER に一本化、weekly-maintenance は実機健全性確認に絞った",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0033（conflict marker 検出、#84）・T-0008（nix flake check を CI に追加、#85）・T-0009（weekly-maintenance と CHARTER の役割分担、#86）を完遂。続けて T-0013（PBS バックアップ体制の調査）を完遂し docs/backup.md を作成。実機確認が要る点は T-0034（needs-human）として切り出し、T-0029 の blocked_by を張り替えた",
       "prs": [84, 85, 86]
     }
   ]

--- a/ops/state.json
+++ b/ops/state.json
@@ -93,7 +93,7 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0033（conflict marker 検出、#84）・T-0008（nix flake check を CI に追加、#85）・T-0009（weekly-maintenance と CHARTER の役割分担、#86）を完遂。続けて T-0013（PBS バックアップ体制の調査）を完遂し docs/backup.md を作成。実機確認が要る点は T-0034（needs-human）として切り出し、T-0029 の blocked_by を張り替えた",
-      "prs": [84, 85, 86]
+      "prs": [84, 85, 86, 87]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`docs/backup.md` を新規作成し、PBS (Proxmox Backup Server) 周りの現状を repo 内の記録から棚卸しした。

- node01 のアプリデータ（immich / vaultwarden / coder 等）は `local-path` provisioner で node01 の
  ディスクに直接乗っている。PBS が node01 (`qemu/113`) を対象にしたバックアップジョブを持っていなければ、
  これらのデータは一切バックアップされていないことになる
- PBS のジョブ設定・スケジュール・保持世代数・直近の成功可否・リストア検証の記録が repo 内に無く、
  実機（Proxmox/PBS）でしか確認できない

## 検証したこと

ドキュメント作成のみ。設定変更は行っていない。実機確認は autopilot のクラウドサンドボックスから
到達できないため（`ops/CHARTER.md` §5.2）、`ops/backlog.json` に T-0034（`needs-human`）として切り出した。
`needs_human_reason` に確認してほしい 5 点を具体的に書いてある。データを失いうる T-0029（immich
postgres/vchord のメジャー更新）の `blocked_by` を T-0013 から T-0034 に張り替えた

## ロールバック手順

`docs/backup.md` を削除し、`ops/backlog.json` の T-0013/T-0029/T-0034 の変更を revert すれば元に戻る。
実インフラへの変更は無い

## backlog task id

T-0013（T-0034 を新規起票）

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThURoNQbyntEtVj2DKnRjC)_