### PR TITLE
ci: hashicorp/setup-terraform を v3 → v4 に上げる (T-0046)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 1.15.0
           terraform_wrapper: false

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 49,
-  "updated": "2026-08-05T01:12:00Z",
+  "updated": "2026-08-05T01:25:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -830,7 +830,7 @@
       "title": "hashicorp/setup-terraform を v3 → v4 に上げる",
       "kind": "ci",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 27,
       "why": "T-0043 (run #16) の調査で判明。現在 v3、最新は v4（Node.js 24 へのランタイム更新が唯一の破壊的変更）",
       "dod": "ci.yml の hashicorp/setup-terraform@v3 が v4 になり CI が green",
@@ -838,7 +838,8 @@
         ".github/workflows/ci.yml"
       ],
       "created": "2026-08-05",
-      "pr": null
+      "pr": 120,
+      "notes": "run #17: subagent に v3.0.0〜v4.0.1 の changelog を原文確認させた。破壊的変更は Node24 ランタイム更新のみ。v3.0.0 時点のラッパー由来 stdout 挙動変更は terraform_wrapper: false のため元から無関係。terraform_version(1.15.0) 等の入力は変更なし"
     },
     {
       "id": "T-0047",

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -217,12 +217,12 @@
       "id": "gha-hashicorp-setup-terraform",
       "kind": "github-action",
       "name": "hashicorp/setup-terraform",
-      "current": "v3",
+      "current": "v4",
       "file": ".github/workflows/ci.yml",
       "match": "hashicorp/setup-terraform@",
       "upstream": "github:hashicorp/setup-terraform",
       "policy": "auto",
-      "note": "T-0043 (run #16) で発見。最新 v4 は Node24 ランタイム更新のみ → T-0046"
+      "note": "T-0046 (run #17) で v3→v4 に更新。破壊的変更は Node24 ランタイムのみ。terraform_wrapper: false のためラッパー由来の stdout 挙動変更（v3.0.0 時点の話）とも無関係"
     },
     {
       "id": "gha-cachix-install-nix-action",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -505,4 +505,6 @@
   エントリ 7 件を追加した。これで T-0040（inventory.json の週次再調査）が GitHub Actions も
   自動的にカバーする（#118, merged）
 - 続けて T-0045（azure/setup-helm v4→v5）を完遂。subagent に release notes を原文確認させ、
-  破壊的変更は Node24 ランタイム更新のみ（GitHub-hosted runner では透過的）と確認して更新（#119）
+  破壊的変更は Node24 ランタイム更新のみ（GitHub-hosted runner では透過的）と確認して更新（#119, merged）
+- 続けて T-0046（hashicorp/setup-terraform v3→v4）を完遂。同じ subagent 調査で破壊的変更は
+  Node24 ランタイムのみと確認済み（terraform_wrapper: false のためラッパー由来の挙動変更とも無関係）（#120）


### PR DESCRIPTION
## 変更点

CI (`.github/workflows/ci.yml` の `terraform validate` job) が使う `hashicorp/setup-terraform` を v3 → v4 に上げた。`terraform_version: 1.15.0` / `terraform_wrapper: false` は変更していない。

T-0043（GitHub Actions の棚卸し）で v3 が 1 メジャー遅れていると判明していた。

## 検証したこと

- changelog（v3.0.0 〜 v4.0.1）を原文確認。破壊的変更は Node.js ランタイムの 20→24 更新のみで、GitHub-hosted runner では透過的。v3.0.0 時点にあったラッパー由来の stdout 挙動変更は `terraform_wrapper: false` のため元から無関係。`terraform_version` 等の入力に変更なし
- `python3 ops/validate.py` — 0 error
- CI（`terraform validate` job）の green を確認して進める

## ロールバック手順

`hashicorp/setup-terraform@v4` を `@v3` に戻すだけ。

## backlog task id

T-0046

---
_Generated by [Claude Code](https://claude.ai/code/session_0161jzze4yd7GVCFanbjb2H6)_