### PR TITLE
ops: run #9 の記録をまとめ、ダッシュボードを再生成する

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,34 @@
   "open": [],
   "merged": [
     {
+      "number": 92,
+      "title": "T-0021: coder-postgres を 17.5 → 17.10 に上げる",
+      "url": "https://github.com/hikuohiku/homelab/pull/92",
+      "mergedAt": "2026-08-04T21:37:02Z",
+      "headRefName": "autopilot/t-0021-coder-postgres-patch"
+    },
+    {
+      "number": 91,
+      "title": "T-0020: busybox を 1.37 → 1.38.0 に上げる",
+      "url": "https://github.com/hikuohiku/homelab/pull/91",
+      "mergedAt": "2026-08-04T21:34:45Z",
+      "headRefName": "autopilot/t-0020-busybox-patch"
+    },
+    {
+      "number": 90,
+      "title": "T-0019: immich の valkey を 9.1-alpine → 9.1.1-alpine に上げる",
+      "url": "https://github.com/hikuohiku/homelab/pull/90",
+      "mergedAt": "2026-08-04T21:32:13Z",
+      "headRefName": "autopilot/t-0019-immich-valkey-patch"
+    },
+    {
+      "number": 89,
+      "title": "T-0016: ダッシュボードの PR 一覧を gh CLI 非依存にする",
+      "url": "https://github.com/hikuohiku/homelab/pull/89",
+      "mergedAt": "2026-08-04T21:29:16Z",
+      "headRefName": "autopilot/t-0016-dashboard-pr-list-mcp"
+    },
+    {
       "number": 88,
       "title": "T-0035: ops/dashboard/index.html を Git 管理から外す",
       "url": "https://github.com/hikuohiku/homelab/pull/88",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -263,4 +263,8 @@
   17 系メジャー内の最新パッチと確認（マイナー内なのでデータ移行不要）。coder は autopilot 自身の開発環境を
   ホストしているため注意して進めたが、17.x のマイナー更新でスキーマ非互換は無い前提
 - ここで一区切り。優先度 14（T-0019〜T-0021）を全て完遂。次の起動へ: backlog の todo で優先度が低いのは
-  T-0016（priority 13, 完遂済み）の次は T-0022（priority 16, immich chart 0.12.0→0.13.1, medium risk）
+  T-0022（priority 16, immich chart 0.12.0→0.13.1, medium risk）。T-0024/T-0025（tailscale, high risk）は
+  組み合わせを決めてから着手。T-0026〜T-0028（external-secrets/immich/argo-cd のメジャー更新, high risk）は
+  リリースノート全読みが必要
+- run #9 のまとめ: 5 PR（#88〜#92）を直列でマージまで見届けた。プロセス上の教訓（issue #56 の未読フィードバック
+  取りこぼし）を仕組み（CHARTER §6）に落とし、`ops/dashboard/index.html` の恒常的な衝突源を構造的に解消（T-0035）できたのが今回の主な成果。ops/dashboard/prs.json も最新化（45 件の merged PR、open 0 件）

--- a/ops/state.json
+++ b/ops/state.json
@@ -94,6 +94,14 @@
       "by": "cloud routine",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0033（conflict marker 検出、#84）・T-0008（nix flake check を CI に追加、#85）・T-0009（weekly-maintenance と CHARTER の役割分担、#86）を完遂。続けて T-0013（PBS バックアップ体制の調査）を完遂し docs/backup.md を作成。実機確認が要る点は T-0034（needs-human）として切り出し、T-0029 の blocked_by を張り替えた",
       "prs": [84, 85, 86, 87]
+    },
+    {
+      "n": 9,
+      "at": "2026-08-04T21:37:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "run #8 の journal が『issue #56 に未読フィードバックなし』と誤記していたのを発見（実際は 2 件あり、目視比較での取りこぼし）。CHARTER §6 に機械的な洗い出しを追記し、2 件を反映: ops/dashboard/index.html を Git 管理から外す（T-0035, #88。直列化後も他の主体との衝突が続いていたため）、workflows/ruleset の権限非対称を記録（§5.2）。続けて T-0016（ダッシュボードの PR 一覧を gh CLI 非依存にする、#89）を完遂し、起動のたびに mcp__github__list_pull_requests でキャッシュを最新化する手順を確立。優先度 14 の patch 更新 3 件 T-0019/T-0020/T-0021（immich valkey・busybox・coder-postgres、#90/#91/#92）を完遂。副産物として WebFetch が curl の 403 を回避できるケース（hub.docker.com）と mcp__github__list_pull_requests の merged フィールドの不具合を発見し CHARTER に記録",
+      "prs": [88, 89, 90, 91, 92]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

- `ops/state.json` に run #9 の記録を追加（#88〜#92）
- `ops/dashboard/prs.json` を最新化（45 件の merged PR、open 0 件）
- `ops/journal/2026-08.md` に run #9 のまとめを追記

内容はコード上の論点を含まない運用記録の更新のみです（CHARTER §4 の相乗り例外）。

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 実行成功
- `python3 ops/check_version_sync.py` → ok

## ロールバック手順

このコミットを revert すれば記録は元に戻る。実インフラには影響しない。

## backlog task id

なし（運用記録のみ）

---
_Generated by [Claude Code](https://claude.ai/code/session_01XusKhJr186BnQVQWKDavr3)_