### PR TITLE
ci: nix-installer-action の floating ref を固定する (T-0042)

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -56,7 +56,7 @@ jobs:
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@v22
 
       - name: Setup Cachix
         uses: cachix/cachix-action@v15

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 42,
+  "next_id": 44,
   "updated": "2026-08-05T06:20:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
@@ -750,6 +750,42 @@
       "created": "2026-08-05",
       "pr": 114,
       "notes": "run #15: grep で `permissions.ask` / kubectl ask への言及を repo 横断で確認し、Plans.md 以外（CHARTER.md, CLAUDE.md, journal, dashboard/prs.json）は既に現状に即した記述か履歴記録であることを確認した上で Plans.md のみ修正"
+    },
+    {
+      "id": "T-0042",
+      "domain": "homelab",
+      "title": ".github/workflows/release-image.yml の nix-installer-action を @main から固定タグへ変える",
+      "kind": "ci",
+      "risk": "low",
+      "status": "done",
+      "priority": 8,
+      "why": "run #16: CHARTER §3 の調査（backlog todo が 0 件）で発見。`DeterminateSystems/nix-installer-action@main` だけが可変ブランチ参照で、同ファイル内の他の Action（actions/checkout@v4, cachix/cachix-action@v15, softprops/action-gh-release@v2）はすべてタグ pin。T-0001（tailscale k8s-nameserver の floating tag `unstable` を固定した）と同じ形のリスクで、レビュー無しに Action の中身が変わりうる",
+      "dod": "release-image.yml の nix-installer-action が具体的なリリースタグを指す",
+      "refs": [
+        ".github/workflows/release-image.yml"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #16: WebFetch で upstream の releases ページと README を確認。最新は v22。README には『このアクションは Action 自体のバージョンに関わらず常に最新の Determinate Nix をインストールする（固定した Nix バージョンが必要なら determinate-nix-action へ）』とあり、Action 参照の pin と実際にインストールされる Nix バージョンは無関係と判明。ここでの懸念は Nix バージョンではなく Action 自体のコードが `@main` だとレビュー無しに変わりうる点なので、リポジトリの他の Action と同じ慣習（メジャータグ pin）に合わせて `@v22` に固定した。Nix バージョンの固定は別の関心事のため対象外とした"
+    },
+    {
+      "id": "T-0043",
+      "domain": "homelab",
+      "title": ".github/workflows/*.yml の Action バージョンを棚卸しし、監視の要否を判断する",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "todo",
+      "priority": 26,
+      "why": "T-0042 (run #16) で発見。ops/inventory.json はアプリ/インフラのバージョンしか監視しておらず、CI workflow が使う GitHub Actions（actions/checkout, azure/setup-helm, hashicorp/setup-terraform, cachix/install-nix-action, cachix/cachix-action, softprops/action-gh-release 等）は誰も追っていない。T-0042 で見つけた `@main` の floating ref は個別に直したが、他にも同種の問題（メジャータグ pin だが実際は古いメジャー、等）が残っていないか未確認",
+      "dod": "各 workflow の `uses:` 行を洗い出し、(1) floating ref（`@main`/`@master`等ブランチ名）が残っていないか (2) 各メジャータグの最新版から大きく遅れていないか を確認する。継続監視が要ると判断すれば ops/inventory.json に kind: \"github-action\" 相当のエントリとして追加する。この調査自体ではコードを変更しない",
+      "refs": [
+        ".github/workflows/ci.yml",
+        ".github/workflows/direct-push-guard.yml",
+        ".github/workflows/release-image.yml",
+        "ops/inventory.json"
+      ],
+      "created": "2026-08-05",
+      "pr": null
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -765,7 +765,7 @@
         ".github/workflows/release-image.yml"
       ],
       "created": "2026-08-05",
-      "pr": null,
+      "pr": 115,
       "notes": "run #16: WebFetch で upstream の releases ページと README を確認。最新は v22。README には『このアクションは Action 自体のバージョンに関わらず常に最新の Determinate Nix をインストールする（固定した Nix バージョンが必要なら determinate-nix-action へ）』とあり、Action 参照の pin と実際にインストールされる Nix バージョンは無関係と判明。ここでの懸念は Nix バージョンではなく Action 自体のコードが `@main` だとレビュー無しに変わりうる点なので、リポジトリの他の Action と同じ慣習（メジャータグ pin）に合わせて `@v22` に固定した。Nix バージョンの固定は別の関心事のため対象外とした"
     },
     {

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,13 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 114,
       "title": "docs: Plans.md の kubectl ask 前提の記述を実態に合わせる (T-0041)",
       "url": "https://github.com/hikuohiku/homelab/pull/114",
-      "isDraft": false,
-      "createdAt": "2026-08-05T00:21:31Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "PENDING"
-        }
-      ],
-      "headRefName": "autopilot/T-0041-plans-md-ask-drift",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-05T00:24:50Z",
+      "headRefName": "autopilot/T-0041-plans-md-ask-drift"
+    },
     {
       "number": 113,
       "title": "ops: run #14 の記録をまとめ、ダッシュボードを再生成する",
@@ -421,13 +413,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/54",
       "mergedAt": "2026-08-04T16:18:12Z",
       "headRefName": "coder-template-skills-bootstrap"
-    },
-    {
-      "number": 53,
-      "title": "feat(coder): use immutable workspace image",
-      "url": "https://github.com/hikuohiku/homelab/pull/53",
-      "mergedAt": "2026-08-04T04:42:17Z",
-      "headRefName": "coder-template-image"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -465,3 +465,21 @@
 - T-0041 として起票・即完遂。補足文を現状（kubectl CLI で書き込み、ask 全廃）に更新（#114）
 - 次の起動へ: backlog の todo はこの PR の merge 後も実質 0 件（T-0040 は 2026-08-11 まで defer）。
   次回も CHARTER §3 の調査から入ることになりそう
+
+## 2026-08-05 00:43 UTC — run #16
+
+- 前回の中断確認: オープン PR 無し、`autopilot/*` ブランチ無し。中断なし
+- 読んだフィードバック: issue #56 の最新コメント（23:59:38）が `last_read` と一致。未読なし
+- backlog の todo は 0 件（T-0040/T-0012 とも次回レビューは 2026-08-11）。CHARTER §3 に従い調査。
+  これまでのドキュメント整合性チェックとは別角度で、`.github/workflows/*.yml` の Action バージョンを見た
+- `.github/workflows/release-image.yml` の `DeterminateSystems/nix-installer-action@main` が
+  可変ブランチ参照のまま残っているのを発見。同ファイルの他の Action（`actions/checkout@v4` 等）は
+  すべてタグ pin で、T-0001（tailscale k8s-nameserver の floating tag 固定）と同型のリスク
+- WebFetch で upstream の README を確認: この Action は自身のバージョン pin に関わらず常に最新の
+  Determinate Nix をインストールする仕様（固定 Nix バージョンが要るなら別 Action `determinate-nix-action`
+  へ）。つまり `@main` の懸念は「古い/新しい Nix が入る」ではなく「Action 自体のコードがレビュー無しに
+  変わりうる」点。リポジトリの他の Action と同じ慣習（メジャータグ pin）に合わせ `@v22`（最新）に固定した
+- T-0042 として起票・即完遂（このヘッダの PR に相乗り）。他の workflow の Action バージョンも同様の
+  問題が無いか一括では確認していないため、T-0043（investigate, todo）として切り出した
+- 次の起動へ: T-0043（Action バージョンの棚卸し）が次の todo 候補。T-0040/T-0012 の next_review は
+  引き続き 2026-08-11

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T00:35:00Z",
+  "updated": "2026-08-05T00:43:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -203,6 +203,14 @@
       "prs": [
         114
       ]
+    },
+    {
+      "n": 16,
+      "at": "2026-08-05T00:43:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。backlog の todo が 0 件だったため、今回は .github/workflows/*.yml の Action バージョンという新しい角度で調査。release-image.yml の DeterminateSystems/nix-installer-action@main が可変ブランチ参照のまま残っていたのを発見（T-0001 の floating tag と同型のリスク）。upstream README を確認しこの Action の pin が実際にインストールされる Nix バージョンとは無関係と分かった上で、リポジトリの他の Action と揃えて @v22 に固定（T-0042）。他の workflow の Action バージョンは未確認のため T-0043 として起票",
+      "prs": []
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -210,7 +210,9 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。backlog の todo が 0 件だったため、今回は .github/workflows/*.yml の Action バージョンという新しい角度で調査。release-image.yml の DeterminateSystems/nix-installer-action@main が可変ブランチ参照のまま残っていたのを発見（T-0001 の floating tag と同型のリスク）。upstream README を確認しこの Action の pin が実際にインストールされる Nix バージョンとは無関係と分かった上で、リポジトリの他の Action と揃えて @v22 に固定（T-0042）。他の workflow の Action バージョンは未確認のため T-0043 として起票",
-      "prs": []
+      "prs": [
+        115
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`.github/workflows/release-image.yml` の `DeterminateSystems/nix-installer-action@main` を `@v22`（最新リリースタグ）に固定した。同ファイルの他の Action（`actions/checkout@v4`、`cachix/cachix-action@v15`、`softprops/action-gh-release@v2`）はすべてタグ pin されており、`@main` だけがレビュー無しに中身が変わりうる可変参照になっていた（T-0001 で固定した tailscale k8s-nameserver の floating tag `unstable` と同じ形のリスク）。

あわせて `ops/` の運用記録（journal / backlog / state / PR キャッシュ）を更新した。

## 検証したこと

- upstream (`DeterminateSystems/nix-installer-action`) の README を確認: この Action は自身のバージョン pin に関わらず常に最新の Determinate Nix をインストールする仕様。したがって `@main` → `@v22` の変更は実際にインストールされる Nix のバージョンには影響しない（懸念していたのは Action 自体のコードがレビュー無しに変わりうる点で、そちらのみ解消される）
- `release-image.yml` は `workflow_dispatch` トリガーのみで実行頻度は低く、この変更で挙動が変わる箇所は無い（Action 参照のみの変更）
- `python3 ops/validate.py` で 0 error を確認済み

## ロールバック手順

`@v22` を `@main` に戻す 1 行の revert。ワークフロー実行結果に影響がある場合のみ次回の `workflow_dispatch` 実行前に確認すればよい。

## backlog task id

T-0042（`ops/backlog.json`）

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVTHiyzgQew9Hde3dEJGwj)_