### PR TITLE
Maintenance.md: T-0031 revert / T-0038 完遂を反映 (T-0039)

### DIFF
--- a/Maintenance.md
+++ b/Maintenance.md
@@ -36,9 +36,14 @@ vaultwarden 1.36.0 の据え置きにより、web 以外の全クライアント
   同一になる。ただし `X-Forwarded-For` には実クライアントの tailnet peer アドレスが入っているため、
   `apps/vaultwarden/deployment.yaml` に `IP_HEADER=X-Forwarded-For` を設定して読ませるようにした
   （`ops/backlog.json` T-0032）。実際に 429 が発生していたかどうかのログ確認はできていない
-  （クラスタ到達不可）が、原因側の設定不備は解消した
-- icon 取得のタイムアウトが多発。実害なし。`DISABLE_ICON_DOWNLOAD` で無効化可 → **解消（2026-08-05）**:
-  `apps/vaultwarden/deployment.yaml` に `DISABLE_ICON_DOWNLOAD=true` を設定（`ops/backlog.json` T-0031）
+  （クラスタ到達不可）が、原因側の設定不備は解消した。あわせて `IP_HEADER_TRUSTED_PROXIES` を既定の
+  `local`（private アドレス全体を信頼）からこの k3s クラスタの pod CIDR `10.42.0.0/16` に絞り、
+  クラスタ内部の別 Pod による `X-Forwarded-For` 詐称の余地を減らした（T-0038）
+- icon 取得のタイムアウトが多発。実害なし。`DISABLE_ICON_DOWNLOAD` で無効化可 → **見送り（2026-08-05）**:
+  一度 `DISABLE_ICON_DOWNLOAD=true` を設定したが、「実害なしと記録済みの事象のために利用者に見える
+  機能（クライアントのサイトアイコン表示）を犠牲にしている」という指摘（issue #56）を受けて revert した。
+  ログノイズを消す価値より favicon 表示を残す価値のほうが大きいと判断（`ops/backlog.json` T-0031、
+  `dropped`）。実害が出るようになったら改めて起票する
 
 ### 振り返り
 

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -708,7 +708,7 @@
         "Maintenance.md"
       ],
       "created": "2026-08-05",
-      "pr": null,
+      "pr": 112,
       "notes": "run #14: icon 側は「見送り（revert）」に、レート制限側は T-0038（IP_HEADER_TRUSTED_PROXIES を pod CIDR に絞った旨）を追記した"
     }
   ]

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 39,
-  "updated": "2026-08-05T00:20:00Z",
+  "next_id": 40,
+  "updated": "2026-08-05T00:30:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -693,6 +693,23 @@
       "created": "2026-08-05",
       "pr": 111,
       "notes": "run #14: subagent に dani-garcia/vaultwarden の実ソース（tag 1.37.1、このリポジトリの pin と一致）を確認させた。`IP_HEADER_TRUSTED_PROXIES` は 1.37.0 で追加された実在の設定でカンマ区切りの IP/CIDR を受け付ける（`local` は private アドレス全体を信頼、`all` は誰でも信頼）。この k3s クラスタは `--cluster-cidr` を指定していないデフォルト flannel 構成で、service CIDR が 10.43.0.0/16（ts-nameserver-fixed.yaml の clusterIP で確認済み）と k3s のデフォルト組であることから pod CIDR は 10.42.0.0/16 と判断した。`IP_HEADER_TRUSTED_PROXIES=10.42.0.0/16` を設定し、`local`（10/8, 172.16/12, 192.168/16 全体を信頼）から pod CIDR 単体への絞り込みとした。誤って絞りすぎた場合の失敗方向は「信頼されず IP_HEADER が無視されレート制限が proxy pod IP に付く」という以前と同じ安全側の挙動であり、正規アクセスを弾く方向には倒れない"
+    },
+    {
+      "id": "T-0039",
+      "domain": "homelab",
+      "title": "Maintenance.md の持ち越し記録を T-0031 revert / T-0038 完遂の実態に合わせる",
+      "kind": "docs",
+      "risk": "low",
+      "status": "done",
+      "priority": 8,
+      "why": "CHARTER §3 のドキュメント整合性チェック（run #14）で発見。Maintenance.md 2026-08-03 の持ち越し項目が「icon 無効化で解消（2026-08-05）」「IP_HEADER 設定で解消」と書かれたままで、その後の T-0031 revert（#110）・T-0038（#111）を反映していなかった",
+      "dod": "Maintenance.md の該当 2 項目が現在の backlog の状態（T-0031 dropped、T-0038 done）と一致する",
+      "refs": [
+        "Maintenance.md"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #14: icon 側は「見送り（revert）」に、レート制限側は T-0038（IP_HEADER_TRUSTED_PROXIES を pod CIDR に絞った旨）を追記した"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -441,5 +441,9 @@
   IP/CIDR、既定 `local` は private アドレス全体を信頼）と確認。k3s の pod CIDR がデフォルト
   10.42.0.0/16（`--cluster-cidr` 未指定、service CIDR 10.43.0.0/16 が k3s デフォルトと一致することから
   推定）と判断し、`IP_HEADER_TRUSTED_PROXIES=10.42.0.0/16` を設定して完遂
+- #111 merge を確認後、`Maintenance.md` の持ち越し 2 件（icon タイムアウト・レート制限）の記録が
+  T-0031 revert と T-0038 完遂で実態とずれていたことに気づいた（CHARTER §3 のドキュメント整合性チェック）。
+  「icon 無効化で解消」の記録を「revert して見送り」に、レート制限側に T-0038 の追記を反映した（T-0039）
 - run #14 のまとめ: issue #56 のフィードバック 4 件を反映（#109）、T-0031 を revert（#110）、
-  T-0038 を完遂。backlog の todo は再び 0 件（残りは done/blocked/needs-human/dropped のみ）
+  T-0038 を完遂（#111）、Maintenance.md の記録を実態に合わせた（T-0039）。backlog の todo は
+  再び 0 件（残りは done/blocked/needs-human/dropped のみ）


### PR DESCRIPTION
## 変更点

`Maintenance.md` の 2026-08-03 持ち越し項目のうち vaultwarden の 2 件が、その後の対応（T-0031 revert、T-0038 完遂）を反映せず古い記録のままだったため更新する。

- icon 取得タイムアウト: 「`DISABLE_ICON_DOWNLOAD=true` で解消」→「revert して見送り」（利用者に見える機能を犠牲にする割に合わないという issue #56 の指摘を反映、T-0031 は `dropped`）
- レート制限 429 懸念: `IP_HEADER=X-Forwarded-For` の設定に加え、`IP_HEADER_TRUSTED_PROXIES` を pod CIDR (`10.42.0.0/16`) に絞ったこと（T-0038）を追記

コードやインフラの変更は無い。ドキュメントを実態に合わせるだけ。

## 検証したこと

- `python3 ops/validate.py` → 0 error（既存 warning 2 件は本 PR と無関係。3件目「todo が無い」は本PRのbacklog更新 T-0039 追加により一時的に出ているだけで merge 後は起票が必要）

## ロールバック手順

`Maintenance.md` のみの変更。revert すれば即座に戻る。インフラへの影響なし。

## backlog task id

T-0039

---
_Generated by [Claude Code](https://claude.ai/code/session_015rrefiqjRFQoSw5J688XPY)_