### PR TITLE
ops: run #13 の記録をまとめ、ダッシュボードを再生成する

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -555,15 +555,18 @@
       "title": "terraform bpg/proxmox provider の pin (0.89.1) を見直す（現在 v0.111.1 まで進んでいる）",
       "kind": "investigate",
       "risk": "medium",
-      "status": "todo",
+      "status": "needs-human",
       "priority": 25,
       "why": "T-0005 の調査 (run #6) で判明。約 22 リリース分の差。意図的な完全一致 pin（理由コメントあり）なので、まず pin した理由が今も成り立つか確認するのが先。v0.109.0 のリリースノートに VM agent の IP 待機設定まわりの breaking change の言及がある",
       "dod": "providers.tf の pin 理由コメントを再確認し、今も成り立つか判断する。上げる場合は 0.89.1 から v0.111.1 までのリリースノートを原文で読み、breaking change を洗い出す。terraform apply は autopilot が実行できないため、実際の反映は人間の作業になる旨を PR に明記する",
+      "needs_human_reason": "破壊的変更の調査自体は完了し、v0.111.1 への一段更新が安全と分かった（下記 notes）。ただし `.terraform.lock.hcl` の更新には provider バイナリの h1 ハッシュ（dirhash）を計算する必要があり、これは terraform CLI 本体でしか生成できない。この CI（`terraform validate` job）は既存の lock file をそのまま使う（`-upgrade` なし）ため、providers.tf の version だけ書き換えて lock を古いままにすると CI が落ちて ruleset でマージできない。**お願いしたいこと**: terraform が使える環境（人間の対話セッション、または run #0 と同じ環境）で `cd terraform/proxmox && terraform init -upgrade` を実行し、`providers.tf` の version を `= 0.111.1` に、`.terraform.lock.hcl` を再生成したものをコミットしてほしい。version 変更・破壊的変更の調査自体はここで完了しているので、コマンド実行だけで良い",
       "refs": [
-        "terraform/proxmox/providers.tf"
+        "terraform/proxmox/providers.tf",
+        "terraform/proxmox/.terraform.lock.hcl"
       ],
       "created": "2026-08-04",
-      "pr": null
+      "pr": null,
+      "notes": "run #13: subagent に `.tf` ファイル全体（3 リソースタイプのみ使用: download_file, file, virtual_environment_vm）と v0.89.2〜v0.111.1 の CHANGELOG.md / upgrade guide を原文で照合させた。**結論: v0.111.1 への一段更新で安全、.tf ファイルの変更は不要。** 懸念されていた v0.109.0 の `agent.wait_for_ip` 反転（enabled→disabled）は、このリポジトリが `agent.wait_for_ip` を一切設定しておらず（`agent.enabled` のみ使用）、IP 出力（`node01_ip`）もハードコードされた文字列で `ipv4_addresses` を参照していないため無関係と確認。他の breaking change（network_device.enabled 非推奨、LXC cpu.units、VM/container 名の DNS 検証等）もすべて未使用のリソース/属性。providers.tf 冒頭のコメント（`完全一致 pin は nix 管理の terraform と噛み合わないため範囲指定`）は `required_version`（terraform 本体）についての説明で、`bpg/proxmox` provider の pin 理由コメントは別途存在しない（浅いクローンのため元コミットの経緯も確認できず）。terraform 本体が無いため lock file の regenerate ができず、version 変更だけでは CI が落ちる（`.terraform.lock.hcl` はハッシュの手書き生成ができない）ため needs-human とした"
     },
     {
       "id": "T-0031",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,11 +2,39 @@
   "open": [],
   "merged": [
     {
+      "number": 107,
+      "title": "vaultwarden: IP_HEADER=X-Forwarded-For を設定し Tailscale 経由のレート制限誤発火を防ぐ (T-0032)",
+      "url": "https://github.com/hikuohiku/homelab/pull/107",
+      "mergedAt": "2026-08-04T23:38:46Z",
+      "headRefName": "autopilot/t0032-vaultwarden-ip-header"
+    },
+    {
+      "number": 106,
+      "title": "external-secrets chart を 1.3.2 → 2.8.0 に上げる (T-0037)",
+      "url": "https://github.com/hikuohiku/homelab/pull/106",
+      "mergedAt": "2026-08-04T23:35:52Z",
+      "headRefName": "autopilot/t0037-external-secrets-2.8.0"
+    },
+    {
+      "number": 104,
+      "title": "vaultwarden: icon 取得タイムアウトを DISABLE_ICON_DOWNLOAD で無効化する (T-0031)",
+      "url": "https://github.com/hikuohiku/homelab/pull/104",
+      "mergedAt": "2026-08-04T23:31:42Z",
+      "headRefName": "autopilot/t0031-vaultwarden-disable-icon"
+    },
+    {
       "number": 102,
       "title": "external-secrets chart を 1.1.1 → 1.3.2 に上げる (T-0026)",
       "url": "https://github.com/hikuohiku/homelab/pull/102",
       "mergedAt": "2026-08-04T23:15:00Z",
       "headRefName": "autopilot/run12-feedback-t0026"
+    },
+    {
+      "number": 103,
+      "title": "ops: run #12 の記録をまとめ、ダッシュボードを再生成する",
+      "url": "https://github.com/hikuohiku/homelab/pull/103",
+      "mergedAt": "2026-08-04T23:09:47Z",
+      "headRefName": "autopilot/run12-wrapup"
     },
     {
       "number": 101,
@@ -392,34 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/46",
       "mergedAt": "2026-06-21T06:28:16Z",
       "headRefName": "chore/cleanup-orphan-namespaces"
-    },
-    {
-      "number": 45,
-      "title": "chore: Proxmox 棚卸しと pbs の手動管理方針を明示",
-      "url": "https://github.com/hikuohiku/homelab/pull/45",
-      "mergedAt": "2026-06-21T06:04:01Z",
-      "headRefName": "chore/proxmox-cleanup-pbs-manual"
-    },
-    {
-      "number": 43,
-      "title": "feat: GitHub Copilot PR レビューを日本語化",
-      "url": "https://github.com/hikuohiku/homelab/pull/43",
-      "mergedAt": "2026-05-21T00:58:51Z",
-      "headRefName": "feat/copilot-japanese-review"
-    },
-    {
-      "number": 41,
-      "title": "feat: ArgoCD preview deploy commands + PVC data protection",
-      "url": "https://github.com/hikuohiku/homelab/pull/41",
-      "mergedAt": "2026-05-20T15:10:25Z",
-      "headRefName": "feat/preview-deploy-flow"
-    },
-    {
-      "number": 39,
-      "title": "feat(immich): add Immich K8s manifests for LXC migration",
-      "url": "https://github.com/hikuohiku/homelab/pull/39",
-      "mergedAt": "2026-05-20T13:42:27Z",
-      "headRefName": "feat/immich-k8s-migration"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -392,7 +392,25 @@
   `IP_HEADER=X-Forwarded-For` を追加して解消した（`IP_HEADER_TRUSTED_PROXIES` は既定の `local` のままで
   問題ない、直接の peer は CNI のプライベート IP のため）。**ログで実際に観測して確認したわけではなく、
   ソースコード解析による構造的な原因究明であることに注意**
-- run #13 のまとめ（ここまで）: T-0031/T-0037/T-0032 の 3 PR を直列でマージまで見届けた。external-secrets の
+- #107 merge を確認後、ダッシュボードの PR キャッシュを最新化する過程で **別セッションによる並行実行と
+  衝突していたことを発見**。open PR 一覧に、こちらの T-0037 (#106) と同じ変更を別セッション
+  （PR 本文の署名が session_01ByUrMRZpGGNF1S9Ke1BQjC、こちらのセッションとは別）が作った PR #105
+  （23:30:54 作成、こちらの #106 より前の base）が残っていた。#106 が先に merge されていたため #105 は
+  重複・古い base のまま停滞していた。理由をコメントして close した（run #6/#7 で経験した「複数セッションが
+  同時に走ると `ops/` の記録で衝突する」問題の別形態— 今回は記録ファイルでの git conflict ではなく、
+  同一タスクへの重複 PR という形で表面化した。§2 の直列化ルールは自セッション内の複数タスクを対象にしており、
+  別セッションとの並行実行までは防げないことを再確認した。実害は無かった（#106 が正しく merge され、
+  #105 は単に重複だっただけ）ため、CHARTER の変更はせず事実として記録するに留める）
+- 続けて T-0030（terraform bpg/proxmox provider pin 見直し）を調査。subagent に `.tf` 全体（3 リソースタイプ
+  のみ使用）と v0.89.2〜v0.111.1 の CHANGELOG/upgrade guide を照合させ、**v0.111.1 への一段更新が安全
+  （.tf ファイルの変更は不要）** と確認できた。懸念されていた v0.109.0 の `agent.wait_for_ip` 反転はこの
+  リポジトリが該当フィールドを一切使っていないため無関係。ただし `.terraform.lock.hcl` の再生成には
+  provider バイナリの dirhash が要り、これは terraform CLI 本体でしか計算できない（このサンドボックスには
+  無い、CHARTER §5.2）。CI の `terraform validate` job は `-upgrade` なしで既存 lock を使うため、
+  version だけ書き換えると CI が落ちてマージできない。version 変更・破壊的変更調査はここで完了しているため
+  「コマンド実行だけで良い」と具体的に絞った上で T-0030 を `needs-human` にした
+- run #13 のまとめ: T-0031/T-0037/T-0032 の 3 PR を直列でマージまで見届けた。external-secrets の
   メジャー更新を CRD 実ソース照合で安全に完遂し、vaultwarden の 2 つの持ち越し課題（icon タイムアウト・
-  レート制限）を両方解消できた。backlog の todo で残っているのは T-0030（terraform provider pin 見直し,
-  medium）のみ。それ以外は done/blocked/needs-human
+  レート制限）を両方解消できた。T-0030 は調査を完了させ、実行環境の制約（terraform CLI 不在）を理由に
+  具体的な依頼内容で `needs-human` にした。副産物として他セッションとの並行実行による PR 重複を発見・解消。
+  backlog の todo は 0 件（残りは done/blocked/needs-human のみ）

--- a/ops/state.json
+++ b/ops/state.json
@@ -168,6 +168,18 @@
       "prs": [
         102
       ]
+    },
+    {
+      "n": 13,
+      "at": "2026-08-04T23:20:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "issue #56 に未読フィードバックなし。T-0031（vaultwarden icon タイムアウトを DISABLE_ICON_DOWNLOAD で解消）・T-0037（external-secrets chart 1.3.2→2.8.0、CRD 実ソース照合で breaking change 無しと確認）・T-0032（vaultwarden の rate limit が Tailscale プロキシ経由で誤発火する構造的原因を特定し IP_HEADER=X-Forwarded-For で解消）を完遂。T-0030（terraform provider pin 見直し）は調査を完了し v0.111.1 への一段更新が安全と確認したが、.terraform.lock.hcl の再生成に terraform CLI（このサンドボックスに無い）が要るため needs-human に。副産物として別セッションによる並行実行（T-0037 の重複 PR #105）を発見し close した",
+      "prs": [
+        104,
+        106,
+        107
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

- `ops/journal/2026-08.md`: run #13 の記録（T-0031/T-0037/T-0032 完遂、T-0030 needs-human 化、並行実行による重複 PR #105 の発見・close）
- `ops/state.json`: run #13 を追記
- `ops/backlog.json`: T-0030 を `todo` → `needs-human` に変更（調査は完了、`.terraform.lock.hcl` の再生成に terraform CLI が必要なため）
- `ops/dashboard/prs.json`: PR キャッシュを最新化（#104, #106, #107 の merge を反映）

## 検証したこと

- `python3 ops/validate.py` で 0 error を確認（warning 2 件は既知: `ops/dashboard/index.html` 未追跡、todo 0 件）
- `python3 ops/dashboard/build.py` を実行し `ops/dashboard/index.html` を再生成

## ロールバック手順

このコミットを revert して push すれば元の記録に戻る。実インフラには影響しない。

## backlog task id

run #13 の記録（複数タスクの相乗り、CHARTER §4 の例外規定）

---
_Generated by [Claude Code](https://claude.ai/code/session_01PikZKZrm8pRiqNAEib1zF2)_