### PR TITLE
upgrade(tailscale): operator chart 1.90.9→1.98.9、k8s-nameserver を v1.98.9 に揃える (T-0024, T-0025)

### DIFF
--- a/apps/tailscale-operator/dns-config.yaml
+++ b/apps/tailscale-operator/dns-config.yaml
@@ -6,6 +6,9 @@ spec:
   nameserver:
     image:
       repo: tailscale/k8s-nameserver
-      # unstable が 2026-08-04 時点で指していたビルドと同一（digest 一致確認済み）。
-      # 中身は変えずに floating tag だけを固定した（backlog T-0001）
-      tag: unstable-v1.91.150
+      # v1.98.9 は operator chart 1.98.9 と同じ tailscale/tailscale@v1.98.9 タグからビルドされた
+      # 非 floating タグ（T-0025）。以前の unstable-v1.91.150 は floating tag を固定しただけの
+      # スナップショット（T-0001）で、operator chart とバージョンが揃っていなかった。
+      # k8s-nameserver の vX.Y.Z 系タグは chart 1.92 以降にならないと存在しない
+      # （1.90.9 当時の T-0001/T-0005 調査で「stable 相当のタグは無い」としたのはその時点では正しかった）。
+      tag: v1.98.9

--- a/apps/tailscale-operator/kustomization.yaml
+++ b/apps/tailscale-operator/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 helmCharts:
   - name: tailscale-operator
     repo: https://pkgs.tailscale.com/helmcharts
-    version: 1.90.9
+    version: 1.98.9
     releaseName: tailscale-operator
     namespace: tailscale
     valuesInline:

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -426,7 +426,7 @@
       "title": "tailscale-operator chart を 1.90.9 → 1.98.9 に上げる（T-0025 と組み合わせ・順序を揃えて着手）",
       "kind": "upgrade",
       "risk": "high",
-      "status": "todo",
+      "status": "done",
       "priority": 18,
       "why": "T-0005 の調査 (run #6) で判明、正確な最新版は issue #56 (2026-08-04 20:20:15) のフィードバックで確定。operator chart の最新は 1.98.9（公開版: 1.98.9/1.98.4/1.98.3/1.96.5/1.94.2/1.94.1/1.92.5/1.92.4/1.92.3/1.90.9）。tailscale 本体の最新 stable は v1.102.1 だが chart は本体より遅れて出るため 1.98.9 が上限。同フィードバックで T-0025（k8s-nameserver を unstable-v1.103.54 へ）と揃えずに進めると operator と nameserver のバージョンが乖離すると指摘されている",
       "dod": "1.90.9 から 1.98.9 までのリリースノートを原文で読み breaking change を洗い出す。apps/tailscale-operator/kustomization.yaml の version を更新し、ops/inventory.json の current も更新。CHARTER §4 の『到達性を失いうる変更』の手順（復旧手順を PR に書く）に従う。T-0025 と同一 PR にする必要はないが、着手順序と組み合わせ（同時に揃えるか、operator → nameserver の順で刻むか）を先に決めてから着手する",
@@ -435,8 +435,8 @@
         "ops/inventory.json"
       ],
       "created": "2026-08-04",
-      "pr": null,
-      "notes": "run #7: 正確な最新版が判明したため blocked_by を解除。ただし risk=high の到達性変更であり、T-0025 との組み合わせ検討が先に必要なため todo のまま（着手は次回以降）"
+      "pr": 100,
+      "notes": "run #7: 正確な最新版が判明したため blocked_by を解除。ただし risk=high の到達性変更であり、T-0025 との組み合わせ検討が先に必要なため todo のまま（着手は次回以降） | run #11: subagent に調査を投げ、chart 1.90.9→1.98.9 の全中間版のテンプレート/CRD差分を tailscale/tailscale の実タグで直接照合（changelog散文ではなくソース差分）。この repo が使う機能（apiServerProxyConfig.mode: \"true\"、oauth: {} + operator-oauth Secret、DNSConfig の image.repo/tag）に影響する breaking change は無し。DNSConfig CRD は差分ゼロ除去・追加フィールドのみの後方互換変更。ロールバックは git revert + ArgoCD self-heal で完結し、人間・エージェントともクラスタに直接触れる必要が無いことを確認したうえで T-0025 と同一 PR (#100) で着手した"
     },
     {
       "id": "T-0025",
@@ -444,7 +444,7 @@
       "title": "tailscale k8s-nameserver を unstable-v1.91.150 → 安定系タグに上げる（T-0024 の operator chart 上限 1.98.9 と揃える。stable タグの有無を先に確認）",
       "kind": "upgrade",
       "risk": "high",
-      "status": "todo",
+      "status": "done",
       "priority": 18,
       "why": "T-0005 の調査 (run #6)。ghcr.io の tags API を直接叩いて確認済み（T-0001 と同じ手法）で unstable-v1.103.54 まで存在するが、issue #56 (2026-08-04 20:20:15) のフィードバックにより T-0024（operator chart は 1.98.9 が上限）と揃えるべきと判明。unstable-v1.103.54 まで進めると operator（1.98.9 系相当）と nameserver のバージョンが乖離する。unstable タグを追い続ける前提も見直し、stable 系タグが取れないか確認する",
       "dod": "k8s-nameserver に stable 系タグがあるか ghcr.io の tags API で確認する。無ければ operator chart (1.98.9 相当) と揃うバージョンの unstable タグを選ぶ。apps/tailscale-operator/dns-config.yaml のタグを更新、ops/inventory.json の current も更新。CHARTER §4 の到達性変更の手順（復旧手順を PR に明記）に従う。digest も合わせて確認する（T-0001 のやり方を踏襲）。T-0024 との着手順序を決めてから着手する",
@@ -453,8 +453,8 @@
         "ops/inventory.json"
       ],
       "created": "2026-08-04",
-      "pr": null,
-      "notes": "run #7: issue #56 のフィードバックを受け、T-0024 と組み合わせ・順序を揃える前提に変更"
+      "pr": 100,
+      "notes": "run #7: issue #56 のフィードバックを受け、T-0024 と組み合わせ・順序を揃える前提に変更 | run #11: 調査の結果、T-0001/T-0005 時点の「k8s-nameserver に stable タグは無い」という前提が古くなっていたと判明。chart 1.92 系以降は tailscale/tailscale の release tag と同じ非 floating な vX.Y.Z タグが存在し、operator chart 1.98.9 は tailscale/tailscale@v1.98.9 からビルドされているため、nameserver も v1.98.9 を選べば operator と完全に一致する（ghcr.io/Docker Hub 双方で digest 確認済み）。unstable-v1.91.150 → v1.98.9 として T-0024 と同一 PR (#100) で着手"
     },
     {
       "id": "T-0026",

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -50,12 +50,12 @@
       "id": "tailscale-operator-chart",
       "kind": "helm",
       "name": "tailscale-operator",
-      "current": "1.90.9",
+      "current": "1.98.9",
       "file": "apps/tailscale-operator/kustomization.yaml",
       "match": "version:",
       "upstream": "github:tailscale/tailscale",
       "policy": "auto",
-      "note": "到達性の根幹。壊すとクラスタに届かなくなる"
+      "note": "到達性の根幹。壊すとクラスタに届かなくなる。T-0024 で 1.90.9→1.98.9 に更新（#100）。k8s-nameserver（同ファイル群内の別エントリ）と同じ tailscale/tailscale@vX.Y.Z タグから揃えて更新すること"
     },
     {
       "id": "vaultwarden",
@@ -149,12 +149,12 @@
       "id": "k8s-nameserver",
       "kind": "image",
       "name": "tailscale k8s-nameserver",
-      "current": "unstable-v1.91.150",
+      "current": "v1.98.9",
       "file": "apps/tailscale-operator/dns-config.yaml",
       "match": "k8s-nameserver",
       "upstream": "github:tailscale/tailscale",
       "policy": "auto",
-      "note": "T-0001 で floating tag (unstable) を固定した。tailscale/k8s-nameserver に「stable」相当のタグは無く、unstable-vX.Y.Z 形式のスナップショットのみ存在する。更新時は ghcr.io の digest を必ず確認する"
+      "note": "T-0025 で unstable-v1.91.150 → v1.98.9 に更新（#100）。訂正: T-0001/T-0005 時点（chart 1.90.9）では stable 相当のタグは無く unstable-vX.Y.Z のスナップショットのみだったが、chart 1.92 系以降は tailscale/tailscale の release tag と同じ非 floating な vX.Y.Z タグが ghcr.io / Docker Hub 両方に存在する。今後の更新は unstable-* に戻さず、tailscale-operator-chart と同じ vX.Y.Z で揃える"
     },
     {
       "id": "coder-workspace-image",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -312,6 +312,19 @@
 - T-0036: `ops/check_manifest_deletions.py` を新規作成し、CI に `manifest-diff` job（PR の base/head を
   render し `(kind, namespace, name)` 集合を比較、`allow-delete:` 行が無い削除は fail-closed）を追加。
   純粋ロジック（ディレクトリ探索・allow-delete パース・差分判定）はサンドボックス上で python3 単体で
-  動作確認したが、`kustomize`/`helm` が無いため実際の render 経路は CI 任せ（#98, auto-merge 設定予定）。
-  CHARTER「バージョン更新の作法」にこの検証の位置づけ（DB スキーマ破壊などは検出できない、バックアップ
-  確認の代替にはならない）を明記した
+  動作確認したが、`kustomize`/`helm` が無いため実際の render 経路は CI 任せ（#98, merged）
+- #98 merge を確認後、ダッシュボードの PR キャッシュを最新化して再公開（#99, merged）
+- 続けて T-0024/T-0025（tailscale-operator chart 1.90.9→1.98.9 + k8s-nameserver
+  unstable-v1.91.150→v1.98.9、組み合わせて着手する前提で backlog に記載済みだった）に着手。
+  「到達性の根幹」かつ自分自身の観測経路でもあるため、subagent に broken-change 調査を投げ、
+  changelog 散文ではなく tailscale/tailscale の実タグ間でテンプレート/CRD差分を直接照合させた。
+  結論: この repo が使う機能（apiServerProxyConfig.mode: "true"、oauth: {} + operator-oauth Secret、
+  DNSConfig の image.repo/tag）に影響する breaking change は無し。DNSConfig CRD は追加フィールドのみで
+  除去はゼロ。副産物の発見: k8s-nameserver に「stable タグは無い」という T-0001/T-0005 時点の前提が
+  古くなっていた。chart 1.92 系以降は tailscale/tailscale の release tag と同じ非 floating な vX.Y.Z
+  タグが存在し、chart 1.98.9 は tailscale/tailscale@v1.98.9 からビルドされているため、nameserver も
+  v1.98.9 を選べば operator と完全一致する。ロールバックは git revert + ArgoCD self-heal で完結し、
+  人間・エージェントともクラスタに直接触れずに戻せることを確認してから両タスクを同一 PR (#100) で
+  実施した。残った不確実性（node01 の k3s が admissionregistration.k8s.io/v1 に対応しているか、
+  DNS 解決の実地スモークテスト）はサンドボックスから検証できないため PR 本文に明記し、
+  ops/inventory.json の note も新しい事実に合わせて訂正した

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-04T22:20:00Z",
+  "updated": "2026-08-04T22:45:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -152,9 +152,11 @@
       "at": "2026-08-04T22:20:00Z",
       "kind": "scheduled",
       "by": "cloud routine",
-      "summary": "issue #56 の未読フィードバック1件（22:04:42、#95 のレンダリング差分の事後検証）を反映。CI にオブジェクト削除検出 job (manifest-diff) を追加する T-0036 を起票・即完遂し、apps root Application が prune: true である以上必要だった安全網を追加した（#98, auto-merge 設定予定）。",
+      "summary": "issue #56 の未読フィードバック1件（22:04:42、#95 のレンダリング差分の事後検証）を反映。CI にオブジェクト削除検出 job (manifest-diff) を追加する T-0036 を起票・完遂（#98）、ダッシュボード PR キャッシュを更新（#99）。続けて到達性の根幹である T-0024/T-0025（tailscale-operator chart 1.90.9→1.98.9 + k8s-nameserver unstable-v1.91.150→v1.98.9）を subagent 調査（実タグ間のテンプレート/CRD差分照合）に基づき完遂。副産物として k8s-nameserver の stable タグが chart 1.92 以降で利用可能になっていたと判明し、operator chart と揃えた（#100）。",
       "prs": [
-        98
+        98,
+        99,
+        100
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

- `apps/tailscale-operator/kustomization.yaml`: tailscale-operator Helm chart `1.90.9` → `1.98.9`
- `apps/tailscale-operator/dns-config.yaml`: k8s-nameserver イメージタグ `unstable-v1.91.150`（floating snapshot を固定したもの） → `v1.98.9`（non-floating な release tag）
- `ops/inventory.json` の該当 2 エントリを実態に合わせて更新。あわせて「k8s-nameserver に stable タグは無い」という従来の note（T-0001/T-0005 調査時点、chart 1.90.9 当時は事実）を訂正: chart 1.92 系以降は `tailscale/tailscale` の release tag と同じ非 floating な `vX.Y.Z` タグが存在する

T-0024 と T-0025 は「組み合わせ・順序を揃えて着手する」前提で backlog に記載されていたため、1 PR にまとめている。

## なぜ両方を v1.98.9 で揃えるか

`tailscale-operator` chart の `Chart.yaml` に「chart version は release 時点の `tailscale/tailscale` の tag そのもの」と明記されている。つまり chart `1.98.9` は `tailscale/tailscale@v1.98.9` からビルドされている。k8s-nameserver 側にも同じ `v1.98.9` の非 floating タグが `ghcr.io`/Docker Hub 双方に存在する（digest 一致確認済み）ため、operator と nameserver を完全に同一バージョンで揃えられる。以前の `unstable-v1.91.150` は unstable スナップショットの一時点を固定しただけで、operator chart とバージョンが揃っていなかった。

## 検証したこと（到達性の根幹のため厚めに書く）

このコンポーネントは `ops/inventory.json` に「到達性の根幹。壊すとクラスタに届かなくなる」と明記されている通りリスクが高く、かつ自分自身（autopilot）や人間がこの homelab を観測・操作する経路そのものでもある。subagent に、changelog の要約ではなく `tailscale/tailscale` の実タグ間（v1.90.9〜v1.98.9）の Helm テンプレート/CRD の生差分を直接照合させた。結果:

- この repo が使っている機能（`apiServerProxyConfig.mode: "true"`、`oauth: {}` + 事前作成済み `operator-oauth` Secret、`DNSConfig.spec.nameserver.image.{repo,tag}`）に影響する breaking change は無し
- `DNSConfig` CRD スキーマは差分ゼロ除去・新規オプションフィールドの追加のみ（後方互換）
- 1.98.0/1.98.1 にあった MagicDNS 回帰は 1.98.2 で修正済み。1.98.9 はそれより後
- ArgoCD は Kustomize の `helmCharts`（実質 `helm template`）でレンダリングした CRD を通常の `kubectl apply` sync 経路で適用するため、native `helm upgrade` と違い新規/更新 CRD も自動で反映される

`kustomize`/`helm` がこのサンドボックスに無いため実際の render はできず、CI (`manifests` job / 今回追加した `manifest-diff` job) に任せている。

### 残った不確実性（検証できなかった点）

- node01 の k3s が `admissionregistration.k8s.io/v1`（chart が追加する ValidatingAdmissionPolicy 系 RBAC が参照する API group、K8s 1.30+ で GA）に対応しているか、クラスタに到達できないため確認できていない。ただしこの repo は該当機能（ProxyGroup policy）を使っておらず、RBAC 権限の付与自体は inert なので影響は無いと判断している
- マージ後の実地 DNS 解決スモークテスト（`nslookup <host>.ts.net` 等）はクラウドサンドボックスから実行できない。Tailscale 経由で homelab に到達できる人間や対話セッションがあれば、sync 後に確認してもらえると安心

## ロールバック手順

**このコンポーネントが壊れても、GitHub 上での revert だけで復旧できる。** Tailscale の状態は control plane 側と per-proxy Secret にあり、chart バージョンに紐づくスキーマ移行は無い。`DNSConfig` CRD の変更は追加のみで、新規 CRD（`tailnets`/`proxygrouppolicies`）にはこの repo で CR を作っていないため `prune: true` での自動削除も安全。両タグとも non-floating（immutable）なので、`git revert` でこの PR を戻せば digest レベルで元の状態に戻る。**revert → ArgoCD の self-heal による自動同期という経路自体は Tailscale の到達性に依存しない**（ArgoCD は in-cluster のサービスアカウントで GitHub から pull するだけで、Tailscale API proxy 経由のアクセスではない）ため、人間もエージェントもクラスタに直接触れずに復旧できる。

## backlog

T-0024, T-0025


---
_Generated by [Claude Code](https://claude.ai/code/session_01GktW1KENacu3emvmviczj3)_