### PR TITLE
ops: nixpkgs flake.lock の経年放置を発見し T-0049 として起票する (T-0049)

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 49,
-  "updated": "2026-08-05T01:32:00Z",
+  "next_id": 50,
+  "updated": "2026-08-05T01:23:49Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -720,7 +720,7 @@
       "status": "done",
       "priority": 25,
       "why": "run #14 時点で backlog の todo が 0 件になった（T-0005 由来の個別更新タスクを全て消化）。CHARTER §3 は backlog が空のときに調査タスクを自分で起票することを求めている。T-0005 の調査（run #6, 2026-08-04）から日数が経つと inventory.json の各対象がまた古くなる。T-0012（自己振り返り）と同じ recurring の運用に倣い、T-0005 を初回実施とみなして再調査サイクルに載せる",
-      "dod": "T-0005 と同じ手法（subagent 併用）で ops/inventory.json の全対象の上流最新版を確認し、差分があれば個別の更新タスクを起票する（1 コンポーネント 1 タスク）。この調査自体ではコードを変更しない。実施後は次回の next_review を 1 週間先に更新する",
+      "dod": "T-0005 と同じ手法（subagent 併用）で ops/inventory.json の全対象の上流最新版を確認し、差分があれば個別の更新タスクを起票する（1 コンポーネント 1 タスク）。この調査自体ではコードを変更しない。実施後は次回の next_review を 1 週間先に更新する。**`policy: manual` かつ離散リリースが無い対象（nixpkgs 等）は差分確認の対象外だが、`flake.lock` に埋め込まれた `lastModified` から経過月数を出し、目安（6ヶ月）を超えていたら age だけを理由に needs-human を起票する**（T-0049 run #18 参照。離散リリースが無いことを理由に経年チェックまで除外すると、その対象だけ永久に誰も見なくなり CLAUDE.md #49 と同型の塩漬けが起きる）",
       "recurring": "weekly",
       "last_done": "2026-08-04",
       "next_review": "2026-08-11",
@@ -874,6 +874,25 @@
       "created": "2026-08-05",
       "pr": 122,
       "notes": "run #17: subagent に v2.6.2〜v3.0.2 の release notes を原文確認させた。v3.0.0 の唯一の破壊的変更は Node24 ランタイム（upstream が明示: Node20 互換が要るなら v2.6.2 に留まれと明記）。v3.0.1 は依存更新のみ、v3.0.2 の新機能（既存 draft の再利用、Gitea アセット置換対応等）はこのリポジトリの non-draft/non-prerelease 経路には無関係。tag_name/name/body 等の入力に変更なし。T-0045〜T-0048 で GitHub Actions のメジャー更新棚卸し（T-0043）が完了した"
+    },
+    {
+      "id": "T-0049",
+      "domain": "homelab",
+      "title": "nix/images/proxmox-cloud/flake.lock（nixpkgs 等）を `nix flake update` で最新化してほしい",
+      "kind": "upgrade",
+      "risk": "medium",
+      "status": "needs-human",
+      "priority": 28,
+      "why": "backlog の todo が 0 件だったため CHARTER §3 の調査（run #18）。`ops/inventory.json` の nixpkgs エントリは `policy: manual` かつ『離散リリースが無いので T-0005/T-0040 の対象外』とされているが、これは経年チェックそのものも免除している訳ではなかった。`flake.lock` に埋め込まれた `locked.lastModified` を実際に読むと、4 入力（flake-parts, nixpkgs, nixpkgs-lib, sops-nix）とも 2025-11〜12 更新止まりで、今日時点で約 8 ヶ月放置されている。離散リリースが無いことを理由に誰も経年を見ていなかっただけで、CLAUDE.md の Maintenance 節にある vaultwarden 放置（#49）と同型のリスク（気づかれないまま塩漬けになる）に該当する",
+      "dod": "`nix/images/proxmox-cloud` で `nix flake update` を実行し、更新後の `flake.lock` をコミットする。CI（`nix flake check`）が green であることを確認する。configuration.nix / k3s-manifests.nix が参照する NixOS モジュールオプションに 8 ヶ月分の破壊的変更が無いか目視で確認する（nixos-unstable のリリースノート相当は無いため、`nixpkgs` の変更ログではなく実際に使っているオプション — `proxmox.cloudInit`, `services.cloud-init`, `services.k3s` 相当, `sops` 等 — の evaluation が通ることで代用可）。実機（node01）へは自動反映されない（CLAUDE.md: NixOS イメージのビルド・入れ替えは手動運用）ため、イメージの再ビルド・差し替え自体は別途人間の判断でよい",
+      "needs_human_reason": "`nix flake update` は provider/dependency のロックハッシュ（narHash）を実際に nix を実行して計算する必要があり、autopilot のクラウドサンドボックスには nix が無い（CHARTER §5.2、T-0030 の terraform lock と同型の制約）。手で `.lock` の JSON を編集してハッシュを捏造することはできないので、nix が使える環境（人間の対話セッション等）で `nix flake update` を実行し、結果の `flake.lock` をコミットしてほしい。破壊的変更の洗い出しは実行後に自分（次にこの needs-human を拾う起動）が diff を見て引き続き担当する",
+      "refs": [
+        "nix/images/proxmox-cloud/flake.lock",
+        "ops/inventory.json"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #18: flake.lock の `locked.lastModified`（unix epoch）を4入力とも確認し、2025-11-21〜2025-12-12 止まりと判明。T-0040 の DoD に『manual policy かつ離散リリース無しの対象も経年チェックだけは行う』を追記し、今後は自動的に再検出されるようにした"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,7 @@
 {
   "open": [],
   "merged": [
+    {"number": 123, "title": "ops: run #17 の記録をまとめ、ダッシュボードを再生成する", "url": "https://github.com/hikuohiku/homelab/pull/123", "mergedAt": "2026-08-05T01:22:18Z", "headRefName": "autopilot/run17-wrapup"},
     {"number": 122, "title": "ci: softprops/action-gh-release を v2 → v3 に上げる (T-0048)", "url": "https://github.com/hikuohiku/homelab/pull/122", "mergedAt": "2026-08-05T01:18:03Z", "headRefName": "autopilot/T-0048-gh-release-v3"},
     {"number": 121, "title": "ci: cachix/cachix-action を v15 → v17 に上げる (T-0047)", "url": "https://github.com/hikuohiku/homelab/pull/121", "mergedAt": "2026-08-05T01:16:31Z", "headRefName": "autopilot/T-0047-cachix-action-v17"},
     {"number": 120, "title": "ci: hashicorp/setup-terraform を v3 → v4 に上げる (T-0046)", "url": "https://github.com/hikuohiku/homelab/pull/120", "mergedAt": "2026-08-05T01:15:07Z", "headRefName": "autopilot/T-0046-setup-terraform-v4"},

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -517,3 +517,26 @@
   GitHub Actions メジャー更新棚卸し（T-0044〜T-0048）が全て完了した
 - run #17 のまとめ: T-0043, T-0045〜T-0048 の 5 タスクを直列に完遂（#118〜#122）。backlog の todo は
   本 run 終了時点で 0 件。次の起動は CHARTER §3 の調査から入ることになる
+
+## 2026-08-05 01:23 UTC — run #18
+
+- 前回の中断確認: `git fetch` 後 `git branch -r | grep autopilot/` はヒット無し、
+  `mcp__github__list_pull_requests`（state: open）も 0 件。中断なし
+- 読んだフィードバック: issue #56 の最新コメント（2026-08-04T23:59:38Z）が `last_read` と一致。未読なし
+- backlog の todo は 0 件（T-0040/T-0012 とも next_review は 2026-08-11）。CHARTER §3 に従い調査
+- これまでの調査（依存バージョン、ドキュメント整合性、CI Action バージョン）とは別角度で、
+  `ops/inventory.json` の `policy: manual` エントリのうち「離散リリースが無いので監視対象外」と
+  されているものを見た。`nixpkgs`（`nix/images/proxmox-cloud/flake.lock`）がこれに該当し、
+  T-0005/T-0040 の棚卸しから毎回明示的に除外されている
+- `flake.lock` の各入力の `locked.lastModified`（unix epoch、nix 自身が書き込む実際の commit 日時）を
+  読むと、flake-parts/nixpkgs/nixpkgs-lib/sops-nix の 4 入力とも 2025-11-21〜2025-12-12 止まりで、
+  今日時点で約 8 ヶ月放置されていると判明。「離散リリースが無い」は「差分ベースの更新判断ができない」
+  という意味であって「経年チェックが不要」という意味ではなく、この 2 つを混同した結果、
+  nixpkgs だけが誰にも見られないまま塩漬けになる経路が残っていた（CLAUDE.md の vaultwarden 放置
+  #49 と同型のリスク）
+- T-0049 として起票。`nix flake update` にはロックハッシュの実計算が要り、autopilot のサンドボックスに
+  nix が無い（CHARTER §5.2）ため T-0030（terraform lock）と同型の needs-human とした。あわせて
+  T-0040 の DoD に「manual policy かつ離散リリース無しの対象も経年チェックだけは行う」を追記し、
+  次回以降は自動的にこの種の見落としが再検出されるようにした
+- 次の起動へ: backlog の todo は引き続き 0 件（T-0049 は needs-human）。T-0040/T-0012 の
+  next_review は 2026-08-11 のまま

--- a/ops/state.json
+++ b/ops/state.json
@@ -235,7 +235,9 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。backlog の todo が 0 件（T-0040/T-0012 とも next_review は 2026-08-11）だったため CHARTER §3 に従い調査。ops/inventory.json の policy: manual エントリのうち『離散リリースが無いので棚卸し対象外』とされている nixpkgs（nix/images/proxmox-cloud/flake.lock）を見た。flake.lock 内の locked.lastModified を読むと4入力とも2025-11〜12止まりで約8ヶ月放置と判明（離散リリース無し＝経年チェック不要ではなかった）。T-0049 として needs-human 起票（nix flake update にはロックハッシュの実計算が要り、サンドボックスに nix が無い。T-0030 と同型）。あわせて T-0040 の DoD に経年チェックを追記し、今後同種の見落としが再検出されるようにした",
-      "prs": []
+      "prs": [
+        124
+      ]
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T01:18:00Z",
+  "updated": "2026-08-05T01:23:49Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -228,6 +228,14 @@
         121,
         122
       ]
+    },
+    {
+      "n": 18,
+      "at": "2026-08-05T01:23:49Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。backlog の todo が 0 件（T-0040/T-0012 とも next_review は 2026-08-11）だったため CHARTER §3 に従い調査。ops/inventory.json の policy: manual エントリのうち『離散リリースが無いので棚卸し対象外』とされている nixpkgs（nix/images/proxmox-cloud/flake.lock）を見た。flake.lock 内の locked.lastModified を読むと4入力とも2025-11〜12止まりで約8ヶ月放置と判明（離散リリース無し＝経年チェック不要ではなかった）。T-0049 として needs-human 起票（nix flake update にはロックハッシュの実計算が要り、サンドボックスに nix が無い。T-0030 と同型）。あわせて T-0040 の DoD に経年チェックを追記し、今後同種の見落としが再検出されるようにした",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

コード・マニフェストの変更は無し。`ops/` の記録のみ。

- backlog に **T-0049**（needs-human）を起票: `nix/images/proxmox-cloud/flake.lock` の nixpkgs 等 4 入力が最終更新から約 8 ヶ月放置されている
- T-0040（inventory 定期棚卸し）の DoD に、`policy: manual` かつ離散リリースの無い対象（nixpkgs 等）についても `flake.lock` の `locked.lastModified` から経年チェックだけは行う、という手順を追記
- journal に run #18 の記録を追記、state.json に run #18 を追記（作業中に run #17 の wrap-up PR (#123) が並行してマージされたため rebase して取り込み、`ops/dashboard/prs.json` に #123 自身のエントリを追記）

## 見つけたこと

`ops/inventory.json` の `nixpkgs` エントリは「離散リリースが無いので T-0005/T-0040 の棚卸し対象外」とされていましたが、これは経年チェックまで免除する意図ではありませんでした。実際に `flake.lock` の `locked.lastModified`（nix 自身が書き込む実コミット日時）を読むと、`flake-parts` / `nixpkgs` / `nixpkgs-lib` / `sops-nix` の 4 入力とも 2025-11-21〜2025-12-12 止まりで、今日時点で約 8 ヶ月放置されていました。CLAUDE.md の vaultwarden 放置（#49）と同型の「気づかれないまま塩漬け」パターンです。

なお、この pin の更新は node01 の自動運用には影響しません（CLAUDE.md の記載どおり NixOS イメージのビルド・差し替えは手動運用のため）。

## 検証したこと

- `python3 ops/validate.py` → 0 error（3 warning は既知: T-0035 の参照切れ、T-0040 の PR 無し完了、todo 0 件の指摘。いずれも本 PR の変更とは無関係な既存状態）
- `python3 ops/dashboard/build.py` → 正常終了、Artifact に再公開予定

## ロールバック手順

`ops/` 配下の記録ファイルのみの変更のため、実インフラへの影響は無し。問題があれば本 PR の revert で即座に戻せる。

## backlog task id

T-0049（新規起票、needs-human）。あわせて T-0040 を更新。

---
_Generated by [Claude Code](https://claude.ai/code/session_01VanHFHNhcfeCCgLN2kpf5B)_