### PR TITLE
ops: run #11 の記録をまとめ、ダッシュボードを再生成する

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 100,
+      "title": "upgrade(tailscale): operator chart 1.90.9→1.98.9、k8s-nameserver を v1.98.9 に揃える (T-0024, T-0025)",
+      "url": "https://github.com/hikuohiku/homelab/pull/100",
+      "mergedAt": "2026-08-04T22:40:28Z",
+      "headRefName": "autopilot/T-0024-T-0025-tailscale-upgrade"
+    },
+    {
       "number": 98,
       "title": "ci: apps/ render の意図しないオブジェクト削除を検出するジョブを追加 (T-0036)",
       "url": "https://github.com/hikuohiku/homelab/pull/98",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -328,3 +328,13 @@
   実施した。残った不確実性（node01 の k3s が admissionregistration.k8s.io/v1 に対応しているか、
   DNS 解決の実地スモークテスト）はサンドボックスから検証できないため PR 本文に明記し、
   ops/inventory.json の note も新しい事実に合わせて訂正した
+- #100 は CI green で merge 済み。**次の起動への申し送り**: マージ後の実地確認（DNS 解決、
+  Tailscale 経由のアクセス）はこのサンドボックスからはできない。人間が Tailscale を日常的に
+  使っていて気づける前提で進めたが、次の起動で「何も異常の報告が無い」以上のポジティブな確認は
+  できない（T-0015 が未解決なため）。異常の兆候（issue #56 へのフィードバック等）があれば最優先で
+  拾うこと
+- run #11 のまとめ: 3 PR（#98〜#100）を直列でマージまで見届けた。issue #56 のフィードバック1件を
+  反映（CI にオブジェクト削除検出の安全網を追加）。到達性の根幹である tailscale-operator/nameserver
+  の更新を、breaking change の実差分照合とロールバック経路（git revert + ArgoCD self-heal、クラスタ
+  非依存）の確認を経て実施した。backlog の todo で次に優先度が高いのはメジャー更新 3 件
+  （T-0026 external-secrets, T-0027 immich, T-0028 argo-cd、いずれも high risk）


### PR DESCRIPTION
## 変更点

run #11 の journal 締めくくりと、#100 マージ後の `ops/dashboard/prs.json` キャッシュ更新。ダッシュボードは再生成し同じ URL に再公開済み。コード変更は無い。

## 検証したこと

`python3 ops/validate.py` エラー無し。

## ロールバック手順

記録のみの変更。revert すれば戻る。

## backlog

なし


---
_Generated by [Claude Code](https://claude.ai/code/session_01GktW1KENacu3emvmviczj3)_