### PR TITLE
ci: apps/ render の意図しないオブジェクト削除を検出するジョブを追加 (T-0036)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,43 @@ jobs:
           print("all yaml parses")
           PY
 
+  manifest-diff:
+    name: manifest deletion guard
+    # apps root Application は prune: true。render 結果からオブジェクトが消えると
+    # 次の sync でクラスタからも消える（PVC ならデータごと）。base/head の render を
+    # 比較し、消えたオブジェクトが PR 本文で明示的に許可されていなければ落とす
+    # （ops/check_manifest_deletions.py, issue #56 2026-08-04 22:04:42）。
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: head
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      - name: Install kustomize
+        run: |
+          set -euo pipefail
+          curl -sSfL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.8.1/kustomize_v5.8.1_linux_amd64.tar.gz \
+            | tar -xz -C /usr/local/bin kustomize
+          kustomize version
+
+      - name: Check for unexplained object deletions
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$PR_BODY" > /tmp/pr_body.txt
+          python3 head/ops/check_manifest_deletions.py base head /tmp/pr_body.txt
+
   terraform:
     name: terraform validate
     runs-on: ubuntu-latest

--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -165,6 +165,13 @@ high に該当するのは、失敗したときに元へ戻せないもの。**�
 - 上流の最新＝最善ではない。既知の不具合（例: vaultwarden 1.37.0 の alpine ビルド破損）を踏まない
 - 1 PR で 1 コンポーネント。まとめて上げない
 - 二重管理されている pin（`ops/inventory.json` の `mirrors`）は同じ PR で全部揃える
+- **CI (`manifest-diff` job) が `apps/` の render 結果からオブジェクトが消えていないかを機械的に検証する**
+  （`ops/check_manifest_deletions.py`, T-0036）。apps root Application は `prune: true` なので、
+  chart 更新で PVC 名や `metadata.name` が変わると次の sync でクラスタから消える。これまでは
+  chart 更新のたびに人間（構築セッション）が手で render 差分を確認していた（#95 のレビュー）。
+  意図的にオブジェクトを消す PR では本文に `allow-delete: <Kind>/<namespace>/<name>` を明記する。
+  **この検証は「データを失いうる変更」の判断材料の 1 つであって、バックアップの健全性確認の代わりにはならない**
+  （T-0029/T-0023 のように DB のメジャー更新でスキーマが壊れるケースは render の差分には出ない）
 
 ---
 

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 36,
-  "updated": "2026-08-04T22:12:00Z",
+  "next_id": 37,
+  "updated": "2026-08-04T22:20:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -319,7 +319,10 @@
       "priority": 14,
       "why": "T-0005 の調査 (run #6) で判明。patch バージョン、リリースノートに特筆事項なし",
       "dod": "apps/dex/kustomization.yaml の version が 0.24.1。ops/inventory.json の dex-chart current も更新",
-      "refs": ["apps/dex/kustomization.yaml", "ops/inventory.json"],
+      "refs": [
+        "apps/dex/kustomization.yaml",
+        "ops/inventory.json"
+      ],
       "created": "2026-08-04",
       "pr": 79,
       "notes": "run #6: raw.githubusercontent.com 経由で Chart.yaml を確認し、0.24.0→0.24.1 は appVersion 2.44.0 のまま（dex 本体は不変、chart のパッケージング変更のみ）と確認した上で更新"
@@ -334,7 +337,10 @@
       "priority": 14,
       "why": "T-0005 の調査 (run #6) で判明。patch バージョン",
       "dod": "apps/immich/values.yaml の valkey タグが 9.1.1-alpine。ops/inventory.json の immich-valkey current も更新",
-      "refs": ["apps/immich/values.yaml", "ops/inventory.json"],
+      "refs": [
+        "apps/immich/values.yaml",
+        "ops/inventory.json"
+      ],
       "created": "2026-08-04",
       "pr": 90,
       "notes": "run #9: WebFetch で hub.docker.com のタグ一覧を確認（curl は docker hub への直接 HTTPS が組織 egress ポリシーで 403、WebFetch は別経路で到達できた）。9.1.1-alpine が 9.1 系の最新パッチと確認して更新"
@@ -349,7 +355,12 @@
       "priority": 14,
       "why": "T-0005 の調査 (run #6) で判明。3 箇所とも chown のみの initContainer（T-0003 参照）で busybox 固有機能に依存していない",
       "dod": "apps/vaultwarden/deployment.yaml, apps/coder/postgres.yaml, apps/immich/postgres.yaml の busybox タグが 3 箇所とも 1.38.0。ops/inventory.json の busybox current も更新",
-      "refs": ["apps/vaultwarden/deployment.yaml", "apps/coder/postgres.yaml", "apps/immich/postgres.yaml", "ops/inventory.json"],
+      "refs": [
+        "apps/vaultwarden/deployment.yaml",
+        "apps/coder/postgres.yaml",
+        "apps/immich/postgres.yaml",
+        "ops/inventory.json"
+      ],
       "created": "2026-08-04",
       "pr": 91,
       "notes": "run #9: WebFetch で hub.docker.com のタグ一覧を確認し 1.38.0 が最新と確認して 3 箇所とも更新"
@@ -364,7 +375,10 @@
       "priority": 14,
       "why": "T-0005 の調査 (run #6) で判明。16 系メジャー内の patch 5 つ分。postgres 18 系メジャー更新はデータ移行が要るため対象外（人間へ）",
       "dod": "apps/coder/postgres.yaml の postgres イメージタグが 17.10。ops/inventory.json の coder-postgres current も更新",
-      "refs": ["apps/coder/postgres.yaml", "ops/inventory.json"],
+      "refs": [
+        "apps/coder/postgres.yaml",
+        "ops/inventory.json"
+      ],
       "created": "2026-08-04",
       "pr": 92,
       "notes": "run #9: WebFetch で hub.docker.com のタグ一覧を確認し 17.10 が 17 系メジャー内の最新パッチと確認して更新。17.x マイナー内のためデータ移行は不要"
@@ -379,7 +393,10 @@
       "priority": 16,
       "why": "T-0005 の調査 (run #6) で判明。chart 側は 0.12.1 でデフォルトの immich app バージョンを v3.0.0 に、0.13.0 で release-please + OCI 配布 + cosign 署名に変更している。ただし repo は apps/immich/values.yaml で image タグを明示的に上書きしているため、chart の default 変更自体は影響しないはず（要確認）",
       "dod": "apps/immich/kustomization.yaml の chart version が 0.13.1。テンプレート構造の変更（values の形が変わっていないか）を diff で確認し、immich-server/immich-machine-learning の実際のバージョンは T-0021 とは独立に変わらないことを確かめる",
-      "refs": ["apps/immich/kustomization.yaml", "ops/inventory.json"],
+      "refs": [
+        "apps/immich/kustomization.yaml",
+        "ops/inventory.json"
+      ],
       "created": "2026-08-04",
       "pr": 95,
       "notes": "run #10: subagent が 0.12.0→0.13.1 の全リリース(0.12.1/0.13.0/0.13.1)を原文確認。0.12.1 のデフォルト appVersion 変更は image.tag 明示上書きのため無関係、0.12.1 の CNPG/Database CRD 移行は postgresql.* values を使っていないため無関係、0.13.0 の values.schema.json 追加はコメント整理のみで構造変更なし、OCI push 先も oci://ghcr.io/immich-app/immich-charts のまま。values.yaml の4つの上書きブロックは全て構造一致を確認済みのため、apps/immich/values.yaml への追随修正は不要と判断した"
@@ -395,7 +412,11 @@
       "why": "T-0005 の調査 (run #6) で判明。stable チャンネルの最新は v2.35.3。mainline の v2.36.0 は OAuth2 動的クライアント登録・login-type 非推奨化・chat model 設定の DB スキーマ変更など breaking change を含むため避ける。coder は autopilot 自身の開発環境をホストしている（ops/inventory.json のコメント）ため、更新に失敗すると足場を失うリスクがある点に注意。run #10 の subagent 調査で risk を medium → high に見直した: v2.34.7→v2.35.3 は実質マイナー1本分（約650コミット）で、`coder server` は起動時に DB migration を自動適用するが coder は down-migration を提供しないため、失敗時のロールバックはイメージタグを戻すだけでは不十分で Postgres のバックアップ復元が必要になる。coder-postgres は immich-postgres と同じく local-path で node01 のディスク上に直接あり（docs/backup.md）、バックアップの存在・復元手順は T-0034（needs-human）が解決するまで未確認。CHARTER §4『データを失いうる変更』に該当するため T-0029 と同様に着手を見送る。加えて v2.35.0/2.35.1 で X-Forwarded-Host の信頼元を CODER_PROXY_TRUSTED_ORIGINS で絞る変更が入っており、Tailscale 経由アクセス（CODER_ACCESS_URL）への影響が未検証",
       "dod": "T-0034 でバックアップの存在・復元手順が確認されてから着手する。apps/coder/deployment.yaml のイメージタグが v2.35.3。ops/inventory.json の current も更新。CODER_PROXY_TRUSTED_ORIGINS の要否を確認し、必要なら合わせて設定する。更新後に coder の Pod が正常に起動することを CI もしくは次回起動での間接確認で追う（このクラウド実行からは k8s に到達できないため、ArgoCD 側の反映確認は現状できない— T-0015 が解決すれば可能になる）",
       "blocked_by": "T-0034（PBS バックアップジョブの実機確認、needs-human）が終わっておらず、coder-postgres のバックアップ健全性が未確認のため着手しない",
-      "refs": ["apps/coder/deployment.yaml", "ops/inventory.json", "docs/backup.md"],
+      "refs": [
+        "apps/coder/deployment.yaml",
+        "ops/inventory.json",
+        "docs/backup.md"
+      ],
       "created": "2026-08-04",
       "pr": null
     },
@@ -409,7 +430,10 @@
       "priority": 18,
       "why": "T-0005 の調査 (run #6) で判明、正確な最新版は issue #56 (2026-08-04 20:20:15) のフィードバックで確定。operator chart の最新は 1.98.9（公開版: 1.98.9/1.98.4/1.98.3/1.96.5/1.94.2/1.94.1/1.92.5/1.92.4/1.92.3/1.90.9）。tailscale 本体の最新 stable は v1.102.1 だが chart は本体より遅れて出るため 1.98.9 が上限。同フィードバックで T-0025（k8s-nameserver を unstable-v1.103.54 へ）と揃えずに進めると operator と nameserver のバージョンが乖離すると指摘されている",
       "dod": "1.90.9 から 1.98.9 までのリリースノートを原文で読み breaking change を洗い出す。apps/tailscale-operator/kustomization.yaml の version を更新し、ops/inventory.json の current も更新。CHARTER §4 の『到達性を失いうる変更』の手順（復旧手順を PR に書く）に従う。T-0025 と同一 PR にする必要はないが、着手順序と組み合わせ（同時に揃えるか、operator → nameserver の順で刻むか）を先に決めてから着手する",
-      "refs": ["apps/tailscale-operator/kustomization.yaml", "ops/inventory.json"],
+      "refs": [
+        "apps/tailscale-operator/kustomization.yaml",
+        "ops/inventory.json"
+      ],
       "created": "2026-08-04",
       "pr": null,
       "notes": "run #7: 正確な最新版が判明したため blocked_by を解除。ただし risk=high の到達性変更であり、T-0025 との組み合わせ検討が先に必要なため todo のまま（着手は次回以降）"
@@ -424,7 +448,10 @@
       "priority": 18,
       "why": "T-0005 の調査 (run #6)。ghcr.io の tags API を直接叩いて確認済み（T-0001 と同じ手法）で unstable-v1.103.54 まで存在するが、issue #56 (2026-08-04 20:20:15) のフィードバックにより T-0024（operator chart は 1.98.9 が上限）と揃えるべきと判明。unstable-v1.103.54 まで進めると operator（1.98.9 系相当）と nameserver のバージョンが乖離する。unstable タグを追い続ける前提も見直し、stable 系タグが取れないか確認する",
       "dod": "k8s-nameserver に stable 系タグがあるか ghcr.io の tags API で確認する。無ければ operator chart (1.98.9 相当) と揃うバージョンの unstable タグを選ぶ。apps/tailscale-operator/dns-config.yaml のタグを更新、ops/inventory.json の current も更新。CHARTER §4 の到達性変更の手順（復旧手順を PR に明記）に従う。digest も合わせて確認する（T-0001 のやり方を踏襲）。T-0024 との着手順序を決めてから着手する",
-      "refs": ["apps/tailscale-operator/dns-config.yaml", "ops/inventory.json"],
+      "refs": [
+        "apps/tailscale-operator/dns-config.yaml",
+        "ops/inventory.json"
+      ],
       "created": "2026-08-04",
       "pr": null,
       "notes": "run #7: issue #56 のフィードバックを受け、T-0024 と組み合わせ・順序を揃える前提に変更"
@@ -439,7 +466,10 @@
       "priority": 20,
       "why": "T-0005 の調査 (run #6) で判明。1.1.1 → 2.8.0 は大きなメジャー更新の飛び。External Secrets Operator は secrets/ の実体を supply する基盤なので、壊れると全アプリのシークレット取得が止まりうる",
       "dod": "1.1.1 から 2.8.0 までの全リリースノートを原文で読み、breaking change を洗い出す。CHARTER §4『メジャーバージョン更新』の手順に従い 1 PR 1 コンポーネントで刻む（必要なら 1.x の最終版などの中間ステップに分割する）。apps/external-secrets/kustomization.yaml の version、ops/inventory.json の current を更新",
-      "refs": ["apps/external-secrets/kustomization.yaml", "ops/inventory.json"],
+      "refs": [
+        "apps/external-secrets/kustomization.yaml",
+        "ops/inventory.json"
+      ],
       "created": "2026-08-04",
       "pr": null
     },
@@ -453,7 +483,10 @@
       "priority": 20,
       "why": "T-0005 の調査 (run #6) で判明。v3.0.0 で non-destructive editing・Workflows・バックグラウンドバックアップ変更・HLS トランスコーディングなど大きな変更がある。immich-server と immich-machine-learning は必ず同一バージョンで揃える（ops/inventory.json の mirrors）",
       "dod": "v2.6.3 から v3.1.0 までの全リリースノートを原文で読み、DB マイグレーションや設定変更の要否を洗い出す。apps/immich/values.yaml の server / machine-learning 両方のタグを同時に v3.1.0 へ更新し、ops/inventory.json の current も両方更新",
-      "refs": ["apps/immich/values.yaml", "ops/inventory.json"],
+      "refs": [
+        "apps/immich/values.yaml",
+        "ops/inventory.json"
+      ],
       "created": "2026-08-04",
       "pr": null
     },
@@ -467,7 +500,11 @@
       "priority": 19,
       "why": "T-0005 の調査 (run #6) で判明。9→10 で server.additionalApplications/additionalProjects が別 chart (argocd-apps) に分離、redis-ha の selector-label immutability により手動 Pod 削除が必要になる場合があるなど breaking change を含む。ArgoCD 自身なので壊れると全アプリのデプロイ経路が止まる（ops/inventory.json の policy=manual の理由そのもの）",
       "dod": "9.1.6 から 10.2.3 までの全リリースノートを原文で読む。apps/argocd/kustomization.yaml と nix/images/proxmox-cloud/k3s-manifests.nix（T-0002 の二重管理、ops/check_version_sync.py が同時更新を検証する）の両方を同時に更新。CHARTER §4『到達性を失いうる変更（ArgoCD 自身）』の手順に従い、壊れたときの復旧手順を PR に明記する。policy=manual のため実装は用意できても最終判断は人間に委ねる必要があるか、この時点で再検討する",
-      "refs": ["apps/argocd/kustomization.yaml", "nix/images/proxmox-cloud/k3s-manifests.nix", "ops/inventory.json"],
+      "refs": [
+        "apps/argocd/kustomization.yaml",
+        "nix/images/proxmox-cloud/k3s-manifests.nix",
+        "ops/inventory.json"
+      ],
       "created": "2026-08-04",
       "pr": null
     },
@@ -482,7 +519,10 @@
       "why": "T-0005 の調査 (run #6) で判明。postgres 本体は 16.9→16.14 の minor で問題ないが、vchord 拡張が 0.4.3→1.1.1 とメジャー相当の飛びで、ベクタ DB の実データに影響しうる（ops/inventory.json の policy=manual の理由）",
       "dod": "vchord 0.4→1.x の互換性・移行手順を確認する。CHARTER §4『データを失いうる変更』の手順どおり、着手前に immich のバックアップが実際に存在し復元できることを確認する",
       "blocked_by": "T-0034（PBS バックアップジョブの実機確認、needs-human）が終わっておらず、バックアップの健全性が未確認のため着手しない",
-      "refs": ["apps/immich/postgres.yaml", "ops/inventory.json"],
+      "refs": [
+        "apps/immich/postgres.yaml",
+        "ops/inventory.json"
+      ],
       "created": "2026-08-04",
       "pr": null
     },
@@ -496,7 +536,9 @@
       "priority": 25,
       "why": "T-0005 の調査 (run #6) で判明。約 22 リリース分の差。意図的な完全一致 pin（理由コメントあり）なので、まず pin した理由が今も成り立つか確認するのが先。v0.109.0 のリリースノートに VM agent の IP 待機設定まわりの breaking change の言及がある",
       "dod": "providers.tf の pin 理由コメントを再確認し、今も成り立つか判断する。上げる場合は 0.89.1 から v0.111.1 までのリリースノートを原文で読み、breaking change を洗い出す。terraform apply は autopilot が実行できないため、実際の反映は人間の作業になる旨を PR に明記する",
-      "refs": ["terraform/proxmox/providers.tf"],
+      "refs": [
+        "terraform/proxmox/providers.tf"
+      ],
       "created": "2026-08-04",
       "pr": null
     },
@@ -510,7 +552,10 @@
       "priority": 22,
       "why": "Maintenance.md 2026-08-03 の持ち越し。icon 取得のタイムアウトが多発しているが実害は無いと記録されている。ログを埋めるだけなら無効化する価値がある",
       "dod": "現状のログ頻度と実害の有無を確認する。無害だが頻発してログを埋めているなら DISABLE_ICON_DOWNLOAD=true を設定する。実害があるなら原因（Tailscale プロキシ経由のアウトバウンド到達性など）を調べて対処する",
-      "refs": ["Maintenance.md", "apps/vaultwarden/"],
+      "refs": [
+        "Maintenance.md",
+        "apps/vaultwarden/"
+      ],
       "created": "2026-08-04",
       "pr": null
     },
@@ -524,7 +569,10 @@
       "priority": 22,
       "why": "Maintenance.md 2026-08-03 の持ち越し。1.37.0 で追加されたレート制限は送信元 IP 単位。全クライアントが Tailscale プロキシ経由で同一 IP に見えるため、正規クライアントが 429 で弾かれていないか未確認",
       "dod": "ログまたはクライアントの実際の挙動から 429 が発生していないか確認する。発生していれば ROCKET_LIMIT_* 系の設定調整か、送信元判定の見直しを検討する。発生していなければ Maintenance.md に確認済みと記録する",
-      "refs": ["Maintenance.md", "apps/vaultwarden/"],
+      "refs": [
+        "Maintenance.md",
+        "apps/vaultwarden/"
+      ],
       "created": "2026-08-04",
       "pr": null
     },
@@ -556,7 +604,9 @@
       "priority": 8,
       "why": "run #7 で origin/main が同時進行中の別 run に進んでいたため rebase で journal のコンフリクトを手で解消したが、末尾の `>>>>>>> ...` マーカー行を消し忘れたまま push・CI green・merge まで通ってしまった（#80）。ops/validate.py も kustomize build も markdown の中身までは見ないため検出できなかった",
       "dod": "ops/ 配下（少なくとも journal/*.md, *.json, *.md 全般）を conflict marker（行頭 `<<<<<<<` / `=======` / `>>>>>>>`）でスキャンし、見つかれば error にする。次に同じミスをしたら CI が落ちること",
-      "refs": ["ops/validate.py"],
+      "refs": [
+        "ops/validate.py"
+      ],
       "created": "2026-08-04",
       "pr": 84,
       "notes": "run #8: ops/validate.py に check_conflict_markers() を追加（.md / .json を対象、行頭一致）。わざと journal にコンフリクトマーカーを混ぜて 3 件検出 → 復元後 0 error に戻ることを手元で確認してから PR を出した（#56 の教訓『検出器はわざと壊して確かめる』を踏襲）"
@@ -571,10 +621,33 @@
       "priority": 8,
       "why": "issue #56 (2026-08-04 20:54:53) の指摘。直列化（run #6 の対処）は autopilot 自身の中でしか効かず、構築セッションなど他の主体が触る PR（#82/#83）とは依然として index.html で衝突した。build.py の生成物であり ops/*.json + journal から決定的に再生成できるので、そもそも Git 管理する理由が無い",
       "dod": "ops/dashboard/index.html が .gitignore 対象になり追跡から外れる。CI (ops job) が build.py の実行成功を検証する。CHARTER §4/§7.1 の記述を更新する",
-      "refs": ["ops/dashboard/index.html", ".gitignore", ".github/workflows/ci.yml", "ops/CHARTER.md"],
+      "refs": [
+        "ops/dashboard/index.html",
+        ".gitignore",
+        ".github/workflows/ci.yml",
+        "ops/CHARTER.md"
+      ],
       "created": "2026-08-04",
       "pr": 88,
       "notes": "run #9: git rm --cached で追跡除外、.gitignore に追加。CI の ops job に `python3 ops/dashboard/build.py` の実行成功チェックを追加。CHARTER §4 の相乗り例外リストと §7.1 を更新"
+    },
+    {
+      "id": "T-0036",
+      "domain": "homelab",
+      "title": "CI に kustomize render のオブジェクト削除検出ジョブを追加する（prune: true の安全網）",
+      "kind": "ci",
+      "risk": "low",
+      "status": "done",
+      "priority": 15,
+      "why": "apps root Application は syncPolicy.automated.prune: true。kustomize build --enable-helm の出力からオブジェクトが消えると次の sync でクラスタからも消え、PVC ならデータごと失われる。この検証は今まで人間（構築セッション）が chart 更新のたびに手で差分を取って確認していた（#95 のレビュー、issue #56 2026-08-04 22:04:42）。T-0026〜T-0029 の high risk メジャー更新はこの網が無いと安全に判断できない",
+      "dod": "PR の base/head 両方で全 kustomization.yaml を render し、消えたオブジェクトがあれば CI が落ちる。PR 本文に allow-delete: <Kind>/<namespace>/<name> の明示がある場合のみ許可する。わざとオブジェクトを消して落ちることを確認する",
+      "refs": [
+        "ops/check_manifest_deletions.py",
+        ".github/workflows/ci.yml"
+      ],
+      "created": "2026-08-04",
+      "pr": null,
+      "notes": "run #11: issue #56 のフィードバック(22:04:42)を反映して起票・即着手。ops/check_manifest_deletions.py を作成し、find_kustomization_dirs/parse_allowed/diff_and_check の純粋ロジックはサンドボックス上で python3 単体テスト済み（kustomize/helm が無いため render 自体はローカル検証できず CI 任せ、CHARTER §5.2）。CI に manifest-diff job を追加。ruleset の必須チェックへの追加は自分からはできないため、PR本文と issue #56 で構築セッションに依頼する"
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -646,7 +646,7 @@
         ".github/workflows/ci.yml"
       ],
       "created": "2026-08-04",
-      "pr": null,
+      "pr": 98,
       "notes": "run #11: issue #56 のフィードバック(22:04:42)を反映して起票・即着手。ops/check_manifest_deletions.py を作成し、find_kustomization_dirs/parse_allowed/diff_and_check の純粋ロジックはサンドボックス上で python3 単体テスト済み（kustomize/helm が無いため render 自体はローカル検証できず CI 任せ、CHARTER §5.2）。CI に manifest-diff job を追加。ruleset の必須チェックへの追加は自分からはできないため、PR本文と issue #56 で構築セッションに依頼する"
     }
   ]

--- a/ops/check_manifest_deletions.py
+++ b/ops/check_manifest_deletions.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""apps/ root Application は syncPolicy.automated.prune: true で動いている。
+つまり `kustomize build --enable-helm` の出力からオブジェクトが消えると、
+次の ArgoCD sync でクラスタからも消える（PVC ならバックエンドの実データも道連れ）。
+
+このスクリプトは PR の base と head、両方の worktree で全 kustomization.yaml を
+render し、(kind, namespace, name) の集合を比較する。head 側で消えているものが
+あれば、PR 本文に明示的な `allow-delete:` 行が無い限り失敗する（fail-closed）。
+
+CI (manifest-diff job) から呼ぶ。標準ライブラリではなく PyYAML を使う
+（.github/workflows/ci.yml の他ジョブも同様に ubuntu-latest 同梱の PyYAML に依存している。
+このチェックは kustomize/helm が無いと render 自体ができず、autopilot のサンドボックスでは
+そもそも手元検証できないため、stdlib のみに絞る意味が無い）。
+
+意図的にオブジェクトを消す PR では、本文に次の形式で許可を書く:
+    allow-delete: <Kind>/<namespace-or-->/<name>
+例: allow-delete: PersistentVolumeClaim/immich/immich-library
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML missing")
+
+ALLOW_RE = re.compile(r"^allow-delete:\s*(\S+)/(\S+)/(\S+)\s*$", re.MULTILINE)
+
+
+def find_kustomization_dirs(root: Path) -> list[str]:
+    """apps/ 配下の kustomization.yaml を持つディレクトリを、repo root からの
+    相対パスで返す（root をまたいで base/head を比較できるようにするため）。"""
+    apps = root / "apps"
+    if not apps.exists():
+        return []
+    dirs = sorted(p.parent.relative_to(root).as_posix() for p in apps.rglob("kustomization.yaml"))
+    return dirs
+
+
+def render_objects(root: Path, rel_dir: str) -> set[tuple[str, str, str]]:
+    """1 つの kustomization ディレクトリを render し、(kind, namespace, name) の集合を返す。
+    render に失敗したら例外を投げて呼び出し元で fail-closed に倒す。"""
+    d = root / rel_dir
+    result = subprocess.run(
+        ["kustomize", "build", "--enable-helm", str(d)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"kustomize build --enable-helm {d} failed:\n{result.stderr}")
+
+    objects: set[tuple[str, str, str]] = set()
+    for doc in yaml.safe_load_all(result.stdout):
+        if not doc or "kind" not in doc:
+            continue
+        metadata = doc.get("metadata") or {}
+        name = metadata.get("name")
+        if not name:
+            continue
+        namespace = metadata.get("namespace") or "-"
+        objects.add((doc["kind"], namespace, name))
+    return objects
+
+
+def render_all(root: Path, dirs: list[str]) -> dict[str, set[tuple[str, str, str]]]:
+    rendered = {}
+    for rel_dir in dirs:
+        if not (root / rel_dir).exists():
+            # このディレクトリは反対側の ref にしか存在しない（新規追加 or 完全削除）。
+            # 完全削除の場合でも、削除されたオブジェクトは反対側の render で捕捉される。
+            rendered[rel_dir] = set()
+            continue
+        rendered[rel_dir] = render_objects(root, rel_dir)
+    return rendered
+
+
+def parse_allowed(pr_body: str) -> set[tuple[str, str, str]]:
+    return {(k, ns, n) for k, ns, n in ALLOW_RE.findall(pr_body or "")}
+
+
+def diff_and_check(
+    base: dict[str, set[tuple[str, str, str]]],
+    head: dict[str, set[tuple[str, str, str]]],
+    allowed: set[tuple[str, str, str]],
+) -> list[str]:
+    """戻り値: 許可されていない削除の説明文リスト（空なら問題なし）"""
+    violations = []
+    all_dirs = sorted(set(base) | set(head))
+    for rel_dir in all_dirs:
+        removed = base.get(rel_dir, set()) - head.get(rel_dir, set())
+        for obj in sorted(removed):
+            if obj in allowed:
+                print(f"allowed deletion: {rel_dir}: {obj[0]}/{obj[1]}/{obj[2]}")
+                continue
+            violations.append(f"{rel_dir}: {obj[0]}/{obj[1]}/{obj[2]}")
+    return violations
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        sys.exit(f"usage: {sys.argv[0]} <base-worktree> <head-worktree> <pr-body-file|->")
+
+    base_root = Path(sys.argv[1]).resolve()
+    head_root = Path(sys.argv[2]).resolve()
+    body_arg = sys.argv[3]
+    pr_body = sys.stdin.read() if body_arg == "-" else Path(body_arg).read_text()
+
+    dirs = sorted(set(find_kustomization_dirs(base_root)) | set(find_kustomization_dirs(head_root)))
+
+    try:
+        base_objects = render_all(base_root, dirs)
+        head_objects = render_all(head_root, dirs)
+    except RuntimeError as e:
+        print(f"::error::{e}")
+        return 1
+
+    allowed = parse_allowed(pr_body)
+    violations = diff_and_check(base_objects, head_objects, allowed)
+
+    if violations:
+        print("::error::head で消えているオブジェクトがあります（apps root Application は prune: true）")
+        for v in violations:
+            print(f"::error::  {v}")
+        print(
+            "\n意図的な削除なら PR 本文に次の形式で明示してください:\n"
+            "  allow-delete: <Kind>/<namespace-or-->/<name>"
+        )
+        return 1
+
+    print("no unexplained object deletions")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -301,3 +301,17 @@
   更新）は調査の結果 risk を high に見直して blocked に変更（DB migration が不可逆でバックアップ未確認の
   ため T-0029 と同じ理由）、T-0012（自己振り返り）で PR 監視が webhook ベースでできることを発見し
   CHARTER に反映した。次回の自己振り返り（T-0012）は 2026-08-11 以降
+
+## 2026-08-04 22:20 UTC — run #11
+
+- 前回の中断確認: オープン PR・`autopilot/*` ブランチともに無し。中断なし
+- 読んだフィードバック: issue #56 の未読コメント 1 件（22:04:42, #95 immich chart 更新の事後検証）。
+  apps root Application が `prune: true` である以上、chart 更新で render 結果からオブジェクトが消えると
+  データごとクラスタから消えうるが、それを毎回確認していたのは人間（構築セッション）だけだったという指摘。
+  「CI にレンダリング結果の削除検出 job を足す」という提案を T-0036 として起票し、この起動内で即着手した
+- T-0036: `ops/check_manifest_deletions.py` を新規作成し、CI に `manifest-diff` job（PR の base/head を
+  render し `(kind, namespace, name)` 集合を比較、`allow-delete:` 行が無い削除は fail-closed）を追加。
+  純粋ロジック（ディレクトリ探索・allow-delete パース・差分判定）はサンドボックス上で python3 単体で
+  動作確認したが、`kustomize`/`helm` が無いため実際の render 経路は CI 任せ（#98, auto-merge 設定予定）。
+  CHARTER「バージョン更新の作法」にこの検証の位置づけ（DB スキーマ破壊などは検出できない、バックアップ
+  確認の代替にはならない）を明記した

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-04T22:10:23Z",
+  "updated": "2026-08-04T22:20:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-04T21:38:00Z"
+    "last_read": "2026-08-04T22:04:42Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -45,7 +45,9 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "issue #56 のフィードバックを反映し T-0014 起票。workflow の中身は書けたが GitHub App に workflows 権限が無く push 不可と判明、needs-human に変更",
-      "prs": [63]
+      "prs": [
+        63
+      ]
     },
     {
       "n": 3,
@@ -53,7 +55,10 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "T-0014 完遂（direct-push-guard.yml push、workflows 権限が実際に効くことを確認）。issue #56 の設計フィードバックを受け T-0010 を T-0015 に具体化（token 待ちで needs-human）。続けて T-0004（terraform lock の残骸除去）も完遂",
-      "prs": [67, 68]
+      "prs": [
+        67,
+        68
+      ]
     },
     {
       "n": 4,
@@ -61,7 +66,10 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "issue #56 の未読フィードバック（PR #67 のレビュー3点）を反映（PR #70, auto-merged）。gh CLI がこの環境に無いと判明し CHARTER を MCP ツール前提に修正。T-0001（tailscale k8s-nameserver の floating tag 固定）完遂。ダッシュボードの PR キャッシュ更新の仕組み不足を T-0016 として起票",
-      "prs": [70, 71]
+      "prs": [
+        70,
+        71
+      ]
     },
     {
       "n": 5,
@@ -69,7 +77,12 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "issue #56 の未読フィードバックを反映: このクラウドサンドボックスのツール有無を実測し CHARTER §5.2 として記録（terraform/kustomize は無い。run #0 の人間セッションとは環境が違う）。T-0002（argo-cd chart バージョン二重管理に CI 検出を追加）・T-0003（busybox バージョン統一）を完遂。途中 git checkout の事故があったが commit 前だったため復旧し、CHARTER に教訓を追記",
-      "prs": [73, 74, 75, 76]
+      "prs": [
+        73,
+        74,
+        75,
+        76
+      ]
     },
     {
       "n": 6,
@@ -77,7 +90,11 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "issue #56 の未読フィードバック 2 件（run #5 が last_read を進めずに終えたため残っていた）を反映。T-0017: check_version_sync.py の pyyaml 依存を除去し nix 側の抽出を brace 単位の構造依存に修正。CHARTER §2 に『複数タスクを扱う起動では前のタスクの PR が merge されるまで次のブランチを作らない』を追記（ops/ 記録が全タスク PR に相乗りするため並行 PR はコンフリクトする、run #5 の実例を踏まえた対処）。続けて T-0005（inventory.json 全対象の上流調査）を完遂し、14 個の個別更新タスク T-0018〜T-0030 を起票。さらに T-0018（dex chart patch 更新）を完遂",
-      "prs": [77, 78, 79]
+      "prs": [
+        77,
+        78,
+        79
+      ]
     },
     {
       "n": 7,
@@ -85,7 +102,10 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "run #6 とこの run が同時に走っていたことに気づき（作業中に origin/main が T-0018 の完了分だけ先行していた）、rebase で追従して journal/backlog/state の衝突を解消。issue #56 の未読フィードバック 2 件を反映し、tailscale-operator chart の確定情報(1.98.9)で T-0024 の blocked_by を解除、T-0025 と組み合わせる前提を追記。T-0006（Plans.md M2 のディスク要因解消の反映）・T-0007（Maintenance.md 持ち越し課題の backlog 取り込み、T-0031/T-0032 起票）を完遂。作業中に見つけた自分のミス（journal に git conflict marker を消し忘れたまま merge していた）を修正し、再発防止の CI 検出を T-0033 として起票",
-      "prs": [80, 81]
+      "prs": [
+        80,
+        81
+      ]
     },
     {
       "n": 8,
@@ -93,7 +113,12 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0033（conflict marker 検出、#84）・T-0008（nix flake check を CI に追加、#85）・T-0009（weekly-maintenance と CHARTER の役割分担、#86）を完遂。続けて T-0013（PBS バックアップ体制の調査）を完遂し docs/backup.md を作成。実機確認が要る点は T-0034（needs-human）として切り出し、T-0029 の blocked_by を張り替えた",
-      "prs": [84, 85, 86, 87]
+      "prs": [
+        84,
+        85,
+        86,
+        87
+      ]
     },
     {
       "n": 9,
@@ -101,7 +126,13 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "run #8 の journal が『issue #56 に未読フィードバックなし』と誤記していたのを発見（実際は 2 件あり、目視比較での取りこぼし）。CHARTER §6 に機械的な洗い出しを追記し、2 件を反映: ops/dashboard/index.html を Git 管理から外す（T-0035, #88。直列化後も他の主体との衝突が続いていたため）、workflows/ruleset の権限非対称を記録（§5.2）。続けて T-0016（ダッシュボードの PR 一覧を gh CLI 非依存にする、#89）を完遂し、起動のたびに mcp__github__list_pull_requests でキャッシュを最新化する手順を確立。優先度 14 の patch 更新 3 件 T-0019/T-0020/T-0021（immich valkey・busybox・coder-postgres、#90/#91/#92）を完遂。副産物として WebFetch が curl の 403 を回避できるケース（hub.docker.com）と mcp__github__list_pull_requests の merged フィールドの不具合を発見し CHARTER に記録",
-      "prs": [88, 89, 90, 91, 92]
+      "prs": [
+        88,
+        89,
+        90,
+        91,
+        92
+      ]
     },
     {
       "n": 10,
@@ -109,7 +140,22 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "issue #56 の未読フィードバック1件を反映: 「到達性を失いうる変更」の定義に、自分や人間がこの homelab を観測・操作する経路自身（Coder、GitHub Actions）を含める旨を CHARTER §4 に明記（#94）。T-0022（immich Helm chart 0.12.0→0.13.1、アプリバージョンは不変）を subagent の調査結果に基づき完遂（#95）。T-0023（coder v2.35.3 更新）は調査の結果、DB migration が不可逆でバックアップ未確認と判明し risk を medium→high に見直して blocked に変更（#96）。T-0012（自己振り返り、weekly recurring）で、PR の CI/merge 状況は webhook で自動通知されるためポーリング不要と発見し CHARTER §2 に反映。recurring タスクの再キュー方法が無かったため last_done/next_review の暫定運用を追加（#97）",
-      "prs": [94, 95, 96, 97]
+      "prs": [
+        94,
+        95,
+        96,
+        97
+      ]
+    },
+    {
+      "n": 11,
+      "at": "2026-08-04T22:20:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "issue #56 の未読フィードバック1件（22:04:42、#95 のレンダリング差分の事後検証）を反映。CI にオブジェクト削除検出 job (manifest-diff) を追加する T-0036 を起票・即完遂し、apps root Application が prune: true である以上必要だった安全網を追加した（#98, auto-merge 設定予定）。",
+      "prs": [
+        98
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`apps/` root Application は `syncPolicy.automated.prune: true` で動いている。つまり `kustomize build --enable-helm` の出力からオブジェクトが消えると、次の ArgoCD sync でクラスタからも消える（PVC ならバックエンドの実データも道連れ）。

これまではこの確認を人間（構築セッション）が chart 更新のたびに手で render 差分を取って行っていた（#95 のレビュー、issue #56 2026-08-04 22:04:42 のフィードバック）。今回、CI にこれを機械化する `manifest-diff` job を追加した。

- 新規: `ops/check_manifest_deletions.py` — PR の base/head 両方の worktree で全 `kustomization.yaml` を render し、`(kind, namespace, name)` の集合を比較する。base にあって head に無いオブジェクトを「削除」として検出する
- `.github/workflows/ci.yml` に `manifest-diff` job を追加（`pull_request` イベントのみ）
- 意図的な削除は PR 本文に `allow-delete: <Kind>/<namespace-or-->/<name>` を書くと許可される（何でも止まると使えないための逃げ道）
- `ops/CHARTER.md`「バージョン更新の作法」にこの検証の位置づけを追記。**ただし DB のメジャー更新のようなスキーマ破壊は render の差分には出ないため、バックアップ健全性の確認を代替するものではない**、と明記した

## 検証したこと

- `find_kustomization_dirs` / `parse_allowed` / `diff_and_check` の純粋ロジックはこのサンドボックス上で python3 単体で動作確認済み（削除ありで検出、`allow-delete` ありで許可、削除なしで通過の 3 パターン）
- `kustomize` / `helm` はこのサンドボックスに無いため、実際の render・CI 上での動作は検証できていない（`ops/CHARTER.md` §5.2 の既知の制約）。CI の green を見届ける
- `python3 ops/validate.py` / `python3 ops/check_version_sync.py` / `python3 ops/dashboard/build.py` はいずれもエラー無し

## ロールバック手順

このコミットを revert する PR を出せば、`manifest-diff` job ごと元に戻る。既存の `manifests` / `terraform` / `ops` / `nix` の各 CI job には触れていないので、この job だけを revert しても他の検証には影響しない。

## 経路への影響について

このジョブ自体は追加のみで、既存 job の挙動は変えていない。ただし変更対象が GitHub Actions（CI の検証経路）そのものである点は明記しておく。誤検知（false positive）で `manifest-diff` が落ちても、他の必須チェック（kustomize build / terraform validate / ops state validate / nix flake check）は影響を受けないため、検証経路全体が止まることはない。

## お願いしたいこと

この `manifest-diff` job は必須チェックへの追加を検討してほしい（`ops/CHARTER.md` §5.2 の非対称: `.github/workflows/*.yml` は autopilot から書けるが、ruleset の必須チェック一覧は変更できない）。追加するまでは検出はできるが強制力が無い状態になる。

## backlog

T-0036


---
_Generated by [Claude Code](https://claude.ai/code/session_01GktW1KENacu3emvmviczj3)_