### PR TITLE
external-secrets chart を 1.3.2 → 2.8.0 に上げる (T-0037)

### DIFF
--- a/apps/external-secrets/kustomization.yaml
+++ b/apps/external-secrets/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 helmCharts:
   - name: external-secrets
     repo: https://charts.external-secrets.io
-    version: 1.3.2
+    version: 2.8.0
     releaseName: external-secrets
     namespace: external-secrets
     valuesInline:

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -489,7 +489,7 @@
         "ops/inventory.json"
       ],
       "created": "2026-08-04",
-      "pr": null,
+      "pr": 106,
       "notes": "run #12: T-0026 の分割で新規起票。調査結果は T-0026 の notes を参照 | run #13: T-0026 (#102) が merge・反映確認済みであることを確認してから着手。subagent に v1.3.2〜v2.8.0 の全 11 リリース（v2.0.0〜v2.8.0）の release note を原文で読ませ、CRD (`externalsecrets`/`clustersecretstores`) を両タグの実ソースで直接比較させた。結論: v1.3.2 は 1.x 系最終版で直後に v2.0.0 が続くため想定していた欠番は無く、chart version と appVersion が完全一致することも確認。全区間で見つかった breaking change（Alibaba/Device42 プロバイダ削除、Sprig 由来のテンプレート関数改名、Flux OCIRepository のレイヤーセレクタ要件等）はいずれもこのリポジトリの使用範囲（doppler 単独、`template`/`dataFrom`/generator 不使用、Kustomize 経由デプロイ）に該当しない。`external-secrets.io/v1` の `remoteRef` enum・`target.deletionPolicy`・doppler の認証形状は両タグで同一（`target.creationPolicy` に `CreateOrMerge` が追加されたのみで既存の `Owner` 指定に影響なし）。CRD バンドルは generator CRD 追加で同等かそれ以上のサイズのため `ServerSideApply=true` の必要性も変わらない。T-0026 時点で「完全 diff は未検証」としていた CRD 本体を実ソース照合まで済ませたため risk を high→medium に見直して着手した"
     },
     {

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -479,19 +479,18 @@
       "domain": "homelab",
       "title": "external-secrets chart を 1.3.2 → 2.8.0 に上げる（メジャー更新の第2段、T-0026 の続き）",
       "kind": "upgrade",
-      "risk": "high",
-      "status": "todo",
+      "risk": "medium",
+      "status": "done",
       "priority": 20,
       "why": "T-0026 (run #12) の続き。1.x→2.x のメジャーバンプ自体は調査済みで、このリポジトリの使用範囲（doppler単独・シンプルな ExternalSecret のみ）に影響する breaking change は見つかっていない。ただし CRD 本体の完全 diff は未検証（WebFetch のサイズ制限）のため、T-0026 (1.3.2) のマージ・ArgoCD 反映が確認できてから改めて着手する",
       "dod": "apps/external-secrets/kustomization.yaml の version が 2.8.0。ops/inventory.json の current も更新。着手前に T-0026 の反映後に異常の兆候が無いか（issue #56 へのフィードバック等）を確認する",
-      "blocked_by": "T-0026 のマージ・反映確認が先。ブロック理由というより実施順序の都合（同一コンポーネントの連続更新を同時に走らせない）",
       "refs": [
         "apps/external-secrets/kustomization.yaml",
         "ops/inventory.json"
       ],
       "created": "2026-08-04",
       "pr": null,
-      "notes": "run #12: T-0026 の分割で新規起票。調査結果は T-0026 の notes を参照"
+      "notes": "run #12: T-0026 の分割で新規起票。調査結果は T-0026 の notes を参照 | run #13: T-0026 (#102) が merge・反映確認済みであることを確認してから着手。subagent に v1.3.2〜v2.8.0 の全 11 リリース（v2.0.0〜v2.8.0）の release note を原文で読ませ、CRD (`externalsecrets`/`clustersecretstores`) を両タグの実ソースで直接比較させた。結論: v1.3.2 は 1.x 系最終版で直後に v2.0.0 が続くため想定していた欠番は無く、chart version と appVersion が完全一致することも確認。全区間で見つかった breaking change（Alibaba/Device42 プロバイダ削除、Sprig 由来のテンプレート関数改名、Flux OCIRepository のレイヤーセレクタ要件等）はいずれもこのリポジトリの使用範囲（doppler 単独、`template`/`dataFrom`/generator 不使用、Kustomize 経由デプロイ）に該当しない。`external-secrets.io/v1` の `remoteRef` enum・`target.deletionPolicy`・doppler の認証形状は両タグで同一（`target.creationPolicy` に `CreateOrMerge` が追加されたのみで既存の `Owner` 指定に影響なし）。CRD バンドルは generator CRD 追加で同等かそれ以上のサイズのため `ServerSideApply=true` の必要性も変わらない。T-0026 時点で「完全 diff は未検証」としていた CRD 本体を実ソース照合まで済ませたため risk を high→medium に見直して着手した"
     },
     {
       "id": "T-0027",

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -30,12 +30,12 @@
       "id": "external-secrets-chart",
       "kind": "helm",
       "name": "external-secrets",
-      "current": "1.3.2",
+      "current": "2.8.0",
       "file": "apps/external-secrets/kustomization.yaml",
       "match": "version:",
       "upstream": "github:external-secrets/external-secrets",
       "policy": "auto",
-      "note": "T-0026 で 1.1.1→1.3.2 に更新 (#run12)。2.8.0 までのメジャー更新は T-0037 で継続（1.x 系の自然な区切りで刻んだ）"
+      "note": "T-0026 で 1.1.1→1.3.2 (#run12)、T-0037 で 1.3.2→2.8.0 (#run13) に更新。1.3.2 は 1.x 系最終版で直後に 2.0.0 が続くため v1.4〜v1.x の欠番は無い。chart version と appVersion は完全一致"
     },
     {
       "id": "immich-chart",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -372,4 +372,14 @@
 - T-0031: ログ頻度そのものはこのサンドボックスから確認できないが、Maintenance.md 2026-08-03 の時点で
   実機到達できる人間セッションが既に「多発するが実害なし」と確認済みの記録があり、それを根拠に
   `DISABLE_ICON_DOWNLOAD=true` を設定して完遂。favicon 表示のみに影響しデータには触れない変更で、
-  環境変数 1 行の削除で即座に戻せるため low risk
+  環境変数 1 行の削除で即座に戻せるため low risk（#104, merged）
+- #104 merge を確認後、subagent の T-0037 調査結果が届いた。v1.3.2〜v2.8.0 の全 11 リリース（v2.0.0〜v2.8.0）
+  の release note を原文で読ませ、CRD (`externalsecrets`/`clustersecretstores`) を両タグの実ソースで
+  直接比較させる調査。結論: v1.3.2 は 1.x 系最終版で直後に v2.0.0 が続くため想定していた欠番（v1.4〜v1.x）
+  は無く、chart version と appVersion が完全一致することも確認。全区間の breaking change（Alibaba/Device42
+  プロバイダ削除、Sprig 由来のテンプレート関数改名、Flux OCIRepository のレイヤーセレクタ要件等）はいずれも
+  このリポジトリの使用範囲（doppler 単独、`template`/`dataFrom`/generator 不使用、Kustomize 経由デプロイ）に
+  該当しない。`external-secrets.io/v1` の `remoteRef` enum・`target.deletionPolicy`・doppler の認証形状は
+  両タグで同一（`target.creationPolicy` に `CreateOrMerge` が追加されたのみ）。T-0026 時点で「完全 diff は
+  未検証」としていた CRD 本体を実ソース照合まで済ませたため risk を high→medium に見直し、1.3.2→2.8.0 を
+  1 PR で完遂した


### PR DESCRIPTION
## 変更点

- `apps/external-secrets/kustomization.yaml` の Helm chart version を `1.3.2` → `2.8.0` に更新（T-0026 のメジャー更新の第2段、1.x→2.x 本体）
- `ops/inventory.json` の `external-secrets-chart` current を追従
- `ops/backlog.json`: T-0037 を完遂、risk を high → medium に見直し
- `ops/journal/2026-08.md`: run #13 の記録

## 検証したこと

subagent に v1.3.2〜v2.8.0 の全 11 リリース（v2.0.0〜v2.8.0）の release note を原文で読ませ、CRD (`externalsecrets` / `clustersecretstores`) を両タグの実ソース（`config/crds/bases/`）で直接比較させた。

- v1.3.2 は 1.x 系最終版で直後に v2.0.0 が続くため、T-0026 時点で懸念していた v1.4〜v1.x の欠番は無い。chart version と appVersion は両タグとも完全一致
- 全区間で見つかった breaking change: Alibaba/Device42 プロバイダ削除（v2.0.0）、Sprig 由来のテンプレート関数改名（v2.0.1）、Flux OCIRepository のレイヤーセレクタ要件（v2.2.0）等。いずれもこのリポジトリの使用範囲（doppler 単独の `ClusterSecretStore`、`template`/`dataFrom`/generator 不使用のシンプルな `ExternalSecret` ×5、Kustomize 経由デプロイ）に該当しない
- `external-secrets.io/v1` の `remoteRef.conversionStrategy`/`decodingStrategy`/`metadataPolicy` enum、`target.deletionPolicy` は両タグで同一。`target.creationPolicy` に `CreateOrMerge` が追加されたのみ（既存の `Owner` 指定に影響なし）
- doppler provider の認証形状（`secretRef.dopplerToken{name,key,namespace}`）は両タグで同一
- `installCRDs` の意味・デフォルトは不変。新規の必須 values は無し
- CRD バンドルは generator CRD 追加で同等かそれ以上のサイズのため、262KB 超対応の `ServerSideApply=true`（ArgoCD Application 側）は引き続き必要かつ有効
- `kubeVersion` 制約（`>= 1.19.0-0`）は両タグで不変
- 手元に `kustomize`/`helm` が無いためレンダリング検証はできず、CI（`kustomize build` job・`manifest-diff` job）に委譲（CHARTER §5.2）

## 影響範囲についての注意

External Secrets Operator は Doppler からシークレットを取得する基盤で、Tailscale operator の OAuth シークレット (`operator-oauth`)、Coder/Immich/Dex/vaultwarden の認証情報もこれ経由。ただし全 `ExternalSecret` が `deletionPolicy: Retain` かつ `creationPolicy: Owner` で、既存の k8s Secret はそのまま残る。ESO の Pod が更新中に一時的に再起動しても、次の `refreshInterval`（1h）まで既存シークレットで動作は継続するため、到達性が即座に失われる変更ではない。

## ロールバック手順

このコミットを revert して push すれば ArgoCD が旧 chart version (1.3.2) に self-heal で戻す。クラスタへの直接操作は不要。

## backlog task id

T-0037

---
_Generated by [Claude Code](https://claude.ai/code/session_01PikZKZrm8pRiqNAEib1zF2)_