### PR TITLE
ci: softprops/action-gh-release を v2 → v3 に上げる (T-0048)

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -77,7 +77,7 @@ jobs:
           cat "nixos-proxmox-cloud-${VERSION}.qcow2.sha256"
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.version }}
           name: ${{ steps.version.outputs.version }}

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 49,
-  "updated": "2026-08-05T01:29:00Z",
+  "updated": "2026-08-05T01:32:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -864,7 +864,7 @@
       "title": "softprops/action-gh-release を v2 → v3 に上げる",
       "kind": "ci",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 27,
       "why": "T-0043 (run #16) の調査で判明。現在 v2、最新は v3。release-image.yml（workflow_dispatch 手動実行のみ）でのリリース作成に使用",
       "dod": "release-image.yml の softprops/action-gh-release@v2 が v3 になる。workflow_dispatch のため実行時検証は次回の手動実行まで難しく、release note に破壊的変更が無いことの確認で足りるとする",
@@ -872,7 +872,8 @@
         ".github/workflows/release-image.yml"
       ],
       "created": "2026-08-05",
-      "pr": null
+      "pr": 122,
+      "notes": "run #17: subagent に v2.6.2〜v3.0.2 の release notes を原文確認させた。v3.0.0 の唯一の破壊的変更は Node24 ランタイム（upstream が明示: Node20 互換が要るなら v2.6.2 に留まれと明記）。v3.0.1 は依存更新のみ、v3.0.2 の新機能（既存 draft の再利用、Gitea アセット置換対応等）はこのリポジトリの non-draft/non-prerelease 経路には無関係。tag_name/name/body 等の入力に変更なし。T-0045〜T-0048 で GitHub Actions のメジャー更新棚卸し（T-0043）が完了した"
     }
   ]
 }

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -250,12 +250,12 @@
       "id": "gha-softprops-action-gh-release",
       "kind": "github-action",
       "name": "softprops/action-gh-release",
-      "current": "v2",
+      "current": "v3",
       "file": ".github/workflows/release-image.yml",
       "match": "softprops/action-gh-release@",
       "upstream": "github:softprops/action-gh-release",
       "policy": "auto",
-      "note": "T-0043 (run #16) で発見。最新 v3 → T-0048"
+      "note": "T-0048 (run #17) で v2→v3 に更新。破壊的変更は Node24 ランタイムのみ。non-draft/non-prerelease の使用範囲には無関係な変更（既存 draft の再利用、Gitea 対応等）のみ追加"
     },
     {
       "id": "gha-nix-installer-action",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -511,4 +511,7 @@
 - 続けて T-0047（cachix/cachix-action v15→v17）を完遂。使用箇所は ci.yml ではなく
   release-image.yml（workflow_dispatch 手動実行）だったと判明。破壊的変更は Node24 ランタイムのみだが、
   v17 でエラー伝播の修正が入り、これまで握り潰されていた push 失敗が次回の手動実行で顕在化しうる旨を
-  inventory.json に記録した（#121）
+  inventory.json に記録した（#121, merged）
+- 続けて T-0048（softprops/action-gh-release v2→v3）を完遂。破壊的変更は Node24 ランタイムのみ、
+  非 draft/非 prerelease の使用範囲には無関係な追加機能のみと確認（#122）。これで T-0043 由来の
+  GitHub Actions メジャー更新棚卸し（T-0044〜T-0048）が全て完了した


### PR DESCRIPTION
## 変更点

`.github/workflows/release-image.yml`（`workflow_dispatch` 手動実行のみ）が使う `softprops/action-gh-release` を v2 → v3 に上げた。`tag_name` / `name` / `body` 等の入力は変更していない。

T-0043（GitHub Actions の棚卸し）で v2 が 1 メジャー遅れていると判明していた。これで T-0043 由来の GitHub Actions 更新棚卸し（T-0044〜T-0048）が全て完了する。

## 検証したこと

- release notes（v2.6.2 〜 v3.0.2）を原文確認。唯一の破壊的変更は Node.js ランタイムの 20→24 更新（upstream も「Node20 互換が必要なら v2.6.2 に留まれ」と明記）。v3.0.2 の追加機能（既存 draft の再利用、Gitea アセット置換対応）はこのリポジトリの non-draft/non-prerelease 経路には無関係
- `python3 ops/validate.py` — 0 error
- `workflow_dispatch` 手動実行のみのため実行時検証は次回の手動実行まで難しい。release note の原文確認で足りると判断した

## ロールバック手順

`softprops/action-gh-release@v3` を `@v2` に戻すだけ。

## backlog task id

T-0048

---
_Generated by [Claude Code](https://claude.ai/code/session_0161jzze4yd7GVCFanbjb2H6)_