### PR TITLE
ops: run #11 のダッシュボード PR キャッシュを最新化する

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,20 @@
   "open": [],
   "merged": [
     {
+      "number": 98,
+      "title": "ci: apps/ render の意図しないオブジェクト削除を検出するジョブを追加 (T-0036)",
+      "url": "https://github.com/hikuohiku/homelab/pull/98",
+      "mergedAt": "2026-08-04T22:26:27Z",
+      "headRefName": "autopilot/T-0036-manifest-deletion-guard"
+    },
+    {
+      "number": 97,
+      "title": "T-0012: 自己振り返りを実施し、run #10 の記録をまとめる",
+      "url": "https://github.com/hikuohiku/homelab/pull/97",
+      "mergedAt": "2026-08-04T22:12:24Z",
+      "headRefName": "autopilot/t-0012-weekly-review"
+    },
+    {
       "number": 96,
       "title": "T-0023: coder v2.35.3 更新のリスクを見直し、blocked にする",
       "url": "https://github.com/hikuohiku/homelab/pull/96",
@@ -343,6 +357,55 @@
       "url": "https://github.com/hikuohiku/homelab/pull/47",
       "mergedAt": "2026-06-21T09:28:10Z",
       "headRefName": "feat/vaultwarden-k8s"
+    },
+    {
+      "number": 46,
+      "title": "chore: IaC 管理外の空 namespace を整理",
+      "url": "https://github.com/hikuohiku/homelab/pull/46",
+      "mergedAt": "2026-06-21T06:28:16Z",
+      "headRefName": "chore/cleanup-orphan-namespaces"
+    },
+    {
+      "number": 45,
+      "title": "chore: Proxmox 棚卸しと pbs の手動管理方針を明示",
+      "url": "https://github.com/hikuohiku/homelab/pull/45",
+      "mergedAt": "2026-06-21T06:04:01Z",
+      "headRefName": "chore/proxmox-cleanup-pbs-manual"
+    },
+    {
+      "number": 43,
+      "title": "feat: GitHub Copilot PR レビューを日本語化",
+      "url": "https://github.com/hikuohiku/homelab/pull/43",
+      "mergedAt": "2026-05-21T00:58:51Z",
+      "headRefName": "feat/copilot-japanese-review"
+    },
+    {
+      "number": 41,
+      "title": "feat: ArgoCD preview deploy commands + PVC data protection",
+      "url": "https://github.com/hikuohiku/homelab/pull/41",
+      "mergedAt": "2026-05-20T15:10:25Z",
+      "headRefName": "feat/preview-deploy-flow"
+    },
+    {
+      "number": 39,
+      "title": "feat(immich): add Immich K8s manifests for LXC migration",
+      "url": "https://github.com/hikuohiku/homelab/pull/39",
+      "mergedAt": "2026-05-20T13:42:27Z",
+      "headRefName": "feat/immich-k8s-migration"
+    },
+    {
+      "number": 33,
+      "title": "feat(nextcloud): add Nextcloud Helm chart configuration",
+      "url": "https://github.com/hikuohiku/homelab/pull/33",
+      "mergedAt": "2025-12-17T13:57:38Z",
+      "headRefName": "claude/investigate-nextcloud-helm-5azra"
+    },
+    {
+      "number": 32,
+      "title": "feat: Add Dex as central IdP with Google OIDC",
+      "url": "https://github.com/hikuohiku/homelab/pull/32",
+      "mergedAt": "2025-12-15T08:45:07Z",
+      "headRefName": "feat/dex-google-auth"
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`ops/dashboard/prs.json` を `mcp__github__list_pull_requests` の実測値（open 0 件、merged 58 件、`merged_at` 降順）で更新した。`gh` CLI がこのサンドボックスに無いため `build.py` はこのキャッシュにフォールバックする（CHARTER §7.1）。#98 のマージ後にダッシュボードを再生成し、同じ URL に再公開済み。

## 検証したこと

`python3 ops/validate.py` / `python3 ops/dashboard/build.py` ともにエラー無し。

## ロールバック手順

revert PR で前のキャッシュに戻る。キャッシュのみの変更なので実インフラへの影響は無い。

## backlog

なし（記録の更新のみ）


---
_Generated by [Claude Code](https://claude.ai/code/session_01GktW1KENacu3emvmviczj3)_