### PR TITLE
T-0016: ダッシュボードの PR 一覧を gh CLI 非依存にする

### DIFF
--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -270,10 +270,20 @@ PR に付いたレビューコメントも同じ扱い。**指摘を受けたら
 
 人間が朝に見る唯一の画面。`ops/` を更新したら**必ず**次を実行する。
 
-```bash
-python3 ops/validate.py          # 0 error であること。落ちたら直してから進む
-python3 ops/dashboard/build.py   # ops/dashboard/index.html を再生成
-```
+`ops/dashboard/build.py` の `fetch_prs()` は内部で `gh pr list` を呼ぶが、このクラウドサンドボックスに
+`gh` は無いので必ず失敗し、`ops/dashboard/prs.json` のキャッシュにフォールバックする（CHARTER §5.2）。
+**キャッシュは自動更新されない。** ビルド前に次の手順でキャッシュを最新化する（T-0016）。
+
+1. `mcp__github__list_pull_requests`（`state: open`）と（`state: closed`, `sort: updated`, `direction: desc`）
+   で取得する。**`merged` フィールドは信用しない**（closed の全件で `false` を返すことがある実測済みの不具合。
+   `merged_at` が非 null かどうかで判定する）
+2. `build.py` が期待する形へ変換して `ops/dashboard/prs.json` に書く:
+   `{"open": [{number, title, url, isDraft, createdAt, statusCheckRollup, headRefName, autoMergeRequest}, ...],
+   "merged": [{number, title, url, mergedAt, headRefName}, ...]}`（`merged` は `mergedAt` 降順で最大 60 件）。
+   open の `statusCheckRollup` は `mcp__github__pull_request_read`（`method: get_status`）の結果を
+   `[{"conclusion": "SUCCESS"|"PENDING"|"FAILURE"}]` 相当に変換すれば `ci_state()` が正しく判定する
+3. `python3 ops/validate.py` → 0 error であること。落ちたら直してから進む
+4. `python3 ops/dashboard/build.py` → `ops/dashboard/index.html` を再生成
 
 **`ops/dashboard/index.html` は Git 管理していない**（`.gitignore` 対象、T-0035）。`build.py` の
 生成物であり、`ops/*.json` + journal から決定的に再生成できるので repo に置く理由が無い。かつては

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -276,7 +276,7 @@
       "title": "ダッシュボードの PR 一覧を gh CLI 非依存にする",
       "kind": "ci",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 13,
       "why": "run #4 で判明: この実行環境に `gh` CLI が無く、`ops/dashboard/build.py` の `fetch_prs()` が失敗してキャッシュ（`ops/dashboard/prs.json`）に頼るしかない。`api.github.com` への直接 HTTPS も組織の egress ポリシーで 403 になり build.py 単体では代替できない（`ghcr.io` など他ホストは到達できるので、egress は GitHub API に限定して塞がれている）。結果としてキャッシュが更新されず、ダッシュボードの PR 一覧が数十件古いまま固定化していた",
       "dod": "毎回の起動でダッシュボードの PR 一覧が実態と一致する。方向性の候補: (a) 起動のたびに agent が `mcp__github__list_pull_requests` で取得して `ops/dashboard/prs.json` を直接更新してから `build.py` を実行する運用にし、CHARTER §7.1 にその手順を明記する (b) build.py に `prs.json` が事前に用意されている前提を明記し、`gh` 実行は human のローカル実行時のみ有効なfallbackと位置付け直す。CI 実行環境（GitHub Actions runner）側は `gh` が使えるはずなので、その差も踏まえること",
@@ -287,7 +287,7 @@
       ],
       "created": "2026-08-04",
       "pr": null,
-      "notes": "run #4 でその場しのぎの urllib 版を書いて動かなかった（403）ため revert 済み。次に着手するときは build.py 単体で完結させようとせず、agent 側の前処理込みで設計すること"
+      "notes": "run #9: (a) を採用。CHARTER §7.1 に、起動のたびに mcp__github__list_pull_requests で open/closed を取得し build.py が期待する形へ変換して prs.json に書く手順を明記した。副産物として `mcp__github__list_pull_requests` の `merged` フィールドが closed 全件で `false` を返す実測不具合を発見し、`merged_at` の非 null 判定に置き換えるよう手順に明記した。この起動で実際に prs.json を最新化（88 件時点、41 件の merged PR）"
     },
     {
       "id": "T-0017",

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -286,7 +286,7 @@
         "ops/CHARTER.md"
       ],
       "created": "2026-08-04",
-      "pr": null,
+      "pr": 89,
       "notes": "run #9: (a) を採用。CHARTER §7.1 に、起動のたびに mcp__github__list_pull_requests で open/closed を取得し build.py が期待する形へ変換して prs.json に書く手順を明記した。副産物として `mcp__github__list_pull_requests` の `merged` フィールドが closed 全件で `false` を返す実測不具合を発見し、`merged_at` の非 null 判定に置き換えるよう手順に明記した。この起動で実際に prs.json を最新化（88 件時点、41 件の merged PR）"
     },
     {

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,136 +2,291 @@
   "open": [],
   "merged": [
     {
-      "mergedAt": "2026-08-04T20:33:11Z",
+      "number": 88,
+      "title": "T-0035: ops/dashboard/index.html を Git 管理から外す",
+      "url": "https://github.com/hikuohiku/homelab/pull/88",
+      "mergedAt": "2026-08-04T21:24:41Z",
+      "headRefName": "autopilot/t-0035-dashboard-html-untrack"
+    },
+    {
+      "number": 87,
+      "title": "PBS バックアップ体制を棚卸しする (T-0013)",
+      "url": "https://github.com/hikuohiku/homelab/pull/87",
+      "mergedAt": "2026-08-04T21:13:05Z",
+      "headRefName": "autopilot/t-0013-pbs-backup-inventory"
+    },
+    {
+      "number": 86,
+      "title": "weekly-maintenance と CHARTER の役割を分ける (T-0009)",
+      "url": "https://github.com/hikuohiku/homelab/pull/86",
+      "mergedAt": "2026-08-04T21:08:55Z",
+      "headRefName": "autopilot/t-0009-weekly-maintenance-charter-roles"
+    },
+    {
+      "number": 85,
+      "title": "CI に nix flake check を追加する (T-0008)",
+      "url": "https://github.com/hikuohiku/homelab/pull/85",
+      "mergedAt": "2026-08-04T21:05:33Z",
+      "headRefName": "autopilot/t-0008-nix-flake-check-ci"
+    },
+    {
+      "number": 84,
+      "title": "ops/validate.py: git のコンフリクトマーカー残留を検出する (T-0033)",
+      "url": "https://github.com/hikuohiku/homelab/pull/84",
+      "mergedAt": "2026-08-04T20:54:36Z",
+      "headRefName": "autopilot/t-0033-conflict-marker-detection"
+    },
+    {
+      "number": 83,
+      "title": "fix(ops): ダッシュボードの数字が嘘をつかないようにする",
+      "url": "https://github.com/hikuohiku/homelab/pull/83",
+      "mergedAt": "2026-08-04T20:50:52Z",
+      "headRefName": "autopilot/fix-dashboard-numbers"
+    },
+    {
+      "number": 82,
+      "title": "ops: run #7 の記録をまとめ、ダッシュボードを再生成する",
+      "url": "https://github.com/hikuohiku/homelab/pull/82",
+      "mergedAt": "2026-08-04T20:34:49Z",
+      "headRefName": "autopilot/run-7-wrapup"
+    },
+    {
       "number": 81,
       "title": "T-0007: Maintenance.md の持ち越し課題を backlog に取り込む",
-      "url": "https://github.com/hikuohiku/homelab/pull/81"
+      "url": "https://github.com/hikuohiku/homelab/pull/81",
+      "mergedAt": "2026-08-04T20:33:11Z",
+      "headRefName": "autopilot/T-0007-maintenance-backlog"
     },
     {
-      "mergedAt": "2026-08-04T21:35:00Z",
       "number": 80,
       "title": "T-0006: Plans.md の syncthing 移行(M2) の保留理由を実態に合わせる",
-      "url": "https://github.com/hikuohiku/homelab/pull/80"
+      "url": "https://github.com/hikuohiku/homelab/pull/80",
+      "mergedAt": "2026-08-04T20:28:44Z",
+      "headRefName": "autopilot/T-0006-plans-md-syncthing-status"
     },
     {
-      "mergedAt": "2026-08-04T20:22:07Z",
       "number": 79,
       "title": "T-0018: dex chart を 0.24.0 → 0.24.1 に上げる",
-      "url": "https://github.com/hikuohiku/homelab/pull/79"
+      "url": "https://github.com/hikuohiku/homelab/pull/79",
+      "mergedAt": "2026-08-04T20:22:07Z",
+      "headRefName": "autopilot/T-0018-dex-chart-patch"
     },
     {
-      "mergedAt": "2026-08-04T20:19:22Z",
       "number": 78,
       "title": "T-0005: inventory.json 全対象の上流バージョンを調査し、更新タスクを起票する",
-      "url": "https://github.com/hikuohiku/homelab/pull/78"
+      "url": "https://github.com/hikuohiku/homelab/pull/78",
+      "mergedAt": "2026-08-04T20:19:22Z",
+      "headRefName": "autopilot/T-0005-inventory-upstream-survey"
     },
     {
-      "mergedAt": "2026-08-04T20:07:23Z",
       "number": 77,
       "title": "T-0017: check_version_sync.py の pyyaml 依存を除去し nix 抽出を構造化する",
-      "url": "https://github.com/hikuohiku/homelab/pull/77"
+      "url": "https://github.com/hikuohiku/homelab/pull/77",
+      "mergedAt": "2026-08-04T20:07:23Z",
+      "headRefName": "autopilot/T-0017-check-version-sync-stdlib"
     },
     {
-      "mergedAt": "2026-08-04T20:00:20Z",
       "number": 76,
       "title": "ops: run #5 の記録をまとめ、ダッシュボードを再生成する",
-      "url": "https://github.com/hikuohiku/homelab/pull/76"
+      "url": "https://github.com/hikuohiku/homelab/pull/76",
+      "mergedAt": "2026-08-04T20:00:20Z",
+      "headRefName": "autopilot/run5-wrapup"
     },
     {
-      "mergedAt": "2026-08-04T19:59:07Z",
       "number": 75,
       "title": "fix(apps): busybox の initContainer バージョンを 1.37 に統一する (T-0003)",
-      "url": "https://github.com/hikuohiku/homelab/pull/75"
+      "url": "https://github.com/hikuohiku/homelab/pull/75",
+      "mergedAt": "2026-08-04T19:59:07Z",
+      "headRefName": "autopilot/T-0003-busybox-version-sync"
     },
     {
-      "mergedAt": "2026-08-04T19:57:49Z",
       "number": 74,
       "title": "fix(argocd): chart バージョンの二重管理に CI 検出を追加する (T-0002)",
-      "url": "https://github.com/hikuohiku/homelab/pull/74"
+      "url": "https://github.com/hikuohiku/homelab/pull/74",
+      "mergedAt": "2026-08-04T19:57:49Z",
+      "headRefName": "autopilot/T-0002-argocd-version-sync"
     },
     {
-      "mergedAt": "2026-08-04T19:56:23Z",
       "number": 73,
       "title": "ops: このクラウドサンドボックスのツール有無を CHARTER に記録する",
-      "url": "https://github.com/hikuohiku/homelab/pull/73"
+      "url": "https://github.com/hikuohiku/homelab/pull/73",
+      "mergedAt": "2026-08-04T19:56:23Z",
+      "headRefName": "autopilot/feedback-tool-availability"
     },
     {
-      "mergedAt": "2026-08-04T19:42:31Z",
       "number": 72,
       "title": "fix(ops): PR 一覧がキャッシュのときダッシュボードに明示する",
-      "url": "https://github.com/hikuohiku/homelab/pull/72"
+      "url": "https://github.com/hikuohiku/homelab/pull/72",
+      "mergedAt": "2026-08-04T19:42:31Z",
+      "headRefName": "autopilot/dashboard-stale-warning"
     },
     {
-      "mergedAt": "2026-08-04T19:40:33Z",
       "number": 71,
       "title": "fix(tailscale): k8s-nameserver の floating tag unstable を固定する",
-      "url": "https://github.com/hikuohiku/homelab/pull/71"
+      "url": "https://github.com/hikuohiku/homelab/pull/71",
+      "mergedAt": "2026-08-04T19:40:33Z",
+      "headRefName": "autopilot/T-0001-pin-tailscale-nameserver"
     },
     {
-      "mergedAt": "2026-08-04T19:34:27Z",
       "number": 70,
       "title": "fix(ci): direct-push-guard のレビュー指摘3点を修正",
-      "url": "https://github.com/hikuohiku/homelab/pull/70"
+      "url": "https://github.com/hikuohiku/homelab/pull/70",
+      "mergedAt": "2026-08-04T19:34:27Z",
+      "headRefName": "autopilot/T-0014-fix-direct-push-guard-review"
     },
     {
-      "mergedAt": "2026-08-04T19:26:25Z",
       "number": 69,
       "title": "fix(ops): ダッシュボードに起動間隔が出ない退行を直す",
-      "url": "https://github.com/hikuohiku/homelab/pull/69"
+      "url": "https://github.com/hikuohiku/homelab/pull/69",
+      "mergedAt": "2026-08-04T19:26:25Z",
+      "headRefName": "autopilot/fix-dashboard-cadence"
     },
     {
-      "mergedAt": "2026-08-04T19:25:17Z",
       "number": 68,
       "title": "fix(terraform): .terraform.lock.hcl から未宣言の tailscale provider を除去する",
-      "url": "https://github.com/hikuohiku/homelab/pull/68"
+      "url": "https://github.com/hikuohiku/homelab/pull/68",
+      "mergedAt": "2026-08-04T19:25:17Z",
+      "headRefName": "autopilot/T-0004-tf-lock-cleanup"
     },
     {
-      "mergedAt": "2026-08-04T19:23:22Z",
       "number": 67,
       "title": "ci: main への直 push を検知する direct-push-guard を追加する",
-      "url": "https://github.com/hikuohiku/homelab/pull/67"
+      "url": "https://github.com/hikuohiku/homelab/pull/67",
+      "mergedAt": "2026-08-04T19:23:22Z",
+      "headRefName": "autopilot/T-0014-direct-push-guard"
     },
     {
-      "mergedAt": "2026-08-04T19:11:18Z",
       "number": 66,
       "title": "ops: 「workflow 本文が失われた」という記録の誤りを訂正する",
-      "url": "https://github.com/hikuohiku/homelab/pull/66"
+      "url": "https://github.com/hikuohiku/homelab/pull/66",
+      "mergedAt": "2026-08-04T19:11:18Z",
+      "headRefName": "autopilot/fix-journal-correction"
     },
     {
-      "mergedAt": "2026-08-04T19:07:42Z",
       "number": 65,
       "title": "ops: workflows 権限の付与を受けて T-0014 のブロックを解除する",
-      "url": "https://github.com/hikuohiku/homelab/pull/65"
+      "url": "https://github.com/hikuohiku/homelab/pull/65",
+      "mergedAt": "2026-08-04T19:07:42Z",
+      "headRefName": "autopilot/unblock-t0014"
     },
     {
-      "mergedAt": "2026-08-04T19:04:54Z",
       "number": 64,
       "title": "ops: T-0014 の pr 番号を記録する (#63)",
-      "url": "https://github.com/hikuohiku/homelab/pull/64"
+      "url": "https://github.com/hikuohiku/homelab/pull/64",
+      "mergedAt": "2026-08-04T19:04:54Z",
+      "headRefName": "autopilot/T-0014-record-pr"
     },
     {
-      "mergedAt": "2026-08-04T19:03:50Z",
       "number": 63,
       "title": "ops: issue #56 のフィードバックを反映、T-0014 を needs-human に",
-      "url": "https://github.com/hikuohiku/homelab/pull/63"
+      "url": "https://github.com/hikuohiku/homelab/pull/63",
+      "mergedAt": "2026-08-04T19:03:50Z",
+      "headRefName": "autopilot/T-0014-direct-push-guard"
     },
     {
-      "mergedAt": "2026-08-04T18:54:48Z",
       "number": 62,
       "title": "fix: permissions.ask を全廃する",
-      "url": "https://github.com/hikuohiku/homelab/pull/62"
+      "url": "https://github.com/hikuohiku/homelab/pull/62",
+      "mergedAt": "2026-08-04T18:54:48Z",
+      "headRefName": "autopilot/drop-ask-rules"
     },
     {
-      "mergedAt": "2026-08-04T18:51:52Z",
       "number": 61,
       "title": "fix(ops): 権限プロンプトで起動が消えるのを防ぐ",
-      "url": "https://github.com/hikuohiku/homelab/pull/61"
+      "url": "https://github.com/hikuohiku/homelab/pull/61",
+      "mergedAt": "2026-08-04T18:51:52Z",
+      "headRefName": "autopilot/no-ask-commands"
     },
     {
-      "mergedAt": "2026-08-04T18:46:44Z",
       "number": 60,
       "title": "ops: 定期実行を 1 時間ごとに変更し、run #1 の記録を残す",
-      "url": "https://github.com/hikuohiku/homelab/pull/60"
+      "url": "https://github.com/hikuohiku/homelab/pull/60",
+      "mergedAt": "2026-08-04T18:46:44Z",
+      "headRefName": "autopilot/hourly"
+    },
+    {
+      "number": 59,
+      "title": "fix(ops): main への直 push を廃し、記録も PR に載せる",
+      "url": "https://github.com/hikuohiku/homelab/pull/59",
+      "mergedAt": "2026-08-04T18:45:09Z",
+      "headRefName": "autopilot/pr-only"
+    },
+    {
+      "number": 58,
+      "title": "feat(ops): 判断を人間に渡さない方針へ憲章を改める",
+      "url": "https://github.com/hikuohiku/homelab/pull/58",
+      "mergedAt": "2026-08-04T18:32:23Z",
+      "headRefName": "autopilot/no-human-judgment"
+    },
+    {
+      "number": 57,
+      "title": "feat(ops): homelab を自律運用する autopilot の器を作る",
+      "url": "https://github.com/hikuohiku/homelab/pull/57",
+      "mergedAt": "2026-08-04T18:23:14Z",
+      "headRefName": "autopilot/bootstrap"
+    },
+    {
+      "number": 55,
+      "title": "fix(coder): secure workspace SSH key before clone",
+      "url": "https://github.com/hikuohiku/homelab/pull/55",
+      "mergedAt": "2026-08-04T16:25:20Z",
+      "headRefName": "coder-template-ssh-key-mode"
+    },
+    {
+      "number": 54,
+      "title": "fix(coder): clone private skills over SSH",
+      "url": "https://github.com/hikuohiku/homelab/pull/54",
+      "mergedAt": "2026-08-04T16:18:12Z",
+      "headRefName": "coder-template-skills-bootstrap"
+    },
+    {
+      "number": 53,
+      "title": "feat(coder): use immutable workspace image",
+      "url": "https://github.com/hikuohiku/homelab/pull/53",
+      "mergedAt": "2026-08-04T04:42:17Z",
+      "headRefName": "coder-template-image"
+    },
+    {
+      "number": 52,
+      "title": "feat: Coder 開発サーバーを手書き manifest で追加",
+      "url": "https://github.com/hikuohiku/homelab/pull/52",
+      "mergedAt": "2026-08-03T14:58:51Z",
+      "headRefName": "feat/coder-handwritten"
+    },
+    {
+      "number": 51,
+      "title": "feat: node01 を 4c/12GB/50GB にスケールアップ",
+      "url": "https://github.com/hikuohiku/homelab/pull/51",
+      "mergedAt": "2026-08-03T14:17:36Z",
+      "headRefName": "feat/node01-scale-up"
+    },
+    {
+      "number": 50,
+      "title": "feat: 週次メンテナンスの手順を /weekly-maintenance コマンドに定義",
+      "url": "https://github.com/hikuohiku/homelab/pull/50",
+      "mergedAt": "2026-08-03T13:45:55Z",
+      "headRefName": "feat/weekly-maintenance-routine"
+    },
+    {
+      "number": 49,
+      "title": "fix(vaultwarden): 1.36.0 → 1.37.1 でクライアント同期不具合を解消",
+      "url": "https://github.com/hikuohiku/homelab/pull/49",
+      "mergedAt": "2026-08-03T13:01:44Z",
+      "headRefName": "fix/vaultwarden-1.37.1"
+    },
+    {
+      "number": 48,
+      "title": "chore: kubectl を ask 付きで許可する方針を反映 + 移行 Plans 更新",
+      "url": "https://github.com/hikuohiku/homelab/pull/48",
+      "mergedAt": "2026-08-03T12:25:50Z",
+      "headRefName": "chore/kubectl-ask-policy-and-plans"
+    },
+    {
+      "number": 47,
+      "title": "feat: vaultwarden を k8s へ移行する manifest を追加",
+      "url": "https://github.com/hikuohiku/homelab/pull/47",
+      "mergedAt": "2026-06-21T09:28:10Z",
+      "headRefName": "feat/vaultwarden-k8s"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -247,3 +247,9 @@
   CI の `ops` job に `python3 ops/dashboard/build.py` の実行成功チェックを追加（生成物は commit しないが
   壊れていないことは CI が担保する）。CHARTER §4（相乗り例外リスト）・§7.1（ダッシュボード手順）を更新。
   §5.2 に workflows/ruleset の権限非対称を追記
+- #88 merge を確認後、続けて T-0016（ダッシュボードの PR 一覧を gh CLI 非依存にする）に着手・完遂。
+  `mcp__github__list_pull_requests` で open/closed を取得し `build.py` が期待する形へ変換して
+  `ops/dashboard/prs.json` を更新する手順を CHARTER §7.1 に明記し、この起動で実際に実行した
+  （41 件の merged PR、open は 0 件で最新化）。**副産物の発見**: `mcp__github__list_pull_requests` の
+  `merged` フィールドは closed 全件で `false` を返す実測不具合がある。`merged_at` の非 null 判定に
+  置き換えるよう CHARTER に明記した


### PR DESCRIPTION
## 変更点

- `ops/dashboard/prs.json`（`build.py` の PR 一覧キャッシュ）を最新化した。それまで #81 時点で止まっていた
- `ops/CHARTER.md` §7.1 に、起動のたびに `mcp__github__list_pull_requests` で open/closed を取得し `build.py` が期待する形式に変換してキャッシュを更新する手順を明記した

## 背景

このクラウドサンドボックスに `gh` CLI が無いため、`ops/dashboard/build.py` の `fetch_prs()` は毎回失敗してキャッシュにフォールバックする。そのキャッシュ自体を最新化する手順が無く、ダッシュボードの PR 一覧が数十件古いまま固定化していた（T-0016）。

副産物として、`mcp__github__list_pull_requests` の `merged` フィールドが closed 状態の PR 全件で `false` を返す実測上の不具合を見つけた。`merged_at` の非 null 判定に置き換えるよう手順に明記した。

## 検証したこと

- `python3 ops/validate.py` → 0 error（T-0016 の `pr` 未設定による warning 1 件のみ、マージ後に埋める）
- `python3 ops/dashboard/build.py` → 手元で実行成功、更新後の prs.json から index.html を再生成できることを確認

## ロールバック手順

このコミットを revert すれば `ops/dashboard/prs.json` は元の内容に戻る。CHARTER の手順追記も同時に戻る。実インフラには影響しない（repo 内で閉じる変更）。

## backlog task id

T-0016

---
_Generated by [Claude Code](https://claude.ai/code/session_01XusKhJr186BnQVQWKDavr3)_