### PR TITLE
T-0020: busybox を 1.37 → 1.38.0 に上げる

### DIFF
--- a/apps/coder/postgres.yaml
+++ b/apps/coder/postgres.yaml
@@ -34,7 +34,7 @@ spec:
         fsGroup: 999
       initContainers:
         - name: init-permissions
-          image: busybox:1.37
+          image: busybox:1.38.0
           command: ["sh", "-c", "chown -R 999:999 /var/lib/postgresql/data"]
           securityContext:
             runAsUser: 0

--- a/apps/immich/postgres.yaml
+++ b/apps/immich/postgres.yaml
@@ -37,7 +37,7 @@ spec:
         fsGroup: 999
       initContainers:
         - name: init-permissions
-          image: busybox:1.37
+          image: busybox:1.38.0
           command: ["sh", "-c", "chown -R 26:999 /var/lib/postgresql/data"]
           securityContext:
             runAsUser: 0

--- a/apps/vaultwarden/deployment.yaml
+++ b/apps/vaultwarden/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       initContainers:
         # local-path の PVC は root:root で作成されるため、非 root 実行に備えて所有権を調整
         - name: init-permissions
-          image: busybox:1.37
+          image: busybox:1.38.0
           command: ["sh", "-c", "chown -R 1000:1000 /data"]
           securityContext:
             runAsUser: 0

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -342,13 +342,14 @@
       "title": "busybox を 1.37 → 1.38.0 に上げる",
       "kind": "upgrade",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 14,
       "why": "T-0005 の調査 (run #6) で判明。3 箇所とも chown のみの initContainer（T-0003 参照）で busybox 固有機能に依存していない",
       "dod": "apps/vaultwarden/deployment.yaml, apps/coder/postgres.yaml, apps/immich/postgres.yaml の busybox タグが 3 箇所とも 1.38.0。ops/inventory.json の busybox current も更新",
       "refs": ["apps/vaultwarden/deployment.yaml", "apps/coder/postgres.yaml", "apps/immich/postgres.yaml", "ops/inventory.json"],
       "created": "2026-08-04",
-      "pr": null
+      "pr": null,
+      "notes": "run #9: WebFetch で hub.docker.com のタグ一覧を確認し 1.38.0 が最新と確認して 3 箇所とも更新"
     },
     {
       "id": "T-0021",

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -348,7 +348,7 @@
       "dod": "apps/vaultwarden/deployment.yaml, apps/coder/postgres.yaml, apps/immich/postgres.yaml の busybox タグが 3 箇所とも 1.38.0。ops/inventory.json の busybox current も更新",
       "refs": ["apps/vaultwarden/deployment.yaml", "apps/coder/postgres.yaml", "apps/immich/postgres.yaml", "ops/inventory.json"],
       "created": "2026-08-04",
-      "pr": null,
+      "pr": 91,
       "notes": "run #9: WebFetch で hub.docker.com のタグ一覧を確認し 1.38.0 が最新と確認して 3 箇所とも更新"
     },
     {

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -137,7 +137,7 @@
       "id": "busybox",
       "kind": "image",
       "name": "busybox (initContainer)",
-      "current": "1.37",
+      "current": "1.38.0",
       "file": "apps/vaultwarden/deployment.yaml",
       "match": "busybox:",
       "mirrors": ["apps/coder/postgres.yaml", "apps/immich/postgres.yaml"],

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -257,3 +257,5 @@
   `curl` で `hub.docker.com`（`registry.hub.docker.com`）を直接叩くと 403 だったが、`WebFetch` ツールは
   別経路で到達でき、タグ一覧から 9.1.1-alpine が 9.1 系の最新パッチと確認できた。**新発見**: curl が 403 の
   ホストでも `WebFetch` は到達できることがある。CHARTER §5.2 に追記した
+- #90 merge を確認後、続けて T-0020（busybox 1.37 → 1.38.0）に着手・完遂。WebFetch で hub.docker.com の
+  タグ一覧を確認し 1.38.0 が最新と確認。vaultwarden/coder/immich の 3 initContainer と inventory.json を更新


### PR DESCRIPTION
## 変更点

- `apps/vaultwarden/deployment.yaml`, `apps/coder/postgres.yaml`, `apps/immich/postgres.yaml` の busybox initContainer タグを `1.37` → `1.38.0` に上げた（patch バージョン）
- `ops/inventory.json` の `busybox` エントリの `current` も同期した

## 検証したこと

- `hub.docker.com` のタグ一覧を `WebFetch` で確認し、`1.38.0` が最新の安定版であることを確認した
- 3 箇所とも postgres データディレクトリの `chown` のみを行う initContainer で、busybox 固有機能には依存していない（T-0003 でバージョンを揃えた際と同じ確認）
- `python3 ops/validate.py` → 0 error（T-0020 の `pr` 未設定による warning 1 件のみ、マージ後に埋める）
- `kustomize build --enable-helm` はこのサンドボックスに `kustomize` が無いため手元では実行できず、CI（`kustomize build` job）に委ねる

## ロールバック手順

このコミットを revert すれば `1.37` に戻る。ArgoCD が追従して再デプロイする。initContainer は起動時に一度だけ chown を実行するだけなので、ロールバックの実害は無い。

## backlog task id

T-0020

---
_Generated by [Claude Code](https://claude.ai/code/session_01XusKhJr186BnQVQWKDavr3)_