### PR TITLE
external-secrets chart を 1.3.2 → 2.8.0 に上げる (T-0037)

### DIFF
--- a/apps/external-secrets/kustomization.yaml
+++ b/apps/external-secrets/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 helmCharts:
   - name: external-secrets
     repo: https://charts.external-secrets.io
-    version: 1.3.2
+    version: 2.8.0
     releaseName: external-secrets
     namespace: external-secrets
     valuesInline:

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 38,
-  "updated": "2026-08-04T23:10:00Z",
+  "updated": "2026-08-04T23:19:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -480,18 +480,17 @@
       "title": "external-secrets chart を 1.3.2 → 2.8.0 に上げる（メジャー更新の第2段、T-0026 の続き）",
       "kind": "upgrade",
       "risk": "high",
-      "status": "todo",
+      "status": "done",
       "priority": 20,
       "why": "T-0026 (run #12) の続き。1.x→2.x のメジャーバンプ自体は調査済みで、このリポジトリの使用範囲（doppler単独・シンプルな ExternalSecret のみ）に影響する breaking change は見つかっていない。ただし CRD 本体の完全 diff は未検証（WebFetch のサイズ制限）のため、T-0026 (1.3.2) のマージ・ArgoCD 反映が確認できてから改めて着手する",
       "dod": "apps/external-secrets/kustomization.yaml の version が 2.8.0。ops/inventory.json の current も更新。着手前に T-0026 の反映後に異常の兆候が無いか（issue #56 へのフィードバック等）を確認する",
-      "blocked_by": "T-0026 のマージ・反映確認が先。ブロック理由というより実施順序の都合（同一コンポーネントの連続更新を同時に走らせない）",
       "refs": [
         "apps/external-secrets/kustomization.yaml",
         "ops/inventory.json"
       ],
       "created": "2026-08-04",
       "pr": null,
-      "notes": "run #12: T-0026 の分割で新規起票。調査結果は T-0026 の notes を参照"
+      "notes": "run #13: subagent に v2.0.0〜v2.8.0 の全 GitHub Release 原文 + CRD bundle (1.3.2/2.8.0) の実差分 diff + Doppler provider Go 型定義の diff を取らせた。破壊的変更は v2.0.0 (Alibaba/Device42 provider 削除) と v2.2.0 (Flux OCIRepository consumer 向け) のみで、いずれも該当なし（Doppler / ArgoCD+Kustomize 使用のため）。Doppler 認証スキーマ・ClusterSecretStore/ExternalSecret の該当フィールドは 1.3.2/2.8.0 間で完全一致。1.3.0 以外に yank されたバージョンは無し。CRD bundle は追加のみで削除なし（manifest deletion guard の対象外）"
     },
     {
       "id": "T-0027",

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -489,7 +489,7 @@
         "ops/inventory.json"
       ],
       "created": "2026-08-04",
-      "pr": null,
+      "pr": 105,
       "notes": "run #13: subagent に v2.0.0〜v2.8.0 の全 GitHub Release 原文 + CRD bundle (1.3.2/2.8.0) の実差分 diff + Doppler provider Go 型定義の diff を取らせた。破壊的変更は v2.0.0 (Alibaba/Device42 provider 削除) と v2.2.0 (Flux OCIRepository consumer 向け) のみで、いずれも該当なし（Doppler / ArgoCD+Kustomize 使用のため）。Doppler 認証スキーマ・ClusterSecretStore/ExternalSecret の該当フィールドは 1.3.2/2.8.0 間で完全一致。1.3.0 以外に yank されたバージョンは無し。CRD bundle は追加のみで削除なし（manifest deletion guard の対象外）"
     },
     {

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,10 +2,17 @@
   "open": [],
   "merged": [
     {
+      "number": 103,
+      "title": "ops: run #12 の記録をまとめ、ダッシュボードを再生成する",
+      "url": "https://github.com/hikuohiku/homelab/pull/103",
+      "mergedAt": "2026-08-04T23:09:47Z",
+      "headRefName": "autopilot/run12-wrapup"
+    },
+    {
       "number": 102,
       "title": "external-secrets chart を 1.1.1 → 1.3.2 に上げる (T-0026)",
       "url": "https://github.com/hikuohiku/homelab/pull/102",
-      "mergedAt": "2026-08-04T23:15:00Z",
+      "mergedAt": "2026-08-04T23:08:09Z",
       "headRefName": "autopilot/run12-feedback-t0026"
     },
     {

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -30,12 +30,12 @@
       "id": "external-secrets-chart",
       "kind": "helm",
       "name": "external-secrets",
-      "current": "1.3.2",
+      "current": "2.8.0",
       "file": "apps/external-secrets/kustomization.yaml",
       "match": "version:",
       "upstream": "github:external-secrets/external-secrets",
       "policy": "auto",
-      "note": "T-0026 で 1.1.1→1.3.2 に更新 (#run12)。2.8.0 までのメジャー更新は T-0037 で継続（1.x 系の自然な区切りで刻んだ）"
+      "note": "T-0026 で 1.1.1→1.3.2、T-0037 で 1.3.2→2.8.0（メジャー更新の第2段）に更新。Doppler provider の認証スキーマ・ClusterSecretStore/ExternalSecret CRD の該当フィールドとも 1.3.2/2.8.0 間で無変更（CRD diff で確認済み）"
     },
     {
       "id": "immich-chart",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -360,3 +360,18 @@
   backlog の todo で他に残っているのは T-0030（terraform provider pin 見直し, medium）、T-0031/T-0032
   （vaultwarden の運用観点調査, low, ただしログ確認にクラスタ到達が要るため実質 needs-human 化を検討する
   余地あり）
+
+## 2026-08-04 23:19 UTC — run #13
+
+- 前回の中断確認: オープン PR・`autopilot/*` ブランチともに無し。中断なし
+- 読んだフィードバック: issue #56 に未読コメントなし（`last_read` 22:42:36 以降、autopilot 自身の返信
+  22:59:49 が最新）
+- T-0037（external-secrets 1.3.2→2.8.0、メジャー更新の第2段）に着手。subagent に v2.0.0〜v2.8.0 の
+  全 GitHub Release 原文に加え、CRD bundle（1.3.2/2.8.0）の実差分と Doppler provider の Go 型定義の diff を
+  取らせた。破壊的変更は v2.0.0（未使用の Alibaba/Device42 provider 削除）と v2.2.0（Flux OCIRepository
+  consumer 向け、当リポジトリは ArgoCD+Kustomize のため無関係）のみ。Doppler 認証スキーマ・
+  ClusterSecretStore/ExternalSecret の該当フィールドは 1.3.2/2.8.0 間で完全一致、CRD は追加のみで削除なし。
+  1.3.0 以外に yank されたバージョンは無し。安全と判断し完遂
+- 次の起動へ: backlog の todo で残っているのは T-0030（terraform provider pin 見直し, medium）、
+  T-0031/T-0032（vaultwarden の運用観点調査, low。ログ確認にクラスタ到達が要るため実質 needs-human 化を
+  検討する余地あり）

--- a/ops/state.json
+++ b/ops/state.json
@@ -175,7 +175,9 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0037（external-secrets 1.3.2→2.8.0、メジャー更新の第2段）を subagent の全リリースノート原文調査 + CRD/Doppler provider 型定義の実差分照合に基づき完遂。破壊的変更は当リポジトリの使用範囲に該当なしと確認",
-      "prs": []
+      "prs": [
+        105
+      ]
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-04T23:20:00Z",
+  "updated": "2026-08-04T23:26:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -168,6 +168,14 @@
       "prs": [
         102
       ]
+    },
+    {
+      "n": 13,
+      "at": "2026-08-04T23:19:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0037（external-secrets 1.3.2→2.8.0、メジャー更新の第2段）を subagent の全リリースノート原文調査 + CRD/Doppler provider 型定義の実差分照合に基づき完遂。破壊的変更は当リポジトリの使用範囲に該当なしと確認",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

- `apps/external-secrets/kustomization.yaml` の Helm chart version を `1.3.2` → `2.8.0` に更新（T-0026 で刻んだメジャー更新の第2段。1.3.2→2.0.0→...→2.8.0）
- `ops/inventory.json` の `external-secrets-chart` current を追従
- `ops/journal/2026-08.md`: run #13 の記録
- `ops/state.json`: run #13 を追記
- `ops/dashboard/prs.json`: PR キャッシュを最新化（#102, #103 を反映）

## 検証したこと

subagent に v2.0.0〜v2.8.0 の全 GitHub Release を原文で読ませ、以下も裏取りさせた。

- CRD bundle（`deploy/crds/bundle.yaml`）を `1.3.2` と `2.8.0` タグ間で実差分diff。追加のみで削除は無し（`manifest deletion guard` 相当の懸念なし）
- Doppler provider の Go 型定義（`secretstore_doppler_types.go`）を diff。`secretRef.dopplerToken{name,key,namespace}` は完全一致で変更なし
- `ClusterSecretStore`/`ExternalSecret` の該当フィールド（`conversionStrategy`/`decodingStrategy`/`metadataPolicy`/`creationPolicy`/`deletionPolicy`）も完全一致
- 明示的な breaking change は `v2.0.0`（未使用の Alibaba/Device42 provider 削除）と `v2.2.0`（Flux `OCIRepository` consumer 向け、当リポジトリは ArgoCD + Kustomize `helmCharts` のため無関係）の2件のみで、いずれも当リポジトリの使用範囲（doppler 単独 `ClusterSecretStore`、`dataFrom`/template/generator 不使用のシンプルな `ExternalSecret` ×5、`installCRDs: true` のみ）に該当なし
- `1.3.0` 以外に yank されたバージョンは無し
- 手元に `kustomize`/`helm` が無いためレンダリング検証はできず、CI（`kustomize build` / `manifest-diff` job）に委譲（CHARTER §5.2）

## 影響範囲についての注意

external-secrets は Doppler からシークレットを取得する基盤で、Tailscale operator の OAuth シークレット等もこれ経由（自分や人間がこの homelab を観測・操作する経路の一部）。ただし全 `ExternalSecret` が `deletionPolicy: Retain` かつ `creationPolicy: Owner` で既存の k8s Secret はそのまま残り、Pod が更新中に一時的に再起動しても次の `refreshInterval`（1h）まで既存シークレットで動作は継続するはずのため、到達性が即座に失われる変更ではない（T-0026 / #102 と同じ理由）。

## ロールバック手順

このコミットを revert して push すれば ArgoCD が旧 chart version (1.3.2) に self-heal で戻す。クラスタへの直接操作は不要。

## backlog task id

T-0037

---
_Generated by [Claude Code](https://claude.ai/code/session_01ByUrMRZpGGNF1S9Ke1BQjC)_