### PR TITLE
T-0021: coder-postgres を 17.5 → 17.10 に上げる

### DIFF
--- a/apps/coder/postgres.yaml
+++ b/apps/coder/postgres.yaml
@@ -43,7 +43,7 @@ spec:
               mountPath: /var/lib/postgresql/data
       containers:
         - name: postgres
-          image: postgres:17.5
+          image: postgres:17.10
           env:
             - name: POSTGRES_USER
               value: coder

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -363,7 +363,7 @@
       "dod": "apps/coder/postgres.yaml の postgres イメージタグが 17.10。ops/inventory.json の coder-postgres current も更新",
       "refs": ["apps/coder/postgres.yaml", "ops/inventory.json"],
       "created": "2026-08-04",
-      "pr": null,
+      "pr": 92,
       "notes": "run #9: WebFetch で hub.docker.com のタグ一覧を確認し 17.10 が 17 系メジャー内の最新パッチと確認して更新。17.x マイナー内のためデータ移行は不要"
     },
     {

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -357,13 +357,14 @@
       "title": "coder-postgres を 17.5 → 17.10 に上げる",
       "kind": "upgrade",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 14,
       "why": "T-0005 の調査 (run #6) で判明。16 系メジャー内の patch 5 つ分。postgres 18 系メジャー更新はデータ移行が要るため対象外（人間へ）",
       "dod": "apps/coder/postgres.yaml の postgres イメージタグが 17.10。ops/inventory.json の coder-postgres current も更新",
       "refs": ["apps/coder/postgres.yaml", "ops/inventory.json"],
       "created": "2026-08-04",
-      "pr": null
+      "pr": null,
+      "notes": "run #9: WebFetch で hub.docker.com のタグ一覧を確認し 17.10 が 17 系メジャー内の最新パッチと確認して更新。17.x マイナー内のためデータ移行は不要"
     },
     {
       "id": "T-0022",

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -83,7 +83,7 @@
       "id": "coder-postgres",
       "kind": "image",
       "name": "postgres",
-      "current": "17.5",
+      "current": "17.10",
       "file": "apps/coder/postgres.yaml",
       "match": "image: postgres:",
       "upstream": "dockerhub:library/postgres",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -259,3 +259,8 @@
   ホストでも `WebFetch` は到達できることがある。CHARTER §5.2 に追記した
 - #90 merge を確認後、続けて T-0020（busybox 1.37 → 1.38.0）に着手・完遂。WebFetch で hub.docker.com の
   タグ一覧を確認し 1.38.0 が最新と確認。vaultwarden/coder/immich の 3 initContainer と inventory.json を更新
+- #91 merge を確認後、続けて T-0021（coder-postgres 17.5 → 17.10）に着手・完遂。WebFetch で 17.10 が
+  17 系メジャー内の最新パッチと確認（マイナー内なのでデータ移行不要）。coder は autopilot 自身の開発環境を
+  ホストしているため注意して進めたが、17.x のマイナー更新でスキーマ非互換は無い前提
+- ここで一区切り。優先度 14（T-0019〜T-0021）を全て完遂。次の起動へ: backlog の todo で優先度が低いのは
+  T-0016（priority 13, 完遂済み）の次は T-0022（priority 16, immich chart 0.12.0→0.13.1, medium risk）


### PR DESCRIPTION
## 変更点

- `apps/coder/postgres.yaml` の postgres イメージタグを `17.5` → `17.10` に上げた（17 系メジャー内の patch 更新）
- `ops/inventory.json` の `coder-postgres` エントリの `current` も同期した

## 検証したこと

- `hub.docker.com` のタグ一覧を `WebFetch` で確認し、`17.10` が 17 系メジャーの最新パッチであることを確認した
- 17.x のマイナーバージョン間で postgres はデータファイル形式・スキーマの非互換を持たない（18 系へのメジャー更新はデータ移行が必要なため別タスクで扱う）
- `python3 ops/validate.py` → 0 error（T-0021 の `pr` 未設定による warning 1 件のみ、マージ後に埋める）
- `kustomize build --enable-helm` はこのサンドボックスに `kustomize` が無いため手元では実行できず、CI（`kustomize build` job）に委ねる

## ロールバック手順

このコミットを revert すれば `17.5` に戻る。ArgoCD が追従して再デプロイする。coder は autopilot 自身の開発環境をホストしているため注意して進めたが、17.x 内のマイナー更新でスキーマ非互換は無い。

## backlog task id

T-0021

---
_Generated by [Claude Code](https://claude.ai/code/session_01XusKhJr186BnQVQWKDavr3)_