### PR TITLE
docs: Plans.md の kubectl ask 前提の記述を実態に合わせる (T-0041)

### DIFF
--- a/Plans.md
+++ b/Plans.md
@@ -56,4 +56,7 @@ Proxmox LXC で手動運用中のサービスを k8s (ArgoCD) へ移行する。
 | M1 | vaultwarden を k8s 移行（手書き manifest） | apps/vaultwarden/ 作成・登録 / Doppler `VAULTWARDEN_ADMIN_TOKEN` 登録 / 旧 LXC tailscale 退避 / /data 移行 / 検証 | - | 完了 [PR #47]（ciphers 781 件移行・ログイン確認済み・旧 LXC 100 破棄済み） |
 | M2 | syncthing を k8s 移行 | 後回し（P2P 特性のため移行可否検討が未了。ディスク容量は 2026-08-04 の node01 拡張（256 GiB, 空き 223 GiB）で解消済み） | - | 保留 |
 
-> 補足: k8s への書き込み操作（移行時の scale/cp/exec 等）に伴い、`.claude/settings.json` の `permissions.ask` に `Bash(kubectl:*)` を追加し、kubectl は人間レビュー（ask）付きで実行する方針に変更（CLAUDE.md 反映済み）。
+> 補足: k8s への書き込み操作（移行時の scale/cp/exec 等）は kubectl CLI で行う方針（CLAUDE.md 反映済み）。
+> 当初は `.claude/settings.json` の `permissions.ask` で毎回人間の承認を求めていたが、autopilot の
+> ヘッドレス実行では誰も承認できず起動が丸ごと無駄になるため、`ask` ルールは全廃した（`ops/CHARTER.md`
+> §5.1）。現在の歯止めは「変更は Git → CI → ArgoCD を通す」という経路そのもの。

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -748,7 +748,7 @@
         ".claude/settings.json"
       ],
       "created": "2026-08-05",
-      "pr": null,
+      "pr": 114,
       "notes": "run #15: grep で `permissions.ask` / kubectl ask への言及を repo 横断で確認し、Plans.md 以外（CHARTER.md, CLAUDE.md, journal, dashboard/prs.json）は既に現状に即した記述か履歴記録であることを確認した上で Plans.md のみ修正"
     }
   ]

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 41,
-  "updated": "2026-08-05T00:35:00Z",
+  "next_id": 42,
+  "updated": "2026-08-05T06:20:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -730,6 +730,26 @@
       "created": "2026-08-05",
       "pr": null,
       "notes": "run #14: T-0005（#78）を初回実施として recurring 化しただけで、この起票自体はコード変更を伴わないため PR は無い（ops/ の記録は run14-wrapup PR に相乗り）。次回 2026-08-11 以降の起動で todo に戻して再調査する"
+    },
+    {
+      "id": "T-0041",
+      "domain": "homelab",
+      "title": "Plans.md の M2 補足が `.claude/settings.json` permissions.ask 前提のまま実態とずれている",
+      "kind": "docs",
+      "risk": "low",
+      "status": "done",
+      "priority": 8,
+      "why": "CHARTER §3 のドキュメント整合性チェック（run #15）で発見。backlog の todo が 0 件だったため実施。Plans.md の LXC→k8s 移行計画の補足に『kubectl は permissions.ask 付きで実行する方針』と書かれたままだったが、CHARTER §5.1 で ask ルールは全廃されており（現在の `.claude/settings.json` に ask キー自体が無い）、CLAUDE.md の Agent Operations 節は既にこの前提で書き換わっている。Plans.md だけが古い記述のまま残っていた",
+      "dod": "Plans.md の該当補足が、CLAUDE.md / CHARTER.md と同じ『ask は全廃、歯止めは Git → CI → ArgoCD 経路』という現状を反映している",
+      "refs": [
+        "Plans.md",
+        "CLAUDE.md",
+        "ops/CHARTER.md",
+        ".claude/settings.json"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #15: grep で `permissions.ask` / kubectl ask への言及を repo 横断で確認し、Plans.md 以外（CHARTER.md, CLAUDE.md, journal, dashboard/prs.json）は既に現状に即した記述か履歴記録であることを確認した上で Plans.md のみ修正"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,28 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 114,
+      "title": "docs: Plans.md の kubectl ask 前提の記述を実態に合わせる (T-0041)",
+      "url": "https://github.com/hikuohiku/homelab/pull/114",
+      "isDraft": false,
+      "createdAt": "2026-08-05T00:21:31Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "PENDING"
+        }
+      ],
+      "headRefName": "autopilot/T-0041-plans-md-ask-drift",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 113,
+      "title": "ops: run #14 の記録をまとめ、ダッシュボードを再生成する",
+      "url": "https://github.com/hikuohiku/homelab/pull/113",
+      "mergedAt": "2026-08-05T00:16:51Z",
+      "headRefName": "autopilot/run14-wrapup"
+    },
     {
       "number": 112,
       "title": "Maintenance.md: T-0031 revert / T-0038 完遂を反映 (T-0039)",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -450,3 +450,18 @@
 - run #14 のまとめ: issue #56 のフィードバック 4 件を反映（#109）、T-0031 を revert（#110）、
   T-0038 を完遂（#111）、Maintenance.md の記録を実態に合わせた（T-0039, #112）。backlog の todo は
   T-0040（次回 2026-08-11 まで defer）のみで実質 0 件（残りは done/blocked/needs-human/dropped）
+
+## 2026-08-05 00:21 UTC — run #15
+
+- 前回の中断確認: オープン PR 無し、`autopilot/*` ブランチ無し。中断なし
+- 読んだフィードバック: issue #56 の最新コメントの `created_at`（23:59:38）が `last_read` と一致。未読なし
+- backlog の todo は 0 件（T-0040 は next_review 2026-08-11 まで defer）。CHARTER §3 に従い調査タスクを
+  自分で起票する番。CLAUDE.md / Plans.md / Maintenance.md / docs/ の実態ずれを探した
+- `Plans.md`（LXC→k8s 移行計画）の M2 補足に「kubectl は `.claude/settings.json` の `permissions.ask`
+  付きで実行する方針」という記述が残っているのを発見。`ask` ルールは CHARTER §5.1 で全廃済みで、
+  `.claude/settings.json` を確認しても `ask` キー自体が無い。`CLAUDE.md` の Agent Operations 節は
+  既に「ask は全廃、歯止めは Git → CI → ArgoCD 経路」という現状に書き換わっているが、Plans.md だけが
+  取り残されていた。repo 横断で `permissions.ask` を grep し、他に同じ古い記述が残っていないことも確認
+- T-0041 として起票・即完遂。補足文を現状（kubectl CLI で書き込み、ask 全廃）に更新（#114）
+- 次の起動へ: backlog の todo はこの PR の merge 後も実質 0 件（T-0040 は 2026-08-11 まで defer）。
+  次回も CHARTER §3 の調査から入ることになりそう

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T00:30:00Z",
+  "updated": "2026-08-05T00:35:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -192,6 +192,16 @@
         110,
         111,
         112
+      ]
+    },
+    {
+      "n": 15,
+      "at": "2026-08-05T00:21:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。backlog の todo が 0 件（T-0040 は 2026-08-11 まで defer）だったため CHARTER §3 に従い調査タスクを起票。CLAUDE.md/Plans.md/Maintenance.md/docs/ の実態ずれを探し、Plans.md（LXC→k8s 移行計画）の補足が『kubectl は permissions.ask 付きで実行する方針』という記述のまま取り残されていたのを発見（ask ルールは CHARTER §5.1 で全廃済み、CLAUDE.md は既に反映済み）。T-0041 として起票・即完遂（#114）",
+      "prs": [
+        114
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

`Plans.md`（LXC → k8s 移行計画）の補足が「kubectl は `.claude/settings.json` の `permissions.ask` 付きで実行する方針」という古い記述のままでした。この `ask` ルールは既に全廃されています（`ops/CHARTER.md` §5.1、`.claude/settings.json` に `ask` キー自体が存在しない）。`CLAUDE.md` の Agent Operations 節は既にこの現状を反映していますが、`Plans.md` だけが取り残されていました。

補足文を「kubectl CLI で書き込みを行う」「ask は全廃、歯止めは Git → CI → ArgoCD 経路」という現状の説明に更新しました。

あわせて `ops/backlog.json` に T-0041 として記録し、`ops/journal/2026-08.md` と `ops/state.json` を更新しています（`ops/` の記録更新は CHARTER §4 の相乗り例外）。

## 検証したこと

- `permissions.ask` / kubectl の ask 運用に関する言及を repo 横断で grep し、`Plans.md` 以外（`ops/CHARTER.md`、`CLAUDE.md`、journal、`ops/dashboard/prs.json`）は現状に即した記述か、履歴記録として残すべきものであることを確認
- `.claude/settings.json` に `ask` キーが存在しないこと、`harness.toml` で `ask = []` と明記されていることを確認
- `python3 ops/validate.py` で 0 error を確認

## ロールバック手順

`git revert` で本 PR のコミットを戻すだけ。ドキュメントのみの変更でインフラへの影響なし。

## backlog task id

T-0041

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPhPUVi1sNe66cwrVPd4B5)_