### PR TITLE
ops: run #16 の PR キャッシュを最新化する

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,20 @@
   "open": [],
   "merged": [
     {
+      "number": 116,
+      "title": "ci: actions/checkout を v4 → v7 に上げる (T-0044)",
+      "url": "https://github.com/hikuohiku/homelab/pull/116",
+      "mergedAt": "2026-08-05T00:51:08Z",
+      "headRefName": "autopilot/T-0044-checkout-v7"
+    },
+    {
+      "number": 115,
+      "title": "ci: nix-installer-action の floating ref を固定する (T-0042)",
+      "url": "https://github.com/hikuohiku/homelab/pull/115",
+      "mergedAt": "2026-08-05T00:46:53Z",
+      "headRefName": "autopilot/T-0042-pin-nix-installer-action"
+    },
+    {
       "number": 114,
       "title": "docs: Plans.md の kubectl ask 前提の記述を実態に合わせる (T-0041)",
       "url": "https://github.com/hikuohiku/homelab/pull/114",


### PR DESCRIPTION
## 変更点

`ops/dashboard/prs.json` に #115（T-0042）・#116（T-0044）を merged として追記した。CHARTER §7.1 の手順どおり、ダッシュボード再生成前に PR キャッシュを最新化するための記録用 PR。

## 検証したこと

- `python3 ops/validate.py` で 0 error を確認済み
- `python3 ops/dashboard/build.py` の実行成功を確認済み

## ロールバック手順

`ops/dashboard/prs.json` の該当エントリを削除するだけ。実インフラには影響しない。

## backlog task id

なし（run #16 の記録作業そのもの、CHARTER §4 の相乗り例外）

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVTHiyzgQew9Hde3dEJGwj)_