### PR TITLE
ops: run #14 の記録をまとめ、ダッシュボードを再生成する

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 40,
-  "updated": "2026-08-05T00:30:00Z",
+  "next_id": 41,
+  "updated": "2026-08-05T00:35:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -710,6 +710,26 @@
       "created": "2026-08-05",
       "pr": 112,
       "notes": "run #14: icon 側は「見送り（revert）」に、レート制限側は T-0038（IP_HEADER_TRUSTED_PROXIES を pod CIDR に絞った旨）を追記した"
+    },
+    {
+      "id": "T-0040",
+      "domain": "homelab",
+      "title": "ops/inventory.json の全対象を再調査し、上流の新しい版が出ていないか確認する（T-0005 の定期再実行）",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "done",
+      "priority": 25,
+      "why": "run #14 時点で backlog の todo が 0 件になった（T-0005 由来の個別更新タスクを全て消化）。CHARTER §3 は backlog が空のときに調査タスクを自分で起票することを求めている。T-0005 の調査（run #6, 2026-08-04）から日数が経つと inventory.json の各対象がまた古くなる。T-0012（自己振り返り）と同じ recurring の運用に倣い、T-0005 を初回実施とみなして再調査サイクルに載せる",
+      "dod": "T-0005 と同じ手法（subagent 併用）で ops/inventory.json の全対象の上流最新版を確認し、差分があれば個別の更新タスクを起票する（1 コンポーネント 1 タスク）。この調査自体ではコードを変更しない。実施後は次回の next_review を 1 週間先に更新する",
+      "recurring": "weekly",
+      "last_done": "2026-08-04",
+      "next_review": "2026-08-11",
+      "refs": [
+        "ops/inventory.json"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #14: T-0005（#78）を初回実施として recurring 化しただけで、この起票自体はコード変更を伴わないため PR は無い（ops/ の記録は run14-wrapup PR に相乗り）。次回 2026-08-11 以降の起動で todo に戻して再調査する"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,41 @@
   "open": [],
   "merged": [
     {
+      "number": 112,
+      "title": "Maintenance.md: T-0031 revert / T-0038 完遂を反映 (T-0039)",
+      "url": "https://github.com/hikuohiku/homelab/pull/112",
+      "mergedAt": "2026-08-05T00:11:46Z",
+      "headRefName": "autopilot/T-0039-maintenance-doc-sync"
+    },
+    {
+      "number": 111,
+      "title": "vaultwarden: IP_HEADER_TRUSTED_PROXIES を pod CIDR に絞る (T-0038)",
+      "url": "https://github.com/hikuohiku/homelab/pull/111",
+      "mergedAt": "2026-08-05T00:09:28Z",
+      "headRefName": "autopilot/T-0038-vaultwarden-trusted-proxies"
+    },
+    {
+      "number": 110,
+      "title": "vaultwarden: icon 取得の無効化を revert する (T-0031)",
+      "url": "https://github.com/hikuohiku/homelab/pull/110",
+      "mergedAt": "2026-08-05T00:05:54Z",
+      "headRefName": "autopilot/T-0031-revert-icon-download"
+    },
+    {
+      "number": 109,
+      "title": "issue #56 のフィードバック4件を反映",
+      "url": "https://github.com/hikuohiku/homelab/pull/109",
+      "mergedAt": "2026-08-05T00:04:19Z",
+      "headRefName": "autopilot/feedback-round14"
+    },
+    {
+      "number": 108,
+      "title": "ops: run #13 の記録をまとめ、ダッシュボードを再生成する",
+      "url": "https://github.com/hikuohiku/homelab/pull/108",
+      "mergedAt": "2026-08-04T23:44:38Z",
+      "headRefName": "autopilot/run13-wrapup"
+    },
+    {
       "number": 107,
       "title": "vaultwarden: IP_HEADER=X-Forwarded-For を設定し Tailscale 経由のレート制限誤発火を防ぐ (T-0032)",
       "url": "https://github.com/hikuohiku/homelab/pull/107",
@@ -23,18 +58,18 @@
       "headRefName": "autopilot/t0031-vaultwarden-disable-icon"
     },
     {
-      "number": 102,
-      "title": "external-secrets chart を 1.1.1 → 1.3.2 に上げる (T-0026)",
-      "url": "https://github.com/hikuohiku/homelab/pull/102",
-      "mergedAt": "2026-08-04T23:15:00Z",
-      "headRefName": "autopilot/run12-feedback-t0026"
-    },
-    {
       "number": 103,
       "title": "ops: run #12 の記録をまとめ、ダッシュボードを再生成する",
       "url": "https://github.com/hikuohiku/homelab/pull/103",
       "mergedAt": "2026-08-04T23:09:47Z",
       "headRefName": "autopilot/run12-wrapup"
+    },
+    {
+      "number": 102,
+      "title": "external-secrets chart を 1.1.1 → 1.3.2 に上げる (T-0026)",
+      "url": "https://github.com/hikuohiku/homelab/pull/102",
+      "mergedAt": "2026-08-04T23:08:09Z",
+      "headRefName": "autopilot/run12-feedback-t0026"
     },
     {
       "number": 101,
@@ -371,55 +406,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/53",
       "mergedAt": "2026-08-04T04:42:17Z",
       "headRefName": "coder-template-image"
-    },
-    {
-      "number": 52,
-      "title": "feat: Coder 開発サーバーを手書き manifest で追加",
-      "url": "https://github.com/hikuohiku/homelab/pull/52",
-      "mergedAt": "2026-08-03T14:58:51Z",
-      "headRefName": "feat/coder-handwritten"
-    },
-    {
-      "number": 51,
-      "title": "feat: node01 を 4c/12GB/50GB にスケールアップ",
-      "url": "https://github.com/hikuohiku/homelab/pull/51",
-      "mergedAt": "2026-08-03T14:17:36Z",
-      "headRefName": "feat/node01-scale-up"
-    },
-    {
-      "number": 50,
-      "title": "feat: 週次メンテナンスの手順を /weekly-maintenance コマンドに定義",
-      "url": "https://github.com/hikuohiku/homelab/pull/50",
-      "mergedAt": "2026-08-03T13:45:55Z",
-      "headRefName": "feat/weekly-maintenance-routine"
-    },
-    {
-      "number": 49,
-      "title": "fix(vaultwarden): 1.36.0 → 1.37.1 でクライアント同期不具合を解消",
-      "url": "https://github.com/hikuohiku/homelab/pull/49",
-      "mergedAt": "2026-08-03T13:01:44Z",
-      "headRefName": "fix/vaultwarden-1.37.1"
-    },
-    {
-      "number": 48,
-      "title": "chore: kubectl を ask 付きで許可する方針を反映 + 移行 Plans 更新",
-      "url": "https://github.com/hikuohiku/homelab/pull/48",
-      "mergedAt": "2026-08-03T12:25:50Z",
-      "headRefName": "chore/kubectl-ask-policy-and-plans"
-    },
-    {
-      "number": 47,
-      "title": "feat: vaultwarden を k8s へ移行する manifest を追加",
-      "url": "https://github.com/hikuohiku/homelab/pull/47",
-      "mergedAt": "2026-06-21T09:28:10Z",
-      "headRefName": "feat/vaultwarden-k8s"
-    },
-    {
-      "number": 46,
-      "title": "chore: IaC 管理外の空 namespace を整理",
-      "url": "https://github.com/hikuohiku/homelab/pull/46",
-      "mergedAt": "2026-06-21T06:28:16Z",
-      "headRefName": "chore/cleanup-orphan-namespaces"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -444,6 +444,9 @@
 - #111 merge を確認後、`Maintenance.md` の持ち越し 2 件（icon タイムアウト・レート制限）の記録が
   T-0031 revert と T-0038 完遂で実態とずれていたことに気づいた（CHARTER §3 のドキュメント整合性チェック）。
   「icon 無効化で解消」の記録を「revert して見送り」に、レート制限側に T-0038 の追記を反映した（T-0039）
+- #112 merge を確認後、backlog の todo が再び 0 件になったため CHARTER §3 に従い調査タスクを起票。
+  T-0005（inventory.json 全対象調査）を初回実施とみなし、T-0012 と同じ recurring（weekly, last_done
+  2026-08-04, next_review 2026-08-11）の運用に載せた（T-0040）
 - run #14 のまとめ: issue #56 のフィードバック 4 件を反映（#109）、T-0031 を revert（#110）、
-  T-0038 を完遂（#111）、Maintenance.md の記録を実態に合わせた（T-0039）。backlog の todo は
-  再び 0 件（残りは done/blocked/needs-human/dropped のみ）
+  T-0038 を完遂（#111）、Maintenance.md の記録を実態に合わせた（T-0039, #112）。backlog の todo は
+  T-0040（次回 2026-08-11 まで defer）のみで実質 0 件（残りは done/blocked/needs-human/dropped）

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-04T23:20:00Z",
+  "updated": "2026-08-05T00:30:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -179,6 +179,19 @@
         104,
         106,
         107
+      ]
+    },
+    {
+      "n": 14,
+      "at": "2026-08-05T00:19:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "issue #56 の未読フィードバック4件を反映（#109）: T-0031（vaultwarden icon 無効化）を「実害なしの事象のために利用者に見える機能を犠牲にしていた」という指摘を受け revert（#110, T-0031 dropped）。CI (manifest-diff) が実際に見ている範囲（レンダリング結果の比較、upstream リポジトリのファイルとは無関係）を CHARTER §5.3 に明記。ブランチの作り直し時の削除・命名統一・中断検知の確認を CHARTER §4 に追記。T-0032 の残余リスク（IP_HEADER_TRUSTED_PROXIES が既定 local のまま）を T-0038 として起票し、subagent に vaultwarden 実ソース（1.37.1）を確認させたうえで pod CIDR 10.42.0.0/16 に絞って完遂（#111）。副産物として Maintenance.md の持ち越し記録が T-0031 revert / T-0038 完遂とずれていたのを発見し実態に合わせた（T-0039, #112）",
+      "prs": [
+        109,
+        110,
+        111,
+        112
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

run #14 の運用記録をまとめる。

- `ops/dashboard/prs.json` を最新化（`mcp__github__list_pull_requests` で open/closed を取得、`merged_at` 基準）
- `ops/state.json` に run #14 のエントリを追記（#109〜#112）
- `ops/backlog.json` に T-0040 を起票: backlog の todo が 0 件になったため CHARTER §3 に従い、T-0005 を初回実施とみなした inventory 再調査タスクを T-0012 と同じ recurring 運用（次回 2026-08-11）で追加
- `ops/journal/2026-08.md` に run #14 のまとめを追記
- ダッシュボードを再生成し、Artifact として再公開（`ops/state.json` の `dashboard.artifact_url` と同じ URL）

## 検証したこと

- `python3 ops/validate.py` → 0 error（warning 2 件はいずれも意図した状態を notes で説明済み: T-0040 は PR を伴わない起票、todo 不在は次回 2026-08-11 まで defer）
- `python3 ops/dashboard/build.py` → 正常終了、`ops/dashboard/index.html` を Artifact に公開済み

## ロールバック手順

`ops/` 配下の記録のみ。revert すれば即座に戻る。インフラへの影響なし。

## backlog task id

run #14 の記録更新 + T-0040 起票

---
_Generated by [Claude Code](https://claude.ai/code/session_015rrefiqjRFQoSw5J688XPY)_