### PR TITLE
ci: cachix/cachix-action を v15 → v17 に上げる (T-0047)

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -59,7 +59,7 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@v22
 
       - name: Setup Cachix
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@v17
         with:
           name: hikuohiku
 

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 49,
-  "updated": "2026-08-05T01:25:00Z",
+  "updated": "2026-08-05T01:29:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -847,7 +847,7 @@
       "title": "cachix/cachix-action を v15 → v17 に上げる",
       "kind": "ci",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 27,
       "why": "T-0043 (run #16) の調査で判明。現在 v15、最新は v17（2 メジャー遅れ）。v16/v17 は Node 24 移行と daemon hook のハードニングが主な変更点。cachix push 用の認証設定 (name: hikuohiku) への影響は release note を精査して確認する",
       "dod": "ci.yml (nix flake check job) の cachix/cachix-action@v15 が v17 になり CI が green。cachix への push（あれば）が引き続き成功することを確認",
@@ -855,7 +855,8 @@
         ".github/workflows/ci.yml"
       ],
       "created": "2026-08-05",
-      "pr": null
+      "pr": 121,
+      "notes": "run #17: 使用箇所は ci.yml ではなく .github/workflows/release-image.yml の Nix イメージビルド job（workflow_dispatch 手動実行のみ）だった。subagent に release notes を原文確認させた。破壊的変更は Node24 ランタイムのみ。v17 でエラー伝播の修正（push 失敗が握り潰されず CI 失敗として顕在化する）が入っており、これまでの隠れた push 失敗が次回の手動実行で表面化する可能性がある（互換性の破壊ではなく検知強化）。name: hikuohiku の認証設定自体への影響は無い。次回 workflow_dispatch 実行時に push が成功することを確認する"
     },
     {
       "id": "T-0048",

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -239,12 +239,12 @@
       "id": "gha-cachix-cachix-action",
       "kind": "github-action",
       "name": "cachix/cachix-action",
-      "current": "v15",
+      "current": "v17",
       "file": ".github/workflows/release-image.yml",
       "match": "cachix/cachix-action@",
       "upstream": "github:cachix/cachix-action",
       "policy": "auto",
-      "note": "T-0043 (run #16) で発見。最新 v17 は 2 メジャー遅れ → T-0047"
+      "note": "T-0047 (run #17) で v15→v17 に更新。破壊的変更は Node24 ランタイムのみ。v17 でエラー伝播の修正が入っており、これまで握り潰されていた push 失敗が今後は CI 失敗として顕在化しうる（workflow_dispatch 手動実行のため次回実行時に確認）"
     },
     {
       "id": "gha-softprops-action-gh-release",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -507,4 +507,8 @@
 - 続けて T-0045（azure/setup-helm v4→v5）を完遂。subagent に release notes を原文確認させ、
   破壊的変更は Node24 ランタイム更新のみ（GitHub-hosted runner では透過的）と確認して更新（#119, merged）
 - 続けて T-0046（hashicorp/setup-terraform v3→v4）を完遂。同じ subagent 調査で破壊的変更は
-  Node24 ランタイムのみと確認済み（terraform_wrapper: false のためラッパー由来の挙動変更とも無関係）（#120）
+  Node24 ランタイムのみと確認済み（terraform_wrapper: false のためラッパー由来の挙動変更とも無関係）（#120, merged）
+- 続けて T-0047（cachix/cachix-action v15→v17）を完遂。使用箇所は ci.yml ではなく
+  release-image.yml（workflow_dispatch 手動実行）だったと判明。破壊的変更は Node24 ランタイムのみだが、
+  v17 でエラー伝播の修正が入り、これまで握り潰されていた push 失敗が次回の手動実行で顕在化しうる旨を
+  inventory.json に記録した（#121）


### PR DESCRIPTION
## 変更点

`.github/workflows/release-image.yml`（Nix イメージビルド、`workflow_dispatch` 手動実行のみ）が使う `cachix/cachix-action` を v15 → v17 に上げた。`name: hikuohiku` の認証設定は変更していない。

T-0043（GitHub Actions の棚卸し）で v15 が 2 メジャー遅れていると判明していた。

## 検証したこと

- release notes（v15 〜 v17）を原文確認。破壊的変更は Node.js ランタイムの 20→24 更新のみ
- **注意点（互換性の破壊ではない）**: v17 でエラー伝播の修正が入っており、これまで握り潰されていた cachix push の失敗が、CI 失敗として顕在化する可能性がある。このジョブは `workflow_dispatch` 手動実行のみなので、次回の手動実行で push が成功することを確認する
- `python3 ops/validate.py` — 0 error

## ロールバック手順

`cachix/cachix-action@v17` を `@v15` に戻すだけ。

## backlog task id

T-0047

---
_Generated by [Claude Code](https://claude.ai/code/session_0161jzze4yd7GVCFanbjb2H6)_