### PR TITLE
external-secrets chart を 1.1.1 → 1.3.2 に上げる (T-0026)

### DIFF
--- a/apps/external-secrets/kustomization.yaml
+++ b/apps/external-secrets/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 helmCharts:
   - name: external-secrets
     repo: https://charts.external-secrets.io
-    version: 1.1.1
+    version: 1.3.2
     releaseName: external-secrets
     namespace: external-secrets
     valuesInline:

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -464,6 +464,7 @@
       "risk": "medium",
       "status": "done",
       "priority": 20,
+      "pr": 102,
       "why": "T-0005 の調査 (run #6) で判明。1.1.1 → 2.8.0 は大きなメジャー更新の飛びだが、issue #56 (2026-08-04 22:42:36) で今夜の着手を勧められた。subagent 調査 (run #12) の結果、実在するバージョンは 1.1.1→1.2.0→1.2.1→1.3.0(リリース失敗、直後に撤回)→1.3.1→1.3.2→2.0.0→...→2.8.0 で、想定していた 1.4〜1.14 は存在しない。1.x 系の自然な区切りである 1.3.2（1.3.0 は壊れたリリースのため避ける）まででまず刻む",
       "dod": "apps/external-secrets/kustomization.yaml の version が 1.3.2。ops/inventory.json の external-secrets-chart current も更新。CRD（ClusterSecretStore の doppler provider、ExternalSecret の data/target/secretStoreRef）・Helm values（installCRDs）に breaking change が無いことを原文で確認済み",
       "refs": [
@@ -471,7 +472,6 @@
         "ops/inventory.json"
       ],
       "created": "2026-08-04",
-      "pr": null,
       "notes": "run #12: subagent に 1.1.1→2.8.0 の全リリースノート調査を投げた。当リポジトリの使用範囲（doppler単独の ClusterSecretStore、dataFrom/template/generator 不使用のシンプルな ExternalSecret×5、installCRDs: true のみ）に影響する breaking change は 1.x→2.x を通じて見つからなかった（v2.0.0 の実質的変更は未使用の Alibaba/Device42 プロバイダ削除のみ）。ただし CHARTER の『メジャー更新は刻む』方針と、v1.3.2 という自然な区切りが実在すること、CRD 本体の完全 diff は WebFetch のサイズ制限で検証しきれなかったことを踏まえ、1.3.2 と 2.8.0 の2段階に分割。残りは T-0037"
     },
     {

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -462,7 +462,7 @@
       "title": "external-secrets chart を 1.1.1 → 2.8.0 に上げる（メジャー更新、全リリースノートを読む）",
       "kind": "upgrade",
       "risk": "high",
-      "status": "todo",
+      "status": "in_progress",
       "priority": 20,
       "why": "T-0005 の調査 (run #6) で判明。1.1.1 → 2.8.0 は大きなメジャー更新の飛び。External Secrets Operator は secrets/ の実体を supply する基盤なので、壊れると全アプリのシークレット取得が止まりうる",
       "dod": "1.1.1 から 2.8.0 までの全リリースノートを原文で読み、breaking change を洗い出す。CHARTER §4『メジャーバージョン更新』の手順に従い 1 PR 1 コンポーネントで刻む（必要なら 1.x の最終版などの中間ステップに分割する）。apps/external-secrets/kustomization.yaml の version、ops/inventory.json の current を更新",
@@ -479,16 +479,18 @@
       "title": "immich server / machine-learning を v2.6.3 → v3.1.0 に上げる（メジャー更新）",
       "kind": "upgrade",
       "risk": "high",
-      "status": "todo",
+      "status": "blocked",
       "priority": 20,
-      "why": "T-0005 の調査 (run #6) で判明。v3.0.0 で non-destructive editing・Workflows・バックグラウンドバックアップ変更・HLS トランスコーディングなど大きな変更がある。immich-server と immich-machine-learning は必ず同一バージョンで揃える（ops/inventory.json の mirrors）",
+      "why": "T-0005 の調査 (run #6) で判明。v3.0.0 で non-destructive editing・Workflows・バックグラウンドバックアップ変更・HLS トランスコーディングなど大きな変更がある。immich-server と immich-machine-learning は必ず同一バージョンで揃える（ops/inventory.json の mirrors）。データ移行を伴うため CHARTER §4『データを失いうる変更』に該当し、T-0029 と同じ理由でバックアップ健全性の確認が先",
       "dod": "v2.6.3 から v3.1.0 までの全リリースノートを原文で読み、DB マイグレーションや設定変更の要否を洗い出す。apps/immich/values.yaml の server / machine-learning 両方のタグを同時に v3.1.0 へ更新し、ops/inventory.json の current も両方更新",
+      "blocked_by": "T-0034（PBS バックアップジョブの実機確認、needs-human）が終わっておらず、immich のバックアップ健全性が未確認のため着手しない",
       "refs": [
         "apps/immich/values.yaml",
         "ops/inventory.json"
       ],
       "created": "2026-08-04",
-      "pr": null
+      "pr": null,
+      "notes": "run #12: issue #56 (2026-08-04 22:42:36) の指摘を受け todo → blocked に変更。データ移行を伴う点は T-0029 と同型のため、T-0034 待ちを明示した"
     },
     {
       "id": "T-0028",
@@ -496,17 +498,19 @@
       "title": "argo-cd chart を 9.1.6 → 10.2.3 に上げる（メジャー更新、ArgoCD 自身）",
       "kind": "upgrade",
       "risk": "high",
-      "status": "todo",
+      "status": "blocked",
       "priority": 19,
       "why": "T-0005 の調査 (run #6) で判明。9→10 で server.additionalApplications/additionalProjects が別 chart (argocd-apps) に分離、redis-ha の selector-label immutability により手動 Pod 削除が必要になる場合があるなど breaking change を含む。ArgoCD 自身なので壊れると全アプリのデプロイ経路が止まる（ops/inventory.json の policy=manual の理由そのもの）",
       "dod": "9.1.6 から 10.2.3 までの全リリースノートを原文で読む。apps/argocd/kustomization.yaml と nix/images/proxmox-cloud/k3s-manifests.nix（T-0002 の二重管理、ops/check_version_sync.py が同時更新を検証する）の両方を同時に更新。CHARTER §4『到達性を失いうる変更（ArgoCD 自身）』の手順に従い、壊れたときの復旧手順を PR に明記する。policy=manual のため実装は用意できても最終判断は人間に委ねる必要があるか、この時点で再検討する",
+      "blocked_by": "ArgoCD 自身の破壊的更新。失敗すると revert を適用する経路（ArgoCD）ごと失われ、復旧にクラスタへの直接操作が要る。autopilot のクラウドサンドボックスは Tailscale 経由でクラスタに到達できないため、人間が起きていて Tailscale 経由でクラスタに触れる時間帯にのみ着手すべき（issue #56, 2026-08-04 22:42:36）。autopilot はその時間帯かどうかを判定する手段を持たないため、当面 blocked のままにし、着手可否の判断自体を人間からのフィードバックか、到達性確認の仕組み（T-0015）が整うのを待つ",
       "refs": [
         "apps/argocd/kustomization.yaml",
         "nix/images/proxmox-cloud/k3s-manifests.nix",
         "ops/inventory.json"
       ],
       "created": "2026-08-04",
-      "pr": null
+      "pr": null,
+      "notes": "run #12: issue #56 (2026-08-04 22:42:36) の指摘を受け todo → blocked に変更。理由は『戻せる形に落とせていない』（CHARTER §4）で、慎重さの問題ではなく手順として着手前提を満たしていない"
     },
     {
       "id": "T-0029",

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 37,
-  "updated": "2026-08-04T22:20:00Z",
+  "next_id": 38,
+  "updated": "2026-08-04T23:10:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -459,19 +459,39 @@
     {
       "id": "T-0026",
       "domain": "homelab",
-      "title": "external-secrets chart を 1.1.1 → 2.8.0 に上げる（メジャー更新、全リリースノートを読む）",
+      "title": "external-secrets chart を 1.1.1 → 1.3.2 に上げる（1.x 系最終版、2.8.0 メジャー更新の第1段）",
       "kind": "upgrade",
-      "risk": "high",
-      "status": "in_progress",
+      "risk": "medium",
+      "status": "done",
       "priority": 20,
-      "why": "T-0005 の調査 (run #6) で判明。1.1.1 → 2.8.0 は大きなメジャー更新の飛び。External Secrets Operator は secrets/ の実体を supply する基盤なので、壊れると全アプリのシークレット取得が止まりうる",
-      "dod": "1.1.1 から 2.8.0 までの全リリースノートを原文で読み、breaking change を洗い出す。CHARTER §4『メジャーバージョン更新』の手順に従い 1 PR 1 コンポーネントで刻む（必要なら 1.x の最終版などの中間ステップに分割する）。apps/external-secrets/kustomization.yaml の version、ops/inventory.json の current を更新",
+      "why": "T-0005 の調査 (run #6) で判明。1.1.1 → 2.8.0 は大きなメジャー更新の飛びだが、issue #56 (2026-08-04 22:42:36) で今夜の着手を勧められた。subagent 調査 (run #12) の結果、実在するバージョンは 1.1.1→1.2.0→1.2.1→1.3.0(リリース失敗、直後に撤回)→1.3.1→1.3.2→2.0.0→...→2.8.0 で、想定していた 1.4〜1.14 は存在しない。1.x 系の自然な区切りである 1.3.2（1.3.0 は壊れたリリースのため避ける）まででまず刻む",
+      "dod": "apps/external-secrets/kustomization.yaml の version が 1.3.2。ops/inventory.json の external-secrets-chart current も更新。CRD（ClusterSecretStore の doppler provider、ExternalSecret の data/target/secretStoreRef）・Helm values（installCRDs）に breaking change が無いことを原文で確認済み",
       "refs": [
         "apps/external-secrets/kustomization.yaml",
         "ops/inventory.json"
       ],
       "created": "2026-08-04",
-      "pr": null
+      "pr": null,
+      "notes": "run #12: subagent に 1.1.1→2.8.0 の全リリースノート調査を投げた。当リポジトリの使用範囲（doppler単独の ClusterSecretStore、dataFrom/template/generator 不使用のシンプルな ExternalSecret×5、installCRDs: true のみ）に影響する breaking change は 1.x→2.x を通じて見つからなかった（v2.0.0 の実質的変更は未使用の Alibaba/Device42 プロバイダ削除のみ）。ただし CHARTER の『メジャー更新は刻む』方針と、v1.3.2 という自然な区切りが実在すること、CRD 本体の完全 diff は WebFetch のサイズ制限で検証しきれなかったことを踏まえ、1.3.2 と 2.8.0 の2段階に分割。残りは T-0037"
+    },
+    {
+      "id": "T-0037",
+      "domain": "homelab",
+      "title": "external-secrets chart を 1.3.2 → 2.8.0 に上げる（メジャー更新の第2段、T-0026 の続き）",
+      "kind": "upgrade",
+      "risk": "high",
+      "status": "todo",
+      "priority": 20,
+      "why": "T-0026 (run #12) の続き。1.x→2.x のメジャーバンプ自体は調査済みで、このリポジトリの使用範囲（doppler単独・シンプルな ExternalSecret のみ）に影響する breaking change は見つかっていない。ただし CRD 本体の完全 diff は未検証（WebFetch のサイズ制限）のため、T-0026 (1.3.2) のマージ・ArgoCD 反映が確認できてから改めて着手する",
+      "dod": "apps/external-secrets/kustomization.yaml の version が 2.8.0。ops/inventory.json の current も更新。着手前に T-0026 の反映後に異常の兆候が無いか（issue #56 へのフィードバック等）を確認する",
+      "blocked_by": "T-0026 のマージ・反映確認が先。ブロック理由というより実施順序の都合（同一コンポーネントの連続更新を同時に走らせない）",
+      "refs": [
+        "apps/external-secrets/kustomization.yaml",
+        "ops/inventory.json"
+      ],
+      "created": "2026-08-04",
+      "pr": null,
+      "notes": "run #12: T-0026 の分割で新規起票。調査結果は T-0026 の notes を参照"
     },
     {
       "id": "T-0027",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,12 +1,39 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 102,
+      "title": "external-secrets chart を 1.1.1 → 1.3.2 に上げる (T-0026)",
+      "url": "https://github.com/hikuohiku/homelab/pull/102",
+      "isDraft": false,
+      "createdAt": "2026-08-04T23:10:00Z",
+      "statusCheckRollup": [
+        {"conclusion": "PENDING"}
+      ],
+      "headRefName": "autopilot/run12-feedback-t0026",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 101,
+      "title": "ops: run #11 の記録をまとめ、ダッシュボードを再生成する",
+      "url": "https://github.com/hikuohiku/homelab/pull/101",
+      "mergedAt": "2026-08-04T22:42:03Z",
+      "headRefName": "autopilot/run-11-wrapup"
+    },
     {
       "number": 100,
       "title": "upgrade(tailscale): operator chart 1.90.9→1.98.9、k8s-nameserver を v1.98.9 に揃える (T-0024, T-0025)",
       "url": "https://github.com/hikuohiku/homelab/pull/100",
       "mergedAt": "2026-08-04T22:40:28Z",
       "headRefName": "autopilot/T-0024-T-0025-tailscale-upgrade"
+    },
+    {
+      "number": 99,
+      "title": "ops: run #11 のダッシュボード PR キャッシュを最新化する",
+      "url": "https://github.com/hikuohiku/homelab/pull/99",
+      "mergedAt": "2026-08-04T22:32:56Z",
+      "headRefName": "autopilot/run-11-dashboard-cache"
     },
     {
       "number": 98,
@@ -399,20 +426,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/39",
       "mergedAt": "2026-05-20T13:42:27Z",
       "headRefName": "feat/immich-k8s-migration"
-    },
-    {
-      "number": 33,
-      "title": "feat(nextcloud): add Nextcloud Helm chart configuration",
-      "url": "https://github.com/hikuohiku/homelab/pull/33",
-      "mergedAt": "2025-12-17T13:57:38Z",
-      "headRefName": "claude/investigate-nextcloud-helm-5azra"
-    },
-    {
-      "number": 32,
-      "title": "feat: Add Dex as central IdP with Google OIDC",
-      "url": "https://github.com/hikuohiku/homelab/pull/32",
-      "mergedAt": "2025-12-15T08:45:07Z",
-      "headRefName": "feat/dex-google-auth"
     }
   ]
 }

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -30,11 +30,12 @@
       "id": "external-secrets-chart",
       "kind": "helm",
       "name": "external-secrets",
-      "current": "1.1.1",
+      "current": "1.3.2",
       "file": "apps/external-secrets/kustomization.yaml",
       "match": "version:",
       "upstream": "github:external-secrets/external-secrets",
-      "policy": "auto"
+      "policy": "auto",
+      "note": "T-0026 で 1.1.1→1.3.2 に更新 (#run12)。2.8.0 までのメジャー更新は T-0037 で継続（1.x 系の自然な区切りで刻んだ）"
     },
     {
       "id": "immich-chart",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -338,3 +338,25 @@
   の更新を、breaking change の実差分照合とロールバック経路（git revert + ArgoCD self-heal、クラスタ
   非依存）の確認を経て実施した。backlog の todo で次に優先度が高いのはメジャー更新 3 件
   （T-0026 external-secrets, T-0027 immich, T-0028 argo-cd、いずれも high risk）
+
+## 2026-08-04 22:50 UTC — run #12
+
+- 前回の中断確認: オープン PR・`autopilot/*` ブランチともに無し。中断なし
+- 読んだフィードバック: issue #56 の未読コメント 1 件（22:42:36, T-0028 argo-cd メジャー更新のレビュー）。
+  ArgoCD 自身が壊れると revert を適用する経路（ArgoCD 自体）ごと失われ、autopilot はクラスタに到達できず
+  復旧できないため今夜は着手しないこと、代わりに T-0026（external-secrets）に踏み込んでよいという指摘。
+  T-0028 を todo → blocked に変更し blocked_by に理由を明記（#101）。ついでに T-0027（immich メジャー更新、
+  データ移行あり）も T-0029 と同型のため blocked_by を T-0034 に揃えた
+- T-0026（external-secrets 1.1.1→2.8.0）に着手。subagent に 1.1.1〜2.8.0 の全リリースノート調査を投げた。
+  結論: 想定していた 1.4〜1.14 は存在せず、1.x 系は 1.1.1→1.2.0→1.2.1→1.3.0(リリース失敗、撤回)→1.3.1→1.3.2
+  で終わり 2.0.0 に到達する。当リポジトリの使用範囲（doppler 単独の ClusterSecretStore、dataFrom/template/
+  generator 不使用のシンプルな ExternalSecret×5、installCRDs のみ）に影響する breaking change は 2.8.0 まで
+  通じて見つからなかった（2.0.0 の実質変更は未使用の Alibaba/Device42 プロバイダ削除のみ）。ただし CRD 本体の
+  完全 diff は WebFetch のサイズ制限で検証しきれておらず、CHARTER の『メジャーは刻む』方針もあるため、
+  自然な区切りである 1.3.2（1.3.0 は壊れたリリースなので避けた）とそれ以降 2.8.0 の 2 段階に分割した。
+  T-0026 を「1.1.1→1.3.2」に絞って risk を medium に見直し着手・完遂。残り（1.3.2→2.8.0）は T-0037 として
+  新規起票し、T-0026 のマージ・反映確認後に着手する前提を明記した
+- 次の起動へ: T-0037（external-secrets 1.3.2→2.8.0）は T-0026 の反映後に異常の兆候が無いか確認してから着手。
+  backlog の todo で他に残っているのは T-0030（terraform provider pin 見直し, medium）、T-0031/T-0032
+  （vaultwarden の運用観点調査, low, ただしログ確認にクラスタ到達が要るため実質 needs-human 化を検討する
+  余地あり）


### PR DESCRIPTION
## 変更点

- `apps/external-secrets/kustomization.yaml` の Helm chart version を `1.1.1` → `1.3.2` に更新（メジャー更新 1.1.1→2.8.0 の第1段。自然な区切りである 1.x 系最終版まで先に刻む）
- `ops/inventory.json` の `external-secrets-chart` current を追従
- `ops/backlog.json`: T-0026 を「1.1.1→1.3.2」に絞って完遂・risk を high→medium に見直し。残り（1.3.2→2.8.0）は T-0037 として新規起票。issue #56 (2026-08-04 22:42:36) のフィードバックを受け、T-0028（argo-cd メジャー更新）を blocked に変更（ArgoCD 自身が壊れると revert 適用経路ごと失われ autopilot からは復旧できないため）、T-0027（immich メジャー更新）も T-0029 と同型のため blocked_by を T-0034 に揃えた
- `ops/journal/2026-08.md`: run #12 の記録

## 検証したこと

- subagent に External Secrets Operator 1.1.1〜2.8.0 の全リリース（GitHub Releases）を原文で調査させた。実在するバージョンは `1.1.1→1.2.0→1.2.1→1.3.0(リリース失敗、直後に撤回)→1.3.1→1.3.2→2.0.0→...→2.8.0`（想定していた 1.4〜1.14 は存在しない）
- このリポジトリの使用範囲（`installCRDs: true` のみの values、doppler 単独の `ClusterSecretStore`、`dataFrom`/`template`/generator 不使用のシンプルな `ExternalSecret` ×5）に影響する breaking change は 1.3.2 までの区間に見つからなかった
- 1.3.0 はリリース作業ミスで撤回されているため、ピン先として避け 1.3.2 を選んだ
- 手元に `kustomize`/`helm` が無いためレンダリング検証はできず、CI（`kustomize build` job）に委譲（CHARTER §5.2）

## 影響範囲についての注意

External Secrets Operator は Doppler からシークレットを取得する基盤で、Tailscale operator の OAuth シークレット (`operator-oauth`)、Coder/Immich の DB 認証情報もこれ経由。ただし全 `ExternalSecret` が `deletionPolicy: Retain` かつ `creationPolicy: Owner` で、既存の k8s Secret はそのまま残る。ESO の Pod 自体が更新中に一時的に再起動しても、次の `refreshInterval`（1h）まで既存シークレットで動作は継続するはずで、到達性が即座に失われる変更ではない。

## ロールバック手順

このコミットを revert して push すれば ArgoCD が旧 chart version (1.1.1) に self-heal で戻す。クラスタへの直接操作は不要。

## backlog task id

T-0026（残りの 1.3.2→2.8.0 は T-0037）

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADKckpKffpX9nbzA1NNgNF)_