### PR TITLE
ci: azure/setup-helm を v4 → v5 に上げる (T-0045)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@v5
         with:
           version: v3.16.4
 
@@ -96,7 +96,7 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           path: base
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@v5
         with:
           version: v3.16.4
 

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 49,
-  "updated": "2026-08-05T01:09:00Z",
+  "updated": "2026-08-05T01:12:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -813,7 +813,7 @@
       "title": "azure/setup-helm を v4 → v5 に上げる",
       "kind": "ci",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 27,
       "why": "T-0043 (run #16) の調査で判明。現在 v4、最新は v5（Node.js ランタイムを node20→node24 に更新する破壊的変更のみ、GitHub-hosted runner では透過的なはず）",
       "dod": "apps/ CI (ci.yml) 内の azure/setup-helm@v4 が v5 になり CI が green",
@@ -821,7 +821,8 @@
         ".github/workflows/ci.yml"
       ],
       "created": "2026-08-05",
-      "pr": null
+      "pr": 119,
+      "notes": "run #17: subagent に v4.0.0〜v5.0.1 の release notes を原文確認させた。破壊的変更は Node20→Node24 ランタイム更新のみ（GitHub-hosted runner では透過的）。抽出バイナリの chmod 777→755 化はセキュリティ向上のみで利用側に影響なし。version 入力（v3.16.4 固定）や他の入出力契約に変更なし。ci.yml 内 2 箇所とも v5 に更新"
     },
     {
       "id": "T-0046",

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -206,12 +206,12 @@
       "id": "gha-azure-setup-helm",
       "kind": "github-action",
       "name": "azure/setup-helm",
-      "current": "v4",
+      "current": "v5",
       "file": ".github/workflows/ci.yml",
       "match": "azure/setup-helm@",
       "upstream": "github:Azure/setup-helm",
       "policy": "auto",
-      "note": "T-0043 (run #16) で発見。最新 v5 は Node24 ランタイム更新のみ → T-0045"
+      "note": "T-0045 (run #17) で v4→v5 に更新。破壊的変更は Node24 ランタイムのみ（GitHub-hosted runner では透過的）"
     },
     {
       "id": "gha-hashicorp-setup-terraform",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -503,4 +503,6 @@
   nix-installer-action のみで他に残っていないことは run #16 で確認済みだったため、残る DoD は
   「継続監視が要るか判断する」のみ。要ると判断し、ops/inventory.json に kind: "github-action" の
   エントリ 7 件を追加した。これで T-0040（inventory.json の週次再調査）が GitHub Actions も
-  自動的にカバーする
+  自動的にカバーする（#118, merged）
+- 続けて T-0045（azure/setup-helm v4→v5）を完遂。subagent に release notes を原文確認させ、
+  破壊的変更は Node24 ランタイム更新のみ（GitHub-hosted runner では透過的）と確認して更新（#119）


### PR DESCRIPTION
## 変更点

CI (`.github/workflows/ci.yml`) が使う `azure/setup-helm` を v4 → v5 に上げた（2 箇所: `manifests` / `manifest-diff` job）。`version: v3.16.4`（実際にインストールされる Helm 本体のバージョン）は変更していない。

T-0043（GitHub Actions の棚卸し）で v4 が 1 メジャー遅れていると判明していた。

## 検証したこと

- release notes（v4.0.0 〜 v5.0.1）を原文確認。破壊的変更は Node.js ランタイムの 20→24 更新のみで、GitHub-hosted runner では透過的。抽出した helm バイナリの権限を 777→755 に絞る変更もセキュリティ向上のみで影響なし。`version` 入力や他の入出力契約に変更はない
- `python3 ops/validate.py` — 0 error
- CI（`kustomize build` job 相当、helm を使う `manifests`/`manifest-diff`）の green を確認して進める

## ロールバック手順

`azure/setup-helm@v5` を `@v4` に戻すだけ（2 箇所）。

## backlog task id

T-0045

---
_Generated by [Claude Code](https://claude.ai/code/session_0161jzze4yd7GVCFanbjb2H6)_