### PR TITLE
ops: run #12 の記録をまとめ、ダッシュボードを再生成する

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,19 +1,13 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 102,
       "title": "external-secrets chart を 1.1.1 → 1.3.2 に上げる (T-0026)",
       "url": "https://github.com/hikuohiku/homelab/pull/102",
-      "isDraft": false,
-      "createdAt": "2026-08-04T23:10:00Z",
-      "statusCheckRollup": [
-        {"conclusion": "PENDING"}
-      ],
-      "headRefName": "autopilot/run12-feedback-t0026",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-04T23:15:00Z",
+      "headRefName": "autopilot/run12-feedback-t0026"
+    },
     {
       "number": 101,
       "title": "ops: run #11 の記録をまとめ、ダッシュボードを再生成する",

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-04T22:45:00Z",
+  "updated": "2026-08-04T23:20:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-04T22:04:42Z"
+    "last_read": "2026-08-04T22:42:36Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -157,6 +157,16 @@
         98,
         99,
         100
+      ]
+    },
+    {
+      "n": 12,
+      "at": "2026-08-04T22:50:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "issue #56 の未読フィードバック1件（22:42:36、T-0028 argo-cd メジャー更新のレビュー）を反映: ArgoCD 自身が壊れると revert 適用経路ごと失われ autopilot からは復旧できないため T-0028 を blocked に変更、T-0027（immich メジャー更新）も T-0029 と同型のため blocked_by を T-0034 に揃えた。続けて T-0026（external-secrets 1.1.1→2.8.0）に着手。subagent に全リリースノート調査を投げ、当リポジトリの使用範囲（doppler単独の ClusterSecretStore、シンプルな ExternalSecret のみ）に影響する breaking change は無いと確認したが、CHARTER の『メジャーは刻む』方針と1.x系の自然な区切り(1.3.2、1.3.0はリリース失敗のため回避)に基づき2段階に分割。1.1.1→1.3.2を完遂し(#102, auto-merged)、残り(1.3.2→2.8.0)はT-0037として起票",
+      "prs": [
+        102
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

- `ops/state.json`: run #12 の記録を追記、feedback.last_read を更新
- `ops/dashboard/prs.json`: PR #102 のマージを反映

## 検証したこと

- `python3 ops/validate.py` → 0 error（既存の warning 1件のみ、本 PR とは無関係）
- `python3 ops/dashboard/build.py` → 正常終了、Artifact に再公開済み

## ロールバック手順

このコミットを revert すれば記録用データのみ元に戻る。実インフラへの影響は無い。

## backlog task id

なし（run #12 の記録のみ、リスクは repo 内で閉じる）

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADKckpKffpX9nbzA1NNgNF)_