### PR TITLE
ci: actions/checkout を v4 → v7 に上げる (T-0044)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: kustomize build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: azure/setup-helm@v4
         with:
@@ -87,11 +87,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           path: head
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: base
@@ -119,7 +119,7 @@ jobs:
     name: terraform validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: hashicorp/setup-terraform@v3
         with:
@@ -139,7 +139,7 @@ jobs:
     name: ops state validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: validate
         run: python3 ops/validate.py
       - name: check duplicated version pins are in sync
@@ -152,7 +152,7 @@ jobs:
     name: nix flake check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: cachix/install-nix-action@v31
         with:

--- a/.github/workflows/direct-push-guard.yml
+++ b/.github/workflows/direct-push-guard.yml
@@ -27,7 +27,7 @@ jobs:
     name: detect direct push outside ops/
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -803,7 +803,7 @@
         ".github/workflows/release-image.yml"
       ],
       "created": "2026-08-05",
-      "pr": null,
+      "pr": 116,
       "notes": "run #16: WebFetch で actions/checkout の CHANGELOG.md を原文確認。この repo の使用範囲（pull_request（非 target）、fetch-depth 0 の使用、submodule 不使用、persist-credentials のデフォルト挙動に依存する git 操作なし）に影響する破壊的変更は無いと確認して着手"
     },
     {

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 44,
+  "next_id": 49,
   "updated": "2026-08-05T06:20:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
@@ -783,6 +783,89 @@
         ".github/workflows/direct-push-guard.yml",
         ".github/workflows/release-image.yml",
         "ops/inventory.json"
+      ],
+      "created": "2026-08-05",
+      "pr": null
+    },
+    {
+      "id": "T-0044",
+      "domain": "homelab",
+      "title": "actions/checkout を v4 → v7 に上げる（全 workflow）",
+      "kind": "ci",
+      "risk": "low",
+      "status": "done",
+      "priority": 26,
+      "why": "T-0043 (run #16) の調査で判明。v4 は現在から 3 メジャー遅れ（v5/v6/v7 は同日リリース）。CHANGELOG を確認: v5.0.0 は Node 24 ランタイム更新（GitHub-hosted runner では透過的）、v6.0.0 は credential の永続化方法の内部実装変更（`.git/config` を直接読む使い方はこの repo に無い）、v7.0.0 は `pull_request_target`/`workflow_run` での fork PR checkout を塞ぐ変更（この repo は 3 workflow とも `pull_request`（target ではない）/`push`/`workflow_dispatch` のみで該当しない）。全 8 箇所とも fetch-depth や path の指定以外は素の checkout で、影響する破壊的変更は無いと判断した",
+      "dod": "ci.yml (6箇所) / direct-push-guard.yml (1箇所) / release-image.yml (1箇所) の actions/checkout がすべて v7。CI が green",
+      "refs": [
+        ".github/workflows/ci.yml",
+        ".github/workflows/direct-push-guard.yml",
+        ".github/workflows/release-image.yml"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #16: WebFetch で actions/checkout の CHANGELOG.md を原文確認。この repo の使用範囲（pull_request（非 target）、fetch-depth 0 の使用、submodule 不使用、persist-credentials のデフォルト挙動に依存する git 操作なし）に影響する破壊的変更は無いと確認して着手"
+    },
+    {
+      "id": "T-0045",
+      "domain": "homelab",
+      "title": "azure/setup-helm を v4 → v5 に上げる",
+      "kind": "ci",
+      "risk": "low",
+      "status": "todo",
+      "priority": 27,
+      "why": "T-0043 (run #16) の調査で判明。現在 v4、最新は v5（Node.js ランタイムを node20→node24 に更新する破壊的変更のみ、GitHub-hosted runner では透過的なはず）",
+      "dod": "apps/ CI (ci.yml) 内の azure/setup-helm@v4 が v5 になり CI が green",
+      "refs": [
+        ".github/workflows/ci.yml"
+      ],
+      "created": "2026-08-05",
+      "pr": null
+    },
+    {
+      "id": "T-0046",
+      "domain": "homelab",
+      "title": "hashicorp/setup-terraform を v3 → v4 に上げる",
+      "kind": "ci",
+      "risk": "low",
+      "status": "todo",
+      "priority": 27,
+      "why": "T-0043 (run #16) の調査で判明。現在 v3、最新は v4（Node.js 24 へのランタイム更新が唯一の破壊的変更）",
+      "dod": "ci.yml の hashicorp/setup-terraform@v3 が v4 になり CI が green",
+      "refs": [
+        ".github/workflows/ci.yml"
+      ],
+      "created": "2026-08-05",
+      "pr": null
+    },
+    {
+      "id": "T-0047",
+      "domain": "homelab",
+      "title": "cachix/cachix-action を v15 → v17 に上げる",
+      "kind": "ci",
+      "risk": "low",
+      "status": "todo",
+      "priority": 27,
+      "why": "T-0043 (run #16) の調査で判明。現在 v15、最新は v17（2 メジャー遅れ）。v16/v17 は Node 24 移行と daemon hook のハードニングが主な変更点。cachix push 用の認証設定 (name: hikuohiku) への影響は release note を精査して確認する",
+      "dod": "ci.yml (nix flake check job) の cachix/cachix-action@v15 が v17 になり CI が green。cachix への push（あれば）が引き続き成功することを確認",
+      "refs": [
+        ".github/workflows/ci.yml"
+      ],
+      "created": "2026-08-05",
+      "pr": null
+    },
+    {
+      "id": "T-0048",
+      "domain": "homelab",
+      "title": "softprops/action-gh-release を v2 → v3 に上げる",
+      "kind": "ci",
+      "risk": "low",
+      "status": "todo",
+      "priority": 27,
+      "why": "T-0043 (run #16) の調査で判明。現在 v2、最新は v3。release-image.yml（workflow_dispatch 手動実行のみ）でのリリース作成に使用",
+      "dod": "release-image.yml の softprops/action-gh-release@v2 が v3 になる。workflow_dispatch のため実行時検証は次回の手動実行まで難しく、release note に破壊的変更が無いことの確認で足りるとする",
+      "refs": [
+        ".github/workflows/release-image.yml"
       ],
       "created": "2026-08-05",
       "pr": null

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -481,5 +481,15 @@
   変わりうる」点。リポジトリの他の Action と同じ慣習（メジャータグ pin）に合わせ `@v22`（最新）に固定した
 - T-0042 として起票・即完遂（このヘッダの PR に相乗り）。他の workflow の Action バージョンも同様の
   問題が無いか一括では確認していないため、T-0043（investigate, todo）として切り出した
-- 次の起動へ: T-0043（Action バージョンの棚卸し）が次の todo 候補。T-0040/T-0012 の next_review は
-  引き続き 2026-08-11
+- #115 merge を確認後、T-0043 の調査を続けた。バックグラウンドの subagent は「渡した一覧を既知/検証済み
+  と誤認して WebFetch を一切せず終了」という空振りをしたため、6 Action の releases ページを自分で直接
+  WebFetch して確認した。結果、cachix/install-nix-action@v31 のみ最新で、残り 5 つはメジャーで遅れていた
+  （actions/checkout v4→v7 で3メジャー、azure/setup-helm v4→v5、hashicorp/setup-terraform v3→v4、
+  cachix/cachix-action v15→v17 で2メジャー、softprops/action-gh-release v2→v3）
+- 影響範囲が最も大きい actions/checkout（全 workflow の全 job で使用）を優先し、CHANGELOG.md を原文確認。
+  v5(Node24 ランタイム)/v6(credential 永続化の内部実装変更)/v7(pull_request_target・workflow_run での
+  fork PR checkout 制限) のいずれも、この repo の使用範囲（`pull_request`（非 target）のみ、submodule
+  不使用、persist-credentials のデフォルト挙動に依存する git 操作なし）には該当しないと判断し v7 に更新
+  （T-0044）。残り 4 件は個別タスク（T-0045〜T-0048, todo）として起票し、次回以降に回した
+- 次の起動へ: T-0045〜T-0048（GitHub Actions のメジャー更新 4 件）が次の todo 候補。T-0040/T-0012 の
+  next_review は引き続き 2026-08-11

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T00:43:00Z",
+  "updated": "2026-08-05T00:52:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -209,7 +209,7 @@
       "at": "2026-08-05T00:43:00Z",
       "kind": "scheduled",
       "by": "cloud routine",
-      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。backlog の todo が 0 件だったため、今回は .github/workflows/*.yml の Action バージョンという新しい角度で調査。release-image.yml の DeterminateSystems/nix-installer-action@main が可変ブランチ参照のまま残っていたのを発見（T-0001 の floating tag と同型のリスク）。upstream README を確認しこの Action の pin が実際にインストールされる Nix バージョンとは無関係と分かった上で、リポジトリの他の Action と揃えて @v22 に固定（T-0042）。他の workflow の Action バージョンは未確認のため T-0043 として起票",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。backlog の todo が 0 件だったため、今回は .github/workflows/*.yml の Action バージョンという新しい角度で調査。release-image.yml の DeterminateSystems/nix-installer-action@main が可変ブランチ参照のまま残っていたのを発見（T-0001 の floating tag と同型のリスク）。upstream README を確認しこの Action の pin が実際にインストールされる Nix バージョンとは無関係と分かった上で、リポジトリの他の Action と揃えて @v22 に固定（T-0042, #115）。続けて T-0043 として他 6 Action の棚卸しを実施（背景 subagent が空振りしたため自分で WebFetch）、cachix/install-nix-action 以外は全てメジャーで遅れていると判明。最も影響範囲が大きい actions/checkout を CHANGELOG 原文確認のうえ v4→v7 に更新（T-0044）、残り4件（azure/setup-helm, hashicorp/setup-terraform, cachix/cachix-action, softprops/action-gh-release）は個別タスク化して次回以降に回した",
       "prs": [
         115
       ]

--- a/ops/state.json
+++ b/ops/state.json
@@ -211,7 +211,8 @@
       "by": "cloud routine",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。backlog の todo が 0 件だったため、今回は .github/workflows/*.yml の Action バージョンという新しい角度で調査。release-image.yml の DeterminateSystems/nix-installer-action@main が可変ブランチ参照のまま残っていたのを発見（T-0001 の floating tag と同型のリスク）。upstream README を確認しこの Action の pin が実際にインストールされる Nix バージョンとは無関係と分かった上で、リポジトリの他の Action と揃えて @v22 に固定（T-0042, #115）。続けて T-0043 として他 6 Action の棚卸しを実施（背景 subagent が空振りしたため自分で WebFetch）、cachix/install-nix-action 以外は全てメジャーで遅れていると判明。最も影響範囲が大きい actions/checkout を CHANGELOG 原文確認のうえ v4→v7 に更新（T-0044）、残り4件（azure/setup-helm, hashicorp/setup-terraform, cachix/cachix-action, softprops/action-gh-release）は個別タスク化して次回以降に回した",
       "prs": [
-        115
+        115,
+        116
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

全 workflow（`ci.yml` 6 箇所 / `direct-push-guard.yml` / `release-image.yml`）の `actions/checkout@v4` を `@v7`（最新）に更新した。T-0043（GitHub Actions バージョンの棚卸し）で発見した、影響範囲が最も大きい Action。

## 検証したこと

- upstream の `CHANGELOG.md` を v4→v7 まで原文確認した:
  - **v5.0.0**: Node.js 24 ランタイムへの更新（GitHub-hosted runner では透過的）
  - **v6.0.0**: credential の永続化方法の内部実装変更（`.git/config` を直接読む使い方はこの repo に無い）
  - **v7.0.0**: `pull_request_target` / `workflow_run` での fork PR checkout を塞ぐ変更（この repo の 3 workflow はいずれも `pull_request`（非 target）/ `push` / `workflow_dispatch` のみで該当しない）
- 8 箇所の呼び出しを確認し、`fetch-depth: 0` や `path:`/`ref:` の指定以外は素の checkout であることを確認（submodule 不使用、persist-credentials のデフォルト挙動に依存する git 操作なし）
- `python3 ops/validate.py` で 0 error を確認済み

## ロールバック手順

`@v7` を `@v4` に戻す 1 行の revert（8 箇所）。

## backlog task id

T-0044（`ops/backlog.json`）。関連: T-0043（調査）、T-0045〜T-0048（残り4 Action の個別タスク、次回以降）

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVTHiyzgQew9Hde3dEJGwj)_