### PR TITLE
T-0022: immich Helm chart を 0.12.0 → 0.13.1 に上げる

### DIFF
--- a/apps/immich/kustomization.yaml
+++ b/apps/immich/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 helmCharts:
   - name: immich
     repo: oci://ghcr.io/immich-app/immich-charts
-    version: 0.12.0
+    version: 0.13.1
     releaseName: immich
     namespace: immich
     valuesFile: values.yaml

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -372,13 +372,14 @@
       "title": "immich Helm chart を 0.12.0 → 0.13.1 に上げる（アプリのバージョンは変えない）",
       "kind": "upgrade",
       "risk": "medium",
-      "status": "todo",
+      "status": "done",
       "priority": 16,
       "why": "T-0005 の調査 (run #6) で判明。chart 側は 0.12.1 でデフォルトの immich app バージョンを v3.0.0 に、0.13.0 で release-please + OCI 配布 + cosign 署名に変更している。ただし repo は apps/immich/values.yaml で image タグを明示的に上書きしているため、chart の default 変更自体は影響しないはず（要確認）",
       "dod": "apps/immich/kustomization.yaml の chart version が 0.13.1。テンプレート構造の変更（values の形が変わっていないか）を diff で確認し、immich-server/immich-machine-learning の実際のバージョンは T-0021 とは独立に変わらないことを確かめる",
       "refs": ["apps/immich/kustomization.yaml", "ops/inventory.json"],
       "created": "2026-08-04",
-      "pr": null
+      "pr": 95,
+      "notes": "run #10: subagent が 0.12.0→0.13.1 の全リリース(0.12.1/0.13.0/0.13.1)を原文確認。0.12.1 のデフォルト appVersion 変更は image.tag 明示上書きのため無関係、0.12.1 の CNPG/Database CRD 移行は postgresql.* values を使っていないため無関係、0.13.0 の values.schema.json 追加はコメント整理のみで構造変更なし、OCI push 先も oci://ghcr.io/immich-app/immich-charts のまま。values.yaml の4つの上書きブロックは全て構造一致を確認済みのため、apps/immich/values.yaml への追随修正は不要と判断した"
     },
     {
       "id": "T-0023",

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -40,7 +40,7 @@
       "id": "immich-chart",
       "kind": "helm",
       "name": "immich (OCI)",
-      "current": "0.12.0",
+      "current": "0.13.1",
       "file": "apps/immich/kustomization.yaml",
       "match": "version:",
       "upstream": "github:immich-app/immich-charts",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -275,4 +275,8 @@
 - 読んだフィードバック: issue #56 の未読コメント 1 件（21:38:00, coder-postgres 更新(#92) のレビュー）。
   「到達性を失いうる変更」は homelab へのアクセスだけでなく、自分や人間がこの homelab を観測・操作する経路
   自身（Coder、GitHub Actions を含む）も指すべきという指摘。CHARTER §4 の共通ルールに risk 区分と独立の
-  チェック項目として追記し、high risk の「到達性を失いうる変更」の定義も明確化した
+  チェック項目として追記し、high risk の「到達性を失いうる変更」の定義も明確化した（#94, merged）
+- #94 merge を確認後、続けて T-0022（immich Helm chart 0.12.0 → 0.13.1）に着手・完遂。subagent に
+  0.12.1/0.13.0/0.13.1 の全リリースノートと values.yaml の差分検証を投げ、この repo が使う4つの values
+  上書きブロック（controllers.main / immich.persistence.library / valkey.* / server.* / machine-learning.*）
+  が構造的に不変であることを確認してから version のみ更新した


### PR DESCRIPTION
## 変更点

`apps/immich/kustomization.yaml` の immich Helm chart version を `0.12.0` → `0.13.1` に上げた。**アプリ本体（immich server / machine-learning）のバージョンは変わらない**（`apps/immich/values.yaml` で `v2.6.3` を明示的に固定しているため）。`ops/inventory.json` の `immich-chart` current も更新。

## 検証したこと

0.12.1 / 0.13.0 / 0.13.1 のリリースノートを原文で確認し、以下を確認した。

- 0.12.1: デフォルトの immich app バージョンを v3.0.0 に変更しているが、`image.tag` を明示上書きしているため無関係。CNPG/Database CRD への移行は `postgresql.*` values を使っていない（このリポジトリは Postgres を chart 外で管理）ため無関係
- 0.13.0: `values.schema.json` の追加はコメント整理のみで構造変更なし。配布方式を release-please + OCI + cosign 署名に変更しているが、push 先は従来どおり `oci://ghcr.io/immich-app/immich-charts`（このリポジトリの参照方式と一致）
- 0.13.1: ArtifactHub アノテーションのクォート修正のみ

`apps/immich/values.yaml` が上書きしている4つのブロック（`controllers.main` / `immich.persistence.library` / `valkey.*` / `server.*` / `machine-learning.*`）は 0.12.0 と 0.13.1 で構造的に同一であることを diff で確認済み。そのため `values.yaml` 側の追随修正は不要と判断した。

## ロールバック手順

`apps/immich/kustomization.yaml` の `version` を `0.12.0` に戻し、`ops/inventory.json` の `immich-chart` current も戻す。ArgoCD が追随して再同期する。アプリのイメージタグは変えていないため、アプリ側のデータ影響は無い。

## backlog task id

T-0022

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9bMe49dzHqVebfS9xCHvQ)_