### PR TITLE
ops: GitHub Actions を inventory.json の監視対象に追加する (T-0043)

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 49,
-  "updated": "2026-08-05T06:20:00Z",
+  "updated": "2026-08-05T01:09:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -774,7 +774,7 @@
       "title": ".github/workflows/*.yml の Action バージョンを棚卸しし、監視の要否を判断する",
       "kind": "investigate",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 26,
       "why": "T-0042 (run #16) で発見。ops/inventory.json はアプリ/インフラのバージョンしか監視しておらず、CI workflow が使う GitHub Actions（actions/checkout, azure/setup-helm, hashicorp/setup-terraform, cachix/install-nix-action, cachix/cachix-action, softprops/action-gh-release 等）は誰も追っていない。T-0042 で見つけた `@main` の floating ref は個別に直したが、他にも同種の問題（メジャータグ pin だが実際は古いメジャー、等）が残っていないか未確認",
       "dod": "各 workflow の `uses:` 行を洗い出し、(1) floating ref（`@main`/`@master`等ブランチ名）が残っていないか (2) 各メジャータグの最新版から大きく遅れていないか を確認する。継続監視が要ると判断すれば ops/inventory.json に kind: \"github-action\" 相当のエントリとして追加する。この調査自体ではコードを変更しない",
@@ -785,7 +785,8 @@
         "ops/inventory.json"
       ],
       "created": "2026-08-05",
-      "pr": null
+      "pr": 118,
+      "notes": "run #17: T-0042 で見つけた floating ref は release-image.yml の nix-installer-action のみで、他に `@main`/`@master` の残りは無いことを確認済み（run #16）。継続監視が要ると判断し、ops/inventory.json に kind: \"github-action\" のエントリ 7 件（actions/checkout, azure/setup-helm, hashicorp/setup-terraform, cachix/install-nix-action, cachix/cachix-action, softprops/action-gh-release, DeterminateSystems/nix-installer-action）を追加。これで T-0040（inventory.json の定期再調査、weekly）が自動的に GitHub Actions もカバーする"
     },
     {
       "id": "T-0044",

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -189,6 +189,84 @@
       "upstream": "github:bpg/terraform-provider-proxmox",
       "policy": "manual",
       "note": "完全一致 pin（理由コメントあり）。上げるときは理由ごと見直す"
+    },
+    {
+      "id": "gha-actions-checkout",
+      "kind": "github-action",
+      "name": "actions/checkout",
+      "current": "v7",
+      "file": ".github/workflows/ci.yml",
+      "match": "actions/checkout@",
+      "mirrors": [".github/workflows/direct-push-guard.yml", ".github/workflows/release-image.yml"],
+      "upstream": "github:actions/checkout",
+      "policy": "auto",
+      "note": "T-0043/T-0044 で発見・v4→v7 に更新済み (run #16)。CI 全 job で使用"
+    },
+    {
+      "id": "gha-azure-setup-helm",
+      "kind": "github-action",
+      "name": "azure/setup-helm",
+      "current": "v4",
+      "file": ".github/workflows/ci.yml",
+      "match": "azure/setup-helm@",
+      "upstream": "github:Azure/setup-helm",
+      "policy": "auto",
+      "note": "T-0043 (run #16) で発見。最新 v5 は Node24 ランタイム更新のみ → T-0045"
+    },
+    {
+      "id": "gha-hashicorp-setup-terraform",
+      "kind": "github-action",
+      "name": "hashicorp/setup-terraform",
+      "current": "v3",
+      "file": ".github/workflows/ci.yml",
+      "match": "hashicorp/setup-terraform@",
+      "upstream": "github:hashicorp/setup-terraform",
+      "policy": "auto",
+      "note": "T-0043 (run #16) で発見。最新 v4 は Node24 ランタイム更新のみ → T-0046"
+    },
+    {
+      "id": "gha-cachix-install-nix-action",
+      "kind": "github-action",
+      "name": "cachix/install-nix-action",
+      "current": "v31",
+      "file": ".github/workflows/ci.yml",
+      "match": "cachix/install-nix-action@",
+      "upstream": "github:cachix/install-nix-action",
+      "policy": "auto",
+      "note": "T-0043 (run #16) 時点で最新"
+    },
+    {
+      "id": "gha-cachix-cachix-action",
+      "kind": "github-action",
+      "name": "cachix/cachix-action",
+      "current": "v15",
+      "file": ".github/workflows/release-image.yml",
+      "match": "cachix/cachix-action@",
+      "upstream": "github:cachix/cachix-action",
+      "policy": "auto",
+      "note": "T-0043 (run #16) で発見。最新 v17 は 2 メジャー遅れ → T-0047"
+    },
+    {
+      "id": "gha-softprops-action-gh-release",
+      "kind": "github-action",
+      "name": "softprops/action-gh-release",
+      "current": "v2",
+      "file": ".github/workflows/release-image.yml",
+      "match": "softprops/action-gh-release@",
+      "upstream": "github:softprops/action-gh-release",
+      "policy": "auto",
+      "note": "T-0043 (run #16) で発見。最新 v3 → T-0048"
+    },
+    {
+      "id": "gha-nix-installer-action",
+      "kind": "github-action",
+      "name": "DeterminateSystems/nix-installer-action",
+      "current": "v22",
+      "file": ".github/workflows/release-image.yml",
+      "match": "DeterminateSystems/nix-installer-action@",
+      "upstream": "github:DeterminateSystems/nix-installer-action",
+      "policy": "auto",
+      "note": "T-0042 (run #16) で @main の floating ref から固定した。Action 自体の pin と、実際にインストールされる Nix のバージョンは無関係（upstream README に明記）"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -493,3 +493,14 @@
   （T-0044）。残り 4 件は個別タスク（T-0045〜T-0048, todo）として起票し、次回以降に回した
 - 次の起動へ: T-0045〜T-0048（GitHub Actions のメジャー更新 4 件）が次の todo 候補。T-0040/T-0012 の
   next_review は引き続き 2026-08-11
+
+## 2026-08-05 01:09 UTC — run #17
+
+- 前回の中断確認: オープン PR 無し、`autopilot/*` ブランチ無し。中断なし
+- 読んだフィードバック: issue #56 の最新コメント（23:59:38）が `last_read` と一致。未読なし
+- backlog の todo: T-0043（優先度 26）、T-0045〜T-0048（優先度 27、GitHub Actions のメジャー更新）
+- T-0043 を完遂。T-0042 で見つけた floating ref（`@main`）は release-image.yml の
+  nix-installer-action のみで他に残っていないことは run #16 で確認済みだったため、残る DoD は
+  「継続監視が要るか判断する」のみ。要ると判断し、ops/inventory.json に kind: "github-action" の
+  エントリ 7 件を追加した。これで T-0040（inventory.json の週次再調査）が GitHub Actions も
+  自動的にカバーする


### PR DESCRIPTION
## 変更点

`ops/inventory.json` に CI workflow が使う GitHub Actions 7 件を `kind: "github-action"` として追加した（バージョン更新は行っていない）。

- `actions/checkout` (v7)
- `azure/setup-helm` (v4)
- `hashicorp/setup-terraform` (v3)
- `cachix/install-nix-action` (v31)
- `cachix/cachix-action` (v15)
- `softprops/action-gh-release` (v2)
- `DeterminateSystems/nix-installer-action` (v22)

T-0042 で `.github/workflows/release-image.yml` の floating ref (`@main`) を固定したのをきっかけに、CI が使う Action のバージョンを誰も継続監視していないと判明していた（T-0043）。floating ref の残りは無いことは前回起動で確認済みだったため、今回は「継続監視するか」の判断のみ行い、監視すると決めて inventory.json にエントリを追加した。これで T-0040（inventory.json の週次再調査タスク）が GitHub Actions のバージョンも自動的にカバーする。

## 検証したこと

- `python3 ops/validate.py` — 0 error（既存の警告 2 件は本 PR と無関係）
- コード（workflow ファイル自体）は変更していないため CI への影響なし

## ロールバック手順

`ops/inventory.json` の該当 7 エントリを削除するだけ。監視対象リストの変更のみで、実際の CI 挙動やインフラには一切影響しない。

## backlog task id

T-0043

---
_Generated by [Claude Code](https://claude.ai/code/session_0161jzze4yd7GVCFanbjb2H6)_