### PR TITLE
vaultwarden: IP_HEADER=X-Forwarded-For を設定し Tailscale 経由のレート制限誤発火を防ぐ (T-0032)

### DIFF
--- a/Maintenance.md
+++ b/Maintenance.md
@@ -31,7 +31,12 @@ vaultwarden 1.36.0 の据え置きにより、web 以外の全クライアント
     P2P 特性の移行可否検討のみに変更（Plans.md 反映済み）
 - `ADMIN_TOKEN` が平文（起動ログに警告）。Argon2 PHC 化は今回見送り → `ops/backlog.json` T-0011（needs-human、Doppler への登録待ち）
 - 1.37.0 でレート制限が追加された。全クライアントが Tailscale プロキシ経由で同一
-  送信元 IP に見えるため、429 が出ないか要確認 → `ops/backlog.json` T-0032
+  送信元 IP に見えるため、429 が出ないか要確認 → **解消（2026-08-05）**: 懸念どおり、
+  Tailscale Ingress はリバースプロキシとして自 Pod から接続するため raw peer IP は全クライアントで
+  同一になる。ただし `X-Forwarded-For` には実クライアントの tailnet peer アドレスが入っているため、
+  `apps/vaultwarden/deployment.yaml` に `IP_HEADER=X-Forwarded-For` を設定して読ませるようにした
+  （`ops/backlog.json` T-0032）。実際に 429 が発生していたかどうかのログ確認はできていない
+  （クラスタ到達不可）が、原因側の設定不備は解消した
 - icon 取得のタイムアウトが多発。実害なし。`DISABLE_ICON_DOWNLOAD` で無効化可 → **解消（2026-08-05）**:
   `apps/vaultwarden/deployment.yaml` に `DISABLE_ICON_DOWNLOAD=true` を設定（`ops/backlog.json` T-0031）
 

--- a/apps/vaultwarden/deployment.yaml
+++ b/apps/vaultwarden/deployment.yaml
@@ -56,6 +56,14 @@ spec:
             # ログを埋めるだけの無害な失敗のため無効化する (T-0031)
             - name: DISABLE_ICON_DOWNLOAD
               value: "true"
+            # 1.37.0 で追加されたレート制限は remote peer の IP を見るが、Tailscale Ingress は
+            # リバースプロキシとして自 Pod から backend へ接続するため、デフォルト設定では
+            # 全クライアントが同一の proxy pod IP に見えてしまう (T-0032)。Tailscale 側は
+            # X-Forwarded-For に実クライアントの tailnet peer アドレスを載せて送っているため、
+            # IP_HEADER で明示的に読ませる。IP_HEADER_TRUSTED_PROXIES は既定の "local" のままでよい
+            # (直接の peer である proxy pod の IP は CNI のプライベートアドレスのため自動的に信頼される)
+            - name: IP_HEADER
+              value: "X-Forwarded-For"
             # WebSocket 通知 (リアルタイム同期) は 1.x 系で HTTP ポートに統合済みのため
             # 別ポート/別 env (WEBSOCKET_ENABLED) は不要。Ingress も 80 だけで完結する。
             - name: ADMIN_TOKEN

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -598,7 +598,7 @@
         "apps/vaultwarden/"
       ],
       "created": "2026-08-04",
-      "pr": null,
+      "pr": 107,
       "notes": "run #13: 実際に 429 が発生していたかのログはクラスタ非到達のため確認できていないが、subagent に tailscale/tailscale と dani-garcia/vaultwarden の実ソースを直接読ませ、懸念の構造的な原因を特定した。Tailscale k8s operator の Ingress はリバースプロキシとして自 Pod から backend Service へ接続する実装（cmd/k8s-operator/ingress.go）のため raw TCP peer IP は常に proxy pod 自身になるが、`addProxyForwardedHeaders()` (ipn/ipnlocal/serve.go) が `X-Forwarded-For` に実クライアントの tailnet peer アドレスを `Set`（`Append` ではない）で書き込んでおり、クライアント側から偽装できない。一方 vaultwarden の `IP_HEADER` は未設定だとデフォルトの `X-Real-IP` を見るため、この `X-Forwarded-For` を読んでいなかった。`apps/vaultwarden/deployment.yaml` に `IP_HEADER=X-Forwarded-For` を追加して解消した。`IP_HEADER_TRUSTED_PROXIES` は既定の `local` のままで、直接の peer（proxy pod、CNI のプライベート IP）は自動的に信頼されるため変更不要"
     },
     {

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -588,8 +588,8 @@
       "domain": "homelab",
       "title": "vaultwarden 1.37 のレート制限が Tailscale プロキシ経由の同一送信元 IP で誤発火していないか確認する",
       "kind": "investigate",
-      "risk": "low",
-      "status": "todo",
+      "risk": "medium",
+      "status": "done",
       "priority": 22,
       "why": "Maintenance.md 2026-08-03 の持ち越し。1.37.0 で追加されたレート制限は送信元 IP 単位。全クライアントが Tailscale プロキシ経由で同一 IP に見えるため、正規クライアントが 429 で弾かれていないか未確認",
       "dod": "ログまたはクライアントの実際の挙動から 429 が発生していないか確認する。発生していれば ROCKET_LIMIT_* 系の設定調整か、送信元判定の見直しを検討する。発生していなければ Maintenance.md に確認済みと記録する",
@@ -598,7 +598,8 @@
         "apps/vaultwarden/"
       ],
       "created": "2026-08-04",
-      "pr": null
+      "pr": null,
+      "notes": "run #13: 実際に 429 が発生していたかのログはクラスタ非到達のため確認できていないが、subagent に tailscale/tailscale と dani-garcia/vaultwarden の実ソースを直接読ませ、懸念の構造的な原因を特定した。Tailscale k8s operator の Ingress はリバースプロキシとして自 Pod から backend Service へ接続する実装（cmd/k8s-operator/ingress.go）のため raw TCP peer IP は常に proxy pod 自身になるが、`addProxyForwardedHeaders()` (ipn/ipnlocal/serve.go) が `X-Forwarded-For` に実クライアントの tailnet peer アドレスを `Set`（`Append` ではない）で書き込んでおり、クライアント側から偽装できない。一方 vaultwarden の `IP_HEADER` は未設定だとデフォルトの `X-Real-IP` を見るため、この `X-Forwarded-For` を読んでいなかった。`apps/vaultwarden/deployment.yaml` に `IP_HEADER=X-Forwarded-For` を追加して解消した。`IP_HEADER_TRUSTED_PROXIES` は既定の `local` のままで、直接の peer（proxy pod、CNI のプライベート IP）は自動的に信頼されるため変更不要"
     },
     {
       "id": "T-0034",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -382,4 +382,17 @@
   該当しない。`external-secrets.io/v1` の `remoteRef` enum・`target.deletionPolicy`・doppler の認証形状は
   両タグで同一（`target.creationPolicy` に `CreateOrMerge` が追加されたのみ）。T-0026 時点で「完全 diff は
   未検証」としていた CRD 本体を実ソース照合まで済ませたため risk を high→medium に見直し、1.3.2→2.8.0 を
-  1 PR で完遂した
+  1 PR で完遂した（#106, merged）
+- #106 merge を確認後、続けて T-0032（vaultwarden の rate limit 誤発火懸念）に着手・完遂。実際の 429 発生有無は
+  ログ非到達で確認できなかったが、subagent に tailscale/tailscale と dani-garcia/vaultwarden の実ソースを
+  読ませて構造的な原因を特定できた。Tailscale k8s operator の Ingress は自 Pod から backend へ接続する
+  リバースプロキシ実装のため raw peer IP は常に proxy pod 自身になるが、Tailscale 側は `X-Forwarded-For` に
+  実クライアントの tailnet peer アドレスを `Set`（クライアントから偽装不可）で書き込んでいる。vaultwarden は
+  `IP_HEADER` 未設定だとデフォルトの `X-Real-IP` しか見ないためこれを読んでいなかった。
+  `IP_HEADER=X-Forwarded-For` を追加して解消した（`IP_HEADER_TRUSTED_PROXIES` は既定の `local` のままで
+  問題ない、直接の peer は CNI のプライベート IP のため）。**ログで実際に観測して確認したわけではなく、
+  ソースコード解析による構造的な原因究明であることに注意**
+- run #13 のまとめ（ここまで）: T-0031/T-0037/T-0032 の 3 PR を直列でマージまで見届けた。external-secrets の
+  メジャー更新を CRD 実ソース照合で安全に完遂し、vaultwarden の 2 つの持ち越し課題（icon タイムアウト・
+  レート制限）を両方解消できた。backlog の todo で残っているのは T-0030（terraform provider pin 見直し,
+  medium）のみ。それ以外は done/blocked/needs-human


### PR DESCRIPTION
## 変更点

- `apps/vaultwarden/deployment.yaml` に `IP_HEADER=X-Forwarded-For` を追加
- `Maintenance.md` の 2026-08-03 持ち越し項目に解消済みの注記を追加
- `ops/backlog.json`: T-0032 を完遂、risk を low → medium に見直し

## 背景・検証したこと

Maintenance.md 2026-08-03 の持ち越し課題（1.37.0 のレート制限が Tailscale プロキシ経由の同一送信元 IP で誤発火しないか）を、subagent に `tailscale/tailscale` と `dani-garcia/vaultwarden` の実ソースを直接読ませて構造的に確認した。

- Tailscale k8s operator の `Ingress` はリバースプロキシとして自 Pod から backend Service (ClusterIP) へ接続する実装（`cmd/k8s-operator/ingress.go`）。そのため vaultwarden から見た raw TCP peer IP は常に proxy pod 自身になる
- ただし Tailscale 側は `addProxyForwardedHeaders()` (`ipn/ipnlocal/serve.go`) で `X-Forwarded-For` に実クライアントの tailnet peer アドレスを **`Set`**（`Append` ではない）で書き込んでいる。クライアントが直接この値を送っても上書きされるため偽装できない
- vaultwarden は `IP_HEADER` が未設定だとデフォルトの `X-Real-IP` しか見ない（`src/config.rs`）ため、`X-Forwarded-For` を読んでいなかった。これが今回設定した理由
- `IP_HEADER_TRUSTED_PROXIES` は既定の `"local"` のままで良い。直接の peer（proxy pod）は CNI のプライベート IP のため `is_global()` が false になり自動的に信頼される（`src/auth.rs`）

**注意**: 実際に 429 が発生していたかどうかのログはこのクラウドサンドボックスから確認できない（クラスタ非到達）。今回の変更は「構造的に誤発火しうる設定不備があった」ことをソースコード解析で特定し、その原因側を解消したものであり、実際に 429 を観測して直したわけではない。

## ロールバック手順

このコミットを revert して push すれば ArgoCD が旧状態（`IP_HEADER` 未設定 = `X-Real-IP`）に self-heal で戻す。クラスタへの直接操作は不要。

## backlog task id

T-0032

---
_Generated by [Claude Code](https://claude.ai/code/session_01PikZKZrm8pRiqNAEib1zF2)_