### PR TITLE
docs(ci): release-image.yml が CI 検証対象外であることを明記する (T-0050)

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
+      # authToken/signingKey が無いため pull（substituter）専用。push は一切行わない（ops/CHARTER.md §5.4）。
       - name: Setup Cachix
         uses: cachix/cachix-action@v17
         with:

--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -269,6 +269,29 @@ upstream リポジトリのファイル（例: `deploy/crds/bundle.yaml` のよ�
 正しかったが、方法として再現性が無い）。CRD やオブジェクトの実体を確認したいなら、chart がレンダリングされた
 結果（`manifest-diff` の出力、または手元に `kustomize`/`helm` があればその場でレンダリングした結果）を見る。
 
+### 5.4 `.github/workflows/release-image.yml` は CI の検証対象外
+
+この workflow は `workflow_dispatch` 専用（人間の手動実行のみ）で、PR にも push にも反応しない。
+`kustomize build` / `terraform validate` / `ops state validate` / `manifest-diff` / `nix flake check` の
+どれもこのファイルの中身を一度も実行しない。**§4 の「CI が検証できない領域」に該当する**（issue #56,
+2026-08-05 01:18:49。T-0042/T-0044/T-0047/T-0048 でここに使われる Action（`DeterminateSystems/nix-installer-action`
+`cachix/cachix-action` `softprops/action-gh-release`）を CI 側と同じ感覚で「release notes 上は Node ランタイム
+更新のみ」と結論して merge したが、実際に動かして確かめた回数はゼロだった）。
+
+対処方針（§4 の一般則をこのファイルに適用したもの）:
+
+- ここでしか使われていない Action（`nix-installer-action` / `cachix-action` / `action-gh-release`。
+  `actions/checkout` は `ci.yml` 等でも使われ間接的に実exercisedされるので対象外）を更新するときは、
+  changelog の要約だけで判断しない。**その Action の実ソース（`action.yml`、本体コード）を読み、
+  このファイルが実際に渡している input（例: `cachix-action` は `name:` のみで `authToken` 無し）で
+  何が起きるかを具体的に確かめる**（§5.3 と同じ「レンダリングされた実体を見る」原則）
+- 2026-08-05 時点で確認済み: `cachix/cachix-action` は `authToken`/`signingKey` が無いと push を一切行わない
+  （`pushMode = None`）ため、v17 で入った「push 失敗が job 失敗として伝播する」変更はこの workflow には
+  影響しない（push 自体が発生しない）。`nix-installer-action` の `determinate: true` デフォルトは
+  v22 固有ではなく、更新前の floating `@main` から既に同じだった
+- 検証しきれない・実ソースを読んでも判断がつかない場合は、**このファイルへの変更を auto-merge の対象から
+  外し**、PR 本文に「次回の手動実行（人間によるリリース操作）まで動作未確認」と明記する
+
 ---
 
 ## 6. 人間からのフィードバック
@@ -291,6 +314,8 @@ upstream リポジトリのファイル（例: `deploy/crds/bundle.yaml` のよ�
 PR に付いたレビューコメントも同じ扱い。**指摘を受けたら、その PR を直すだけでなく、再発しない形（CHARTER・CI・チェックリスト）に落とす。**
 
 **過去の指摘を反映するときは、指摘された時点の前提が今も成り立つか自分で確かめる。** 状態は変わりうる（ruleset の設定、権限、上流のバージョンなど）。「無かった」「まだ塞がっていない」は「まだ見えていない」「もう解消済み」と区別がつかないことがある（issue #56, 2026-08-04 の 2 件の事例）。
+
+**指摘を受けたら、それが自分の環境で実行可能かも同じように確かめる。** 指摘する側（人間・構築セッションいずれも）は、こちらの実行環境の制約（§5.1/§5.2 のツール有無・権限）を知らずに書いてくることがある。実行できない指摘は、黙って諦めるのでも無理に試すのでもなく、「できない、代わりにこう対処する」と issue に返す。今回できないと分かっているなら、次に同じ指摘を受けたときのために CHARTER の該当箇所（§5.1/§5.2）にその旨が既に書いてあるか確認し、無ければ足す（issue #56, 2026-08-05 01:08:27。ブランチ削除を求められたが `git push origin --delete` は 403 で実行不能、§5.1 に既知の事実として記録済みだった）。
 
 ---
 

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 50,
-  "updated": "2026-08-05T01:23:49Z",
+  "next_id": 51,
+  "updated": "2026-08-05T02:10:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -893,6 +893,25 @@
       "created": "2026-08-05",
       "pr": null,
       "notes": "run #18: flake.lock の `locked.lastModified`（unix epoch）を4入力とも確認し、2025-11-21〜2025-12-12 止まりと判明。T-0040 の DoD に『manual policy かつ離散リリース無しの対象も経年チェックだけは行う』を追記し、今後は自動的に再検出されるようにした"
+    },
+    {
+      "id": "T-0050",
+      "domain": "homelab",
+      "title": "release-image.yml が CI の検証対象外であることを明記し、T-0047 で保留にした cachix push 挙動の懸念を実ソースで確定させる",
+      "kind": "docs",
+      "risk": "low",
+      "status": "done",
+      "priority": 5,
+      "why": "issue #56 (2026-08-05 01:18:49) の指摘。T-0042/T-0044/T-0047/T-0048 で release-image.yml の Action を更新したが、この workflow は workflow_dispatch 専用で CI（PR/push）が一度も実行しない。CHARTER §4『CI が検証できない領域の変更を auto-merge してはならない』に反する形で進めていた。T-0047 の notes に残っていた「次回の手動実行で push 失敗が顕在化する可能性」という未決着の懸念も、実際に push するかどうかさえ確認していなかった",
+      "dod": "ops/CHARTER.md に release-image.yml が CI 対象外である事実と、ここでしか使われない Action を更新するときの手順（changelog 要約でなく実ソースで確認する）を明記する。cachix/cachix-action の push 挙動を action 本体のソースで確認し、ops/inventory.json の該当 note を確定した結論に書き換える",
+      "refs": [
+        "ops/CHARTER.md",
+        "ops/inventory.json",
+        ".github/workflows/release-image.yml"
+      ],
+      "created": "2026-08-05",
+      "pr": 125,
+      "notes": "run #19: subagent に cachix/cachix-action・softprops/action-gh-release・DeterminateSystems/nix-installer-action・actions/checkout の実ソース/action.yml/changelog を原文確認させた。結論: 4 件とも現状の使い方（release-image.yml が実際に渡す input）に対して安全。cachix-action は authToken/signingKey が無いと pushMode=None で push を一切行わないため、v17 の『push 失敗が job 失敗として伝播する』変更はそもそも発火しない。revert は不要と判断し、CHARTER §5.4 として release-image.yml の CI 非カバレッジと今後の確認手順を明文化した。着手時点では T-0049 として起票したが、同時に走っていた別セッションが T-0049（nixpkgs flake.lock の経年、#124）を先にマージしたため、rebase 時に T-0050 へ採番し直した（本 run 自身も run #18 と自称したが同じ理由で run #19 に採番し直した）"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,71 +1,393 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 125,
+      "title": "docs(ci): release-image.yml が CI 検証対象外であることを明記する (T-0050)",
+      "url": "https://github.com/hikuohiku/homelab/pull/125",
+      "isDraft": false,
+      "createdAt": "2026-08-05T01:32:00Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "PENDING"
+        }
+      ],
+      "headRefName": "autopilot/T-0049-release-image-ci-blindspot",
+      "autoMergeRequest": {
+        "enabledAt": "2026-08-05T01:32:25Z"
+      }
+    }
+  ],
   "merged": [
-    {"number": 123, "title": "ops: run #17 の記録をまとめ、ダッシュボードを再生成する", "url": "https://github.com/hikuohiku/homelab/pull/123", "mergedAt": "2026-08-05T01:22:18Z", "headRefName": "autopilot/run17-wrapup"},
-    {"number": 122, "title": "ci: softprops/action-gh-release を v2 → v3 に上げる (T-0048)", "url": "https://github.com/hikuohiku/homelab/pull/122", "mergedAt": "2026-08-05T01:18:03Z", "headRefName": "autopilot/T-0048-gh-release-v3"},
-    {"number": 121, "title": "ci: cachix/cachix-action を v15 → v17 に上げる (T-0047)", "url": "https://github.com/hikuohiku/homelab/pull/121", "mergedAt": "2026-08-05T01:16:31Z", "headRefName": "autopilot/T-0047-cachix-action-v17"},
-    {"number": 120, "title": "ci: hashicorp/setup-terraform を v3 → v4 に上げる (T-0046)", "url": "https://github.com/hikuohiku/homelab/pull/120", "mergedAt": "2026-08-05T01:15:07Z", "headRefName": "autopilot/T-0046-setup-terraform-v4"},
-    {"number": 119, "title": "ci: azure/setup-helm を v4 → v5 に上げる (T-0045)", "url": "https://github.com/hikuohiku/homelab/pull/119", "mergedAt": "2026-08-05T01:13:46Z", "headRefName": "autopilot/T-0045-setup-helm-v5"},
-    {"number": 118, "title": "ops: GitHub Actions を inventory.json の監視対象に追加する (T-0043)", "url": "https://github.com/hikuohiku/homelab/pull/118", "mergedAt": "2026-08-05T01:11:31Z", "headRefName": "autopilot/T-0043-github-actions-inventory"},
-    {"number": 117, "title": "ops: run #16 の PR キャッシュを最新化する", "url": "https://github.com/hikuohiku/homelab/pull/117", "mergedAt": "2026-08-05T00:52:49Z", "headRefName": "autopilot/run16-wrapup"},
-    {"number": 116, "title": "ci: actions/checkout を v4 → v7 に上げる (T-0044)", "url": "https://github.com/hikuohiku/homelab/pull/116", "mergedAt": "2026-08-05T00:51:08Z", "headRefName": "autopilot/T-0044-checkout-v7"},
-    {"number": 115, "title": "ci: nix-installer-action の floating ref を固定する (T-0042)", "url": "https://github.com/hikuohiku/homelab/pull/115", "mergedAt": "2026-08-05T00:46:53Z", "headRefName": "autopilot/T-0042-pin-nix-installer-action"},
-    {"number": 114, "title": "docs: Plans.md の kubectl ask 前提の記述を実態に合わせる (T-0041)", "url": "https://github.com/hikuohiku/homelab/pull/114", "mergedAt": "2026-08-05T00:24:50Z", "headRefName": "autopilot/T-0041-plans-md-ask-drift"},
-    {"number": 113, "title": "ops: run #14 の記録をまとめ、ダッシュボードを再生成する", "url": "https://github.com/hikuohiku/homelab/pull/113", "mergedAt": "2026-08-05T00:16:51Z", "headRefName": "autopilot/run14-wrapup"},
-    {"number": 112, "title": "Maintenance.md: T-0031 revert / T-0038 完遂を反映 (T-0039)", "url": "https://github.com/hikuohiku/homelab/pull/112", "mergedAt": "2026-08-05T00:11:46Z", "headRefName": "autopilot/T-0039-maintenance-doc-sync"},
-    {"number": 111, "title": "vaultwarden: IP_HEADER_TRUSTED_PROXIES を pod CIDR に絞る (T-0038)", "url": "https://github.com/hikuohiku/homelab/pull/111", "mergedAt": "2026-08-05T00:09:28Z", "headRefName": "autopilot/T-0038-vaultwarden-trusted-proxies"},
-    {"number": 110, "title": "vaultwarden: icon 取得の無効化を revert する (T-0031)", "url": "https://github.com/hikuohiku/homelab/pull/110", "mergedAt": "2026-08-05T00:05:54Z", "headRefName": "autopilot/T-0031-revert-icon-download"},
-    {"number": 109, "title": "issue #56 のフィードバック4件を反映", "url": "https://github.com/hikuohiku/homelab/pull/109", "mergedAt": "2026-08-05T00:04:19Z", "headRefName": "autopilot/feedback-round14"},
-    {"number": 108, "title": "ops: run #13 の記録をまとめ、ダッシュボードを再生成する", "url": "https://github.com/hikuohiku/homelab/pull/108", "mergedAt": "2026-08-04T23:44:38Z", "headRefName": "autopilot/run13-wrapup"},
-    {"number": 107, "title": "vaultwarden: IP_HEADER=X-Forwarded-For を設定し Tailscale 経由のレート制限誤発火を防ぐ (T-0032)", "url": "https://github.com/hikuohiku/homelab/pull/107", "mergedAt": "2026-08-04T23:38:46Z", "headRefName": "autopilot/t0032-vaultwarden-ip-header"},
-    {"number": 106, "title": "external-secrets chart を 1.3.2 → 2.8.0 に上げる (T-0037)", "url": "https://github.com/hikuohiku/homelab/pull/106", "mergedAt": "2026-08-04T23:35:52Z", "headRefName": "autopilot/t0037-external-secrets-2.8.0"},
-    {"number": 104, "title": "vaultwarden: icon 取得タイムアウトを DISABLE_ICON_DOWNLOAD で無効化する (T-0031)", "url": "https://github.com/hikuohiku/homelab/pull/104", "mergedAt": "2026-08-04T23:31:42Z", "headRefName": "autopilot/t0031-vaultwarden-disable-icon"},
-    {"number": 103, "title": "ops: run #12 の記録をまとめ、ダッシュボードを再生成する", "url": "https://github.com/hikuohiku/homelab/pull/103", "mergedAt": "2026-08-04T23:09:47Z", "headRefName": "autopilot/run12-wrapup"},
-    {"number": 102, "title": "external-secrets chart を 1.1.1 → 1.3.2 に上げる (T-0026)", "url": "https://github.com/hikuohiku/homelab/pull/102", "mergedAt": "2026-08-04T23:08:09Z", "headRefName": "autopilot/run12-feedback-t0026"},
-    {"number": 101, "title": "ops: run #11 の記録をまとめ、ダッシュボードを再生成する", "url": "https://github.com/hikuohiku/homelab/pull/101", "mergedAt": "2026-08-04T22:42:03Z", "headRefName": "autopilot/run-11-wrapup"},
-    {"number": 100, "title": "upgrade(tailscale): operator chart 1.90.9→1.98.9、k8s-nameserver を v1.98.9 に揃える (T-0024, T-0025)", "url": "https://github.com/hikuohiku/homelab/pull/100", "mergedAt": "2026-08-04T22:40:28Z", "headRefName": "autopilot/T-0024-T-0025-tailscale-upgrade"},
-    {"number": 99, "title": "ops: run #11 のダッシュボード PR キャッシュを最新化する", "url": "https://github.com/hikuohiku/homelab/pull/99", "mergedAt": "2026-08-04T22:32:56Z", "headRefName": "autopilot/run-11-dashboard-cache"},
-    {"number": 98, "title": "ci: apps/ render の意図しないオブジェクト削除を検出するジョブを追加 (T-0036)", "url": "https://github.com/hikuohiku/homelab/pull/98", "mergedAt": "2026-08-04T22:26:27Z", "headRefName": "autopilot/T-0036-manifest-deletion-guard"},
-    {"number": 97, "title": "T-0012: 自己振り返りを実施し、run #10 の記録をまとめる", "url": "https://github.com/hikuohiku/homelab/pull/97", "mergedAt": "2026-08-04T22:12:24Z", "headRefName": "autopilot/t-0012-weekly-review"},
-    {"number": 96, "title": "T-0023: coder v2.35.3 更新のリスクを見直し、blocked にする", "url": "https://github.com/hikuohiku/homelab/pull/96", "mergedAt": "2026-08-04T22:08:47Z", "headRefName": "autopilot/t-0023-coder-v2.35.3"},
-    {"number": 95, "title": "T-0022: immich Helm chart を 0.12.0 → 0.13.1 に上げる", "url": "https://github.com/hikuohiku/homelab/pull/95", "mergedAt": "2026-08-04T22:03:02Z", "headRefName": "autopilot/t-0022-immich-chart-0.13.1"},
-    {"number": 94, "title": "CHARTER: 到達性の定義に自分自身の観測・操作経路を含める", "url": "https://github.com/hikuohiku/homelab/pull/94", "mergedAt": "2026-08-04T21:58:14Z", "headRefName": "autopilot/feedback-56-observation-path"},
-    {"number": 93, "title": "ops: run #9 の記録をまとめ、ダッシュボードを再生成する", "url": "https://github.com/hikuohiku/homelab/pull/93", "mergedAt": "2026-08-04T21:39:28Z", "headRefName": "autopilot/run-9-wrapup"},
-    {"number": 92, "title": "T-0021: coder-postgres を 17.5 → 17.10 に上げる", "url": "https://github.com/hikuohiku/homelab/pull/92", "mergedAt": "2026-08-04T21:37:02Z", "headRefName": "autopilot/t-0021-coder-postgres-patch"},
-    {"number": 91, "title": "T-0020: busybox を 1.37 → 1.38.0 に上げる", "url": "https://github.com/hikuohiku/homelab/pull/91", "mergedAt": "2026-08-04T21:34:45Z", "headRefName": "autopilot/t-0020-busybox-patch"},
-    {"number": 90, "title": "T-0019: immich の valkey を 9.1-alpine → 9.1.1-alpine に上げる", "url": "https://github.com/hikuohiku/homelab/pull/90", "mergedAt": "2026-08-04T21:32:13Z", "headRefName": "autopilot/t-0019-immich-valkey-patch"},
-    {"number": 89, "title": "T-0016: ダッシュボードの PR 一覧を gh CLI 非依存にする", "url": "https://github.com/hikuohiku/homelab/pull/89", "mergedAt": "2026-08-04T21:29:16Z", "headRefName": "autopilot/t-0016-dashboard-pr-list-mcp"},
-    {"number": 88, "title": "T-0035: ops/dashboard/index.html を Git 管理から外す", "url": "https://github.com/hikuohiku/homelab/pull/88", "mergedAt": "2026-08-04T21:24:41Z", "headRefName": "autopilot/t-0035-dashboard-html-untrack"},
-    {"number": 87, "title": "PBS バックアップ体制を棚卸しする (T-0013)", "url": "https://github.com/hikuohiku/homelab/pull/87", "mergedAt": "2026-08-04T21:13:05Z", "headRefName": "autopilot/t-0013-pbs-backup-inventory"},
-    {"number": 86, "title": "weekly-maintenance と CHARTER の役割を分ける (T-0009)", "url": "https://github.com/hikuohiku/homelab/pull/86", "mergedAt": "2026-08-04T21:08:55Z", "headRefName": "autopilot/t-0009-weekly-maintenance-charter-roles"},
-    {"number": 85, "title": "CI に nix flake check を追加する (T-0008)", "url": "https://github.com/hikuohiku/homelab/pull/85", "mergedAt": "2026-08-04T21:05:33Z", "headRefName": "autopilot/t-0008-nix-flake-check-ci"},
-    {"number": 84, "title": "ops/validate.py: git のコンフリクトマーカー残留を検出する (T-0033)", "url": "https://github.com/hikuohiku/homelab/pull/84", "mergedAt": "2026-08-04T20:54:36Z", "headRefName": "autopilot/t-0033-conflict-marker-detection"},
-    {"number": 83, "title": "fix(ops): ダッシュボードの数字が嘘をつかないようにする", "url": "https://github.com/hikuohiku/homelab/pull/83", "mergedAt": "2026-08-04T20:50:52Z", "headRefName": "autopilot/fix-dashboard-numbers"},
-    {"number": 82, "title": "ops: run #7 の記録をまとめ、ダッシュボードを再生成する", "url": "https://github.com/hikuohiku/homelab/pull/82", "mergedAt": "2026-08-04T20:34:49Z", "headRefName": "autopilot/run-7-wrapup"},
-    {"number": 81, "title": "T-0007: Maintenance.md の持ち越し課題を backlog に取り込む", "url": "https://github.com/hikuohiku/homelab/pull/81", "mergedAt": "2026-08-04T20:33:11Z", "headRefName": "autopilot/T-0007-maintenance-backlog"},
-    {"number": 80, "title": "T-0006: Plans.md の syncthing 移行(M2) の保留理由を実態に合わせる", "url": "https://github.com/hikuohiku/homelab/pull/80", "mergedAt": "2026-08-04T20:28:44Z", "headRefName": "autopilot/T-0006-plans-md-syncthing-status"},
-    {"number": 79, "title": "T-0018: dex chart を 0.24.0 → 0.24.1 に上げる", "url": "https://github.com/hikuohiku/homelab/pull/79", "mergedAt": "2026-08-04T20:22:07Z", "headRefName": "autopilot/T-0018-dex-chart-patch"},
-    {"number": 78, "title": "T-0005: inventory.json 全対象の上流バージョンを調査し、更新タスクを起票する", "url": "https://github.com/hikuohiku/homelab/pull/78", "mergedAt": "2026-08-04T20:19:22Z", "headRefName": "autopilot/T-0005-inventory-upstream-survey"},
-    {"number": 77, "title": "T-0017: check_version_sync.py の pyyaml 依存を除去し nix 抽出を構造化する", "url": "https://github.com/hikuohiku/homelab/pull/77", "mergedAt": "2026-08-04T20:07:23Z", "headRefName": "autopilot/T-0017-check-version-sync-stdlib"},
-    {"number": 76, "title": "ops: run #5 の記録をまとめ、ダッシュボードを再生成する", "url": "https://github.com/hikuohiku/homelab/pull/76", "mergedAt": "2026-08-04T20:00:20Z", "headRefName": "autopilot/run5-wrapup"},
-    {"number": 75, "title": "fix(apps): busybox の initContainer バージョンを 1.37 に統一する (T-0003)", "url": "https://github.com/hikuohiku/homelab/pull/75", "mergedAt": "2026-08-04T19:59:07Z", "headRefName": "autopilot/T-0003-busybox-version-sync"},
-    {"number": 74, "title": "fix(argocd): chart バージョンの二重管理に CI 検出を追加する (T-0002)", "url": "https://github.com/hikuohiku/homelab/pull/74", "mergedAt": "2026-08-04T19:57:49Z", "headRefName": "autopilot/T-0002-argocd-version-sync"},
-    {"number": 73, "title": "ops: このクラウドサンドボックスのツール有無を CHARTER に記録する", "url": "https://github.com/hikuohiku/homelab/pull/73", "mergedAt": "2026-08-04T19:56:23Z", "headRefName": "autopilot/feedback-tool-availability"},
-    {"number": 72, "title": "fix(ops): PR 一覧がキャッシュのときダッシュボードに明示する", "url": "https://github.com/hikuohiku/homelab/pull/72", "mergedAt": "2026-08-04T19:42:31Z", "headRefName": "autopilot/dashboard-stale-warning"},
-    {"number": 71, "title": "fix(tailscale): k8s-nameserver の floating tag unstable を固定する", "url": "https://github.com/hikuohiku/homelab/pull/71", "mergedAt": "2026-08-04T19:40:33Z", "headRefName": "autopilot/T-0001-pin-tailscale-nameserver"},
-    {"number": 70, "title": "fix(ci): direct-push-guard のレビュー指摘3点を修正", "url": "https://github.com/hikuohiku/homelab/pull/70", "mergedAt": "2026-08-04T19:34:27Z", "headRefName": "autopilot/T-0014-fix-direct-push-guard-review"},
-    {"number": 69, "title": "fix(ops): ダッシュボードに起動間隔が出ない退行を直す", "url": "https://github.com/hikuohiku/homelab/pull/69", "mergedAt": "2026-08-04T19:26:25Z", "headRefName": "autopilot/fix-dashboard-cadence"},
-    {"number": 68, "title": "fix(terraform): .terraform.lock.hcl から未宣言の tailscale provider を除去する", "url": "https://github.com/hikuohiku/homelab/pull/68", "mergedAt": "2026-08-04T19:25:17Z", "headRefName": "autopilot/T-0004-tf-lock-cleanup"},
-    {"number": 67, "title": "ci: main への直 push を検知する direct-push-guard を追加する", "url": "https://github.com/hikuohiku/homelab/pull/67", "mergedAt": "2026-08-04T19:23:22Z", "headRefName": "autopilot/T-0014-direct-push-guard"},
-    {"number": 66, "title": "ops: 「workflow 本文が失われた」という記録の誤りを訂正する", "url": "https://github.com/hikuohiku/homelab/pull/66", "mergedAt": "2026-08-04T19:11:18Z", "headRefName": "autopilot/fix-journal-correction"},
-    {"number": 65, "title": "ops: workflows 権限の付与を受けて T-0014 のブロックを解除する", "url": "https://github.com/hikuohiku/homelab/pull/65", "mergedAt": "2026-08-04T19:07:42Z", "headRefName": "autopilot/unblock-t0014"},
-    {"number": 64, "title": "ops: T-0014 の pr 番号を記録する (#63)", "url": "https://github.com/hikuohiku/homelab/pull/64", "mergedAt": "2026-08-04T19:04:54Z", "headRefName": "autopilot/T-0014-record-pr"},
-    {"number": 63, "title": "ops: issue #56 のフィードバックを反映、T-0014 を needs-human に", "url": "https://github.com/hikuohiku/homelab/pull/63", "mergedAt": "2026-08-04T19:03:50Z", "headRefName": "autopilot/T-0014-direct-push-guard"},
-    {"number": 62, "title": "fix: permissions.ask を全廃する", "url": "https://github.com/hikuohiku/homelab/pull/62", "mergedAt": "2026-08-04T18:54:48Z", "headRefName": "autopilot/drop-ask-rules"},
-    {"number": 61, "title": "fix(ops): 権限プロンプトで起動が消えるのを防ぐ", "url": "https://github.com/hikuohiku/homelab/pull/61", "mergedAt": "2026-08-04T18:51:52Z", "headRefName": "autopilot/no-ask-commands"},
-    {"number": 60, "title": "ops: 定期実行を 1 時間ごとに変更し、run #1 の記録を残す", "url": "https://github.com/hikuohiku/homelab/pull/60", "mergedAt": "2026-08-04T18:46:44Z", "headRefName": "autopilot/hourly"},
-    {"number": 59, "title": "fix(ops): main への直 push を廃し、記録も PR に載せる", "url": "https://github.com/hikuohiku/homelab/pull/59", "mergedAt": "2026-08-04T18:45:09Z", "headRefName": "autopilot/pr-only"},
-    {"number": 58, "title": "feat(ops): 判断を人間に渡さない方針へ憲章を改める", "url": "https://github.com/hikuohiku/homelab/pull/58", "mergedAt": "2026-08-04T18:32:23Z", "headRefName": "autopilot/no-human-judgment"},
-    {"number": 57, "title": "feat(ops): homelab を自律運用する autopilot の器を作る", "url": "https://github.com/hikuohiku/homelab/pull/57", "mergedAt": "2026-08-04T18:23:14Z", "headRefName": "autopilot/bootstrap"}
+    {
+      "number": 124,
+      "title": "ops: nixpkgs flake.lock の経年を調査し T-0049 として起票する",
+      "url": "https://github.com/hikuohiku/homelab/pull/124",
+      "mergedAt": "2026-08-05T01:30:00Z",
+      "headRefName": "autopilot/T-0049-nixpkgs-pin-staleness"
+    },
+    {
+      "number": 123,
+      "title": "ops: run #17 の記録をまとめ、ダッシュボードを再生成する",
+      "url": "https://github.com/hikuohiku/homelab/pull/123",
+      "mergedAt": "2026-08-05T01:22:18Z",
+      "headRefName": "autopilot/run17-wrapup"
+    },
+    {
+      "number": 122,
+      "title": "ci: softprops/action-gh-release を v2 → v3 に上げる (T-0048)",
+      "url": "https://github.com/hikuohiku/homelab/pull/122",
+      "mergedAt": "2026-08-05T01:18:03Z",
+      "headRefName": "autopilot/T-0048-gh-release-v3"
+    },
+    {
+      "number": 121,
+      "title": "ci: cachix/cachix-action を v15 → v17 に上げる (T-0047)",
+      "url": "https://github.com/hikuohiku/homelab/pull/121",
+      "mergedAt": "2026-08-05T01:16:31Z",
+      "headRefName": "autopilot/T-0047-cachix-action-v17"
+    },
+    {
+      "number": 120,
+      "title": "ci: hashicorp/setup-terraform を v3 → v4 に上げる (T-0046)",
+      "url": "https://github.com/hikuohiku/homelab/pull/120",
+      "mergedAt": "2026-08-05T01:15:07Z",
+      "headRefName": "autopilot/T-0046-setup-terraform-v4"
+    },
+    {
+      "number": 119,
+      "title": "ci: azure/setup-helm を v4 → v5 に上げる (T-0045)",
+      "url": "https://github.com/hikuohiku/homelab/pull/119",
+      "mergedAt": "2026-08-05T01:13:46Z",
+      "headRefName": "autopilot/T-0045-setup-helm-v5"
+    },
+    {
+      "number": 118,
+      "title": "ops: GitHub Actions を inventory.json の監視対象に追加する (T-0043)",
+      "url": "https://github.com/hikuohiku/homelab/pull/118",
+      "mergedAt": "2026-08-05T01:11:31Z",
+      "headRefName": "autopilot/T-0043-github-actions-inventory"
+    },
+    {
+      "number": 117,
+      "title": "ops: run #16 の PR キャッシュを最新化する",
+      "url": "https://github.com/hikuohiku/homelab/pull/117",
+      "mergedAt": "2026-08-05T00:52:49Z",
+      "headRefName": "autopilot/run16-wrapup"
+    },
+    {
+      "number": 116,
+      "title": "ci: actions/checkout を v4 → v7 に上げる (T-0044)",
+      "url": "https://github.com/hikuohiku/homelab/pull/116",
+      "mergedAt": "2026-08-05T00:51:08Z",
+      "headRefName": "autopilot/T-0044-checkout-v7"
+    },
+    {
+      "number": 115,
+      "title": "ci: nix-installer-action の floating ref を固定する (T-0042)",
+      "url": "https://github.com/hikuohiku/homelab/pull/115",
+      "mergedAt": "2026-08-05T00:46:53Z",
+      "headRefName": "autopilot/T-0042-pin-nix-installer-action"
+    },
+    {
+      "number": 114,
+      "title": "docs: Plans.md の kubectl ask 前提の記述を実態に合わせる (T-0041)",
+      "url": "https://github.com/hikuohiku/homelab/pull/114",
+      "mergedAt": "2026-08-05T00:24:50Z",
+      "headRefName": "autopilot/T-0041-plans-md-ask-drift"
+    },
+    {
+      "number": 113,
+      "title": "ops: run #14 の記録をまとめ、ダッシュボードを再生成する",
+      "url": "https://github.com/hikuohiku/homelab/pull/113",
+      "mergedAt": "2026-08-05T00:16:51Z",
+      "headRefName": "autopilot/run14-wrapup"
+    },
+    {
+      "number": 112,
+      "title": "Maintenance.md: T-0031 revert / T-0038 完遂を反映 (T-0039)",
+      "url": "https://github.com/hikuohiku/homelab/pull/112",
+      "mergedAt": "2026-08-05T00:11:46Z",
+      "headRefName": "autopilot/T-0039-maintenance-doc-sync"
+    },
+    {
+      "number": 111,
+      "title": "vaultwarden: IP_HEADER_TRUSTED_PROXIES を pod CIDR に絞る (T-0038)",
+      "url": "https://github.com/hikuohiku/homelab/pull/111",
+      "mergedAt": "2026-08-05T00:09:28Z",
+      "headRefName": "autopilot/T-0038-vaultwarden-trusted-proxies"
+    },
+    {
+      "number": 110,
+      "title": "vaultwarden: icon 取得の無効化を revert する (T-0031)",
+      "url": "https://github.com/hikuohiku/homelab/pull/110",
+      "mergedAt": "2026-08-05T00:05:54Z",
+      "headRefName": "autopilot/T-0031-revert-icon-download"
+    },
+    {
+      "number": 109,
+      "title": "issue #56 のフィードバック4件を反映",
+      "url": "https://github.com/hikuohiku/homelab/pull/109",
+      "mergedAt": "2026-08-05T00:04:19Z",
+      "headRefName": "autopilot/feedback-round14"
+    },
+    {
+      "number": 108,
+      "title": "ops: run #13 の記録をまとめ、ダッシュボードを再生成する",
+      "url": "https://github.com/hikuohiku/homelab/pull/108",
+      "mergedAt": "2026-08-04T23:44:38Z",
+      "headRefName": "autopilot/run13-wrapup"
+    },
+    {
+      "number": 107,
+      "title": "vaultwarden: IP_HEADER=X-Forwarded-For を設定し Tailscale 経由のレート制限誤発火を防ぐ (T-0032)",
+      "url": "https://github.com/hikuohiku/homelab/pull/107",
+      "mergedAt": "2026-08-04T23:38:46Z",
+      "headRefName": "autopilot/t0032-vaultwarden-ip-header"
+    },
+    {
+      "number": 106,
+      "title": "external-secrets chart を 1.3.2 → 2.8.0 に上げる (T-0037)",
+      "url": "https://github.com/hikuohiku/homelab/pull/106",
+      "mergedAt": "2026-08-04T23:35:52Z",
+      "headRefName": "autopilot/t0037-external-secrets-2.8.0"
+    },
+    {
+      "number": 104,
+      "title": "vaultwarden: icon 取得タイムアウトを DISABLE_ICON_DOWNLOAD で無効化する (T-0031)",
+      "url": "https://github.com/hikuohiku/homelab/pull/104",
+      "mergedAt": "2026-08-04T23:31:42Z",
+      "headRefName": "autopilot/t0031-vaultwarden-disable-icon"
+    },
+    {
+      "number": 103,
+      "title": "ops: run #12 の記録をまとめ、ダッシュボードを再生成する",
+      "url": "https://github.com/hikuohiku/homelab/pull/103",
+      "mergedAt": "2026-08-04T23:09:47Z",
+      "headRefName": "autopilot/run12-wrapup"
+    },
+    {
+      "number": 102,
+      "title": "external-secrets chart を 1.1.1 → 1.3.2 に上げる (T-0026)",
+      "url": "https://github.com/hikuohiku/homelab/pull/102",
+      "mergedAt": "2026-08-04T23:08:09Z",
+      "headRefName": "autopilot/run12-feedback-t0026"
+    },
+    {
+      "number": 101,
+      "title": "ops: run #11 の記録をまとめ、ダッシュボードを再生成する",
+      "url": "https://github.com/hikuohiku/homelab/pull/101",
+      "mergedAt": "2026-08-04T22:42:03Z",
+      "headRefName": "autopilot/run-11-wrapup"
+    },
+    {
+      "number": 100,
+      "title": "upgrade(tailscale): operator chart 1.90.9→1.98.9、k8s-nameserver を v1.98.9 に揃える (T-0024, T-0025)",
+      "url": "https://github.com/hikuohiku/homelab/pull/100",
+      "mergedAt": "2026-08-04T22:40:28Z",
+      "headRefName": "autopilot/T-0024-T-0025-tailscale-upgrade"
+    },
+    {
+      "number": 99,
+      "title": "ops: run #11 のダッシュボード PR キャッシュを最新化する",
+      "url": "https://github.com/hikuohiku/homelab/pull/99",
+      "mergedAt": "2026-08-04T22:32:56Z",
+      "headRefName": "autopilot/run-11-dashboard-cache"
+    },
+    {
+      "number": 98,
+      "title": "ci: apps/ render の意図しないオブジェクト削除を検出するジョブを追加 (T-0036)",
+      "url": "https://github.com/hikuohiku/homelab/pull/98",
+      "mergedAt": "2026-08-04T22:26:27Z",
+      "headRefName": "autopilot/T-0036-manifest-deletion-guard"
+    },
+    {
+      "number": 97,
+      "title": "T-0012: 自己振り返りを実施し、run #10 の記録をまとめる",
+      "url": "https://github.com/hikuohiku/homelab/pull/97",
+      "mergedAt": "2026-08-04T22:12:24Z",
+      "headRefName": "autopilot/t-0012-weekly-review"
+    },
+    {
+      "number": 96,
+      "title": "T-0023: coder v2.35.3 更新のリスクを見直し、blocked にする",
+      "url": "https://github.com/hikuohiku/homelab/pull/96",
+      "mergedAt": "2026-08-04T22:08:47Z",
+      "headRefName": "autopilot/t-0023-coder-v2.35.3"
+    },
+    {
+      "number": 95,
+      "title": "T-0022: immich Helm chart を 0.12.0 → 0.13.1 に上げる",
+      "url": "https://github.com/hikuohiku/homelab/pull/95",
+      "mergedAt": "2026-08-04T22:03:02Z",
+      "headRefName": "autopilot/t-0022-immich-chart-0.13.1"
+    },
+    {
+      "number": 94,
+      "title": "CHARTER: 到達性の定義に自分自身の観測・操作経路を含める",
+      "url": "https://github.com/hikuohiku/homelab/pull/94",
+      "mergedAt": "2026-08-04T21:58:14Z",
+      "headRefName": "autopilot/feedback-56-observation-path"
+    },
+    {
+      "number": 93,
+      "title": "ops: run #9 の記録をまとめ、ダッシュボードを再生成する",
+      "url": "https://github.com/hikuohiku/homelab/pull/93",
+      "mergedAt": "2026-08-04T21:39:28Z",
+      "headRefName": "autopilot/run-9-wrapup"
+    },
+    {
+      "number": 92,
+      "title": "T-0021: coder-postgres を 17.5 → 17.10 に上げる",
+      "url": "https://github.com/hikuohiku/homelab/pull/92",
+      "mergedAt": "2026-08-04T21:37:02Z",
+      "headRefName": "autopilot/t-0021-coder-postgres-patch"
+    },
+    {
+      "number": 91,
+      "title": "T-0020: busybox を 1.37 → 1.38.0 に上げる",
+      "url": "https://github.com/hikuohiku/homelab/pull/91",
+      "mergedAt": "2026-08-04T21:34:45Z",
+      "headRefName": "autopilot/t-0020-busybox-patch"
+    },
+    {
+      "number": 90,
+      "title": "T-0019: immich の valkey を 9.1-alpine → 9.1.1-alpine に上げる",
+      "url": "https://github.com/hikuohiku/homelab/pull/90",
+      "mergedAt": "2026-08-04T21:32:13Z",
+      "headRefName": "autopilot/t-0019-immich-valkey-patch"
+    },
+    {
+      "number": 89,
+      "title": "T-0016: ダッシュボードの PR 一覧を gh CLI 非依存にする",
+      "url": "https://github.com/hikuohiku/homelab/pull/89",
+      "mergedAt": "2026-08-04T21:29:16Z",
+      "headRefName": "autopilot/t-0016-dashboard-pr-list-mcp"
+    },
+    {
+      "number": 88,
+      "title": "T-0035: ops/dashboard/index.html を Git 管理から外す",
+      "url": "https://github.com/hikuohiku/homelab/pull/88",
+      "mergedAt": "2026-08-04T21:24:41Z",
+      "headRefName": "autopilot/t-0035-dashboard-html-untrack"
+    },
+    {
+      "number": 87,
+      "title": "PBS バックアップ体制を棚卸しする (T-0013)",
+      "url": "https://github.com/hikuohiku/homelab/pull/87",
+      "mergedAt": "2026-08-04T21:13:05Z",
+      "headRefName": "autopilot/t-0013-pbs-backup-inventory"
+    },
+    {
+      "number": 86,
+      "title": "weekly-maintenance と CHARTER の役割を分ける (T-0009)",
+      "url": "https://github.com/hikuohiku/homelab/pull/86",
+      "mergedAt": "2026-08-04T21:08:55Z",
+      "headRefName": "autopilot/t-0009-weekly-maintenance-charter-roles"
+    },
+    {
+      "number": 85,
+      "title": "CI に nix flake check を追加する (T-0008)",
+      "url": "https://github.com/hikuohiku/homelab/pull/85",
+      "mergedAt": "2026-08-04T21:05:33Z",
+      "headRefName": "autopilot/t-0008-nix-flake-check-ci"
+    },
+    {
+      "number": 84,
+      "title": "ops/validate.py: git のコンフリクトマーカー残留を検出する (T-0033)",
+      "url": "https://github.com/hikuohiku/homelab/pull/84",
+      "mergedAt": "2026-08-04T20:54:36Z",
+      "headRefName": "autopilot/t-0033-conflict-marker-detection"
+    },
+    {
+      "number": 83,
+      "title": "fix(ops): ダッシュボードの数字が嘘をつかないようにする",
+      "url": "https://github.com/hikuohiku/homelab/pull/83",
+      "mergedAt": "2026-08-04T20:50:52Z",
+      "headRefName": "autopilot/fix-dashboard-numbers"
+    },
+    {
+      "number": 82,
+      "title": "ops: run #7 の記録をまとめ、ダッシュボードを再生成する",
+      "url": "https://github.com/hikuohiku/homelab/pull/82",
+      "mergedAt": "2026-08-04T20:34:49Z",
+      "headRefName": "autopilot/run-7-wrapup"
+    },
+    {
+      "number": 81,
+      "title": "T-0007: Maintenance.md の持ち越し課題を backlog に取り込む",
+      "url": "https://github.com/hikuohiku/homelab/pull/81",
+      "mergedAt": "2026-08-04T20:33:11Z",
+      "headRefName": "autopilot/T-0007-maintenance-backlog"
+    },
+    {
+      "number": 80,
+      "title": "T-0006: Plans.md の syncthing 移行(M2) の保留理由を実態に合わせる",
+      "url": "https://github.com/hikuohiku/homelab/pull/80",
+      "mergedAt": "2026-08-04T20:28:44Z",
+      "headRefName": "autopilot/T-0006-plans-md-syncthing-status"
+    },
+    {
+      "number": 79,
+      "title": "T-0018: dex chart を 0.24.0 → 0.24.1 に上げる",
+      "url": "https://github.com/hikuohiku/homelab/pull/79",
+      "mergedAt": "2026-08-04T20:22:07Z",
+      "headRefName": "autopilot/T-0018-dex-chart-patch"
+    },
+    {
+      "number": 78,
+      "title": "T-0005: inventory.json 全対象の上流バージョンを調査し、更新タスクを起票する",
+      "url": "https://github.com/hikuohiku/homelab/pull/78",
+      "mergedAt": "2026-08-04T20:19:22Z",
+      "headRefName": "autopilot/T-0005-inventory-upstream-survey"
+    },
+    {
+      "number": 77,
+      "title": "T-0017: check_version_sync.py の pyyaml 依存を除去し nix 抽出を構造化する",
+      "url": "https://github.com/hikuohiku/homelab/pull/77",
+      "mergedAt": "2026-08-04T20:07:23Z",
+      "headRefName": "autopilot/T-0017-check-version-sync-stdlib"
+    },
+    {
+      "number": 76,
+      "title": "ops: run #5 の記録をまとめ、ダッシュボードを再生成する",
+      "url": "https://github.com/hikuohiku/homelab/pull/76",
+      "mergedAt": "2026-08-04T20:00:20Z",
+      "headRefName": "autopilot/run5-wrapup"
+    },
+    {
+      "number": 75,
+      "title": "fix(apps): busybox の initContainer バージョンを 1.37 に統一する (T-0003)",
+      "url": "https://github.com/hikuohiku/homelab/pull/75",
+      "mergedAt": "2026-08-04T19:59:07Z",
+      "headRefName": "autopilot/T-0003-busybox-version-sync"
+    },
+    {
+      "number": 74,
+      "title": "fix(argocd): chart バージョンの二重管理に CI 検出を追加する (T-0002)",
+      "url": "https://github.com/hikuohiku/homelab/pull/74",
+      "mergedAt": "2026-08-04T19:57:49Z",
+      "headRefName": "autopilot/T-0002-argocd-version-sync"
+    },
+    {
+      "number": 73,
+      "title": "ops: このクラウドサンドボックスのツール有無を CHARTER に記録する",
+      "url": "https://github.com/hikuohiku/homelab/pull/73",
+      "mergedAt": "2026-08-04T19:56:23Z",
+      "headRefName": "autopilot/feedback-tool-availability"
+    },
+    {
+      "number": 72,
+      "title": "fix(ops): PR 一覧がキャッシュのときダッシュボードに明示する",
+      "url": "https://github.com/hikuohiku/homelab/pull/72",
+      "mergedAt": "2026-08-04T19:42:31Z",
+      "headRefName": "autopilot/dashboard-stale-warning"
+    },
+    {
+      "number": 71,
+      "title": "fix(tailscale): k8s-nameserver の floating tag unstable を固定する",
+      "url": "https://github.com/hikuohiku/homelab/pull/71",
+      "mergedAt": "2026-08-04T19:40:33Z",
+      "headRefName": "autopilot/T-0001-pin-tailscale-nameserver"
+    }
   ]
 }

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -244,7 +244,7 @@
       "match": "cachix/cachix-action@",
       "upstream": "github:cachix/cachix-action",
       "policy": "auto",
-      "note": "T-0047 (run #17) で v15→v17 に更新。破壊的変更は Node24 ランタイムのみ。v17 でエラー伝播の修正が入っており、これまで握り潰されていた push 失敗が今後は CI 失敗として顕在化しうる（workflow_dispatch 手動実行のため次回実行時に確認）"
+      "note": "T-0047 (run #17) で v15→v17 に更新。破壊的変更は Node24 ランタイムのみ。T-0050 (run #19) でこのファイルの実際の呼び出し（`name:` のみ、`authToken` 無し）を action 本体のソースで確認し、`authToken`/`signingKey` 無しでは push を一切行わない（pushMode=None）ため v17 の push 失敗伝播修正はこの workflow に影響しないと確定した（ops/CHARTER.md §5.4）"
     },
     {
       "id": "gha-softprops-action-gh-release",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -540,3 +540,28 @@
   次回以降は自動的にこの種の見落としが再検出されるようにした
 - 次の起動へ: backlog の todo は引き続き 0 件（T-0049 は needs-human）。T-0040/T-0012 の
   next_review は 2026-08-11 のまま
+
+## 2026-08-05 02:10 UTC — run #19
+
+- 前回の中断: `autopilot/run17-wrapup`（#123）はマージ済みだったが削除権限が無く残骸として残っていた
+  （main に同内容が入っていることを確認済みで拾い直しは不要）
+- 読んだフィードバック: issue #56 の未読 2 件（01:08:27, 01:18:49）
+  - 01:08:27: 「ブランチを消せ」という前回の指摘自体が実行不能（403）だったという訂正。
+    「指摘を受けたら自分の環境で実行可能かも確かめる」を CHARTER §6 に追記
+  - 01:18:49（本命）: T-0042/T-0044/T-0047/T-0048 で更新した release-image.yml の Action は
+    workflow_dispatch 専用で CI が一度も実行しないため、release notes の要約だけでは
+    「動くことの確認」になっていないという指摘。CHARTER §4 の「CI が検証できない領域」に該当
+- やったこと: T-0050 として起票・完遂（当初 T-0049/自称 run #18 として着手したが、同時に走っていた
+  別セッションが `autopilot/T-0049-nixpkgs-pin-staleness`（#124, nixpkgs flake.lock の経年調査）を
+  先にマージしたため、rebase 時に採番し直した）。subagent に 4 つの Action（nix-installer-action /
+  cachix-action / action-gh-release / checkout）の実ソース・action.yml・changelog を原文確認させ、
+  release-image.yml が実際に渡す input（特に cachix-action の `name:` のみで `authToken` 無し）に
+  対してすべて安全と確定した。cachix-action は認証情報が無いと push を一切行わない
+  （pushMode=None）ため、T-0047 で保留にしていた「push 失敗の顕在化」懸念はそもそも発火しないと
+  判明し、revert は不要と判断。CHARTER §5.4 として release-image.yml の CI 非カバレッジと、
+  ここでしか使われない Action を更新するときの確認手順（実ソースを読む）を明文化した（#125）
+- 見つけたこと: 同時に別セッションが動いており、T-0049 の採番が衝突した。CHARTER §2 は「1 起動内での
+  直列化」は定めているが、複数セッションが同時に起動すること自体は防げていない。今回は rebase +
+  採番し直しで解消できたが、頻発するなら backlog の id 発行を PR マージ時点で確定させる（起票時点では
+  仮 id にする）等の対策を検討する価値がある。今回は 1 回限りの事象のため backlog には起票しない
+- 次の起動へ: backlog の todo は本 run 終了時点で 0 件。CHARTER §3 の調査から入ること

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-05T01:23:49Z",
+  "updated": "2026-08-05T02:10:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-04T23:59:38Z"
+    "last_read": "2026-08-05T01:18:49Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -237,6 +237,16 @@
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。backlog の todo が 0 件（T-0040/T-0012 とも next_review は 2026-08-11）だったため CHARTER §3 に従い調査。ops/inventory.json の policy: manual エントリのうち『離散リリースが無いので棚卸し対象外』とされている nixpkgs（nix/images/proxmox-cloud/flake.lock）を見た。flake.lock 内の locked.lastModified を読むと4入力とも2025-11〜12止まりで約8ヶ月放置と判明（離散リリース無し＝経年チェック不要ではなかった）。T-0049 として needs-human 起票（nix flake update にはロックハッシュの実計算が要り、サンドボックスに nix が無い。T-0030 と同型）。あわせて T-0040 の DoD に経年チェックを追記し、今後同種の見落としが再検出されるようにした",
       "prs": [
         124
+      ]
+    },
+    {
+      "n": 19,
+      "at": "2026-08-05T02:10:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "前回の中断: run17-wrapup ブランチが残っていたが #123 として既にマージ済みと main で確認し、拾い直しは不要だった。issue #56 の未読フィードバック2件を反映。01:08:27: 前回指摘（ブランチ削除）が実行不能だったという訂正を受け、『指摘を受けたら自分の環境で実行可能かも確かめる』を CHARTER §6 に追記。01:18:49（本命）: release-image.yml は workflow_dispatch 専用で CI が一度も実行せず、T-0042/T-0044/T-0047/T-0048 の Action 更新は changelog 要約のみで『動作確認』とは言えないという指摘。T-0050 として起票・即完遂（当初 T-0049 として着手したが、同時に走っていた別セッションが T-0049（nixpkgs flake.lock、#124）を先にマージしたため rebase 時に採番し直した）。subagent に4つの Action の実ソース・action.yml・changelog を原文確認させた結果、release-image.yml が実際に渡す input に対して全て安全と確定（cachix-action は authToken 無しでは push を一切行わないため T-0047 の懸念は発火しない）。revert は不要と判断し、CHARTER §5.4 に release-image.yml の CI 非カバレッジと今後の確認手順を明文化した",
+      "prs": [
+        125
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

- `ops/CHARTER.md` §5.4 を新設: `.github/workflows/release-image.yml` は `workflow_dispatch` 専用で CI（PR/push）が一度も実行しないという事実と、ここでしか使われない Action（`nix-installer-action` / `cachix-action` / `action-gh-release`）を更新するときの確認手順（release notes の要約だけでなく実ソースを読む）を明文化した
- `.github/workflows/release-image.yml` に、Cachix 認証情報が無いため push を行わないことを示す一行コメントを追加した（動作は変更していない）
- `ops/inventory.json` の `cachix-action` エントリの note を、確定した結論（push しないため T-0047 で保留にした懸念は発火しない）に更新した

## 経緯

issue #56（2026-08-05 01:18:49）の指摘: 直近の run で `release-image.yml` に使われる 4 つの GitHub Action（`actions/checkout` `DeterminateSystems/nix-installer-action` `cachix/cachix-action` `softprops/action-gh-release`）を更新したが、このファイルは `workflow_dispatch` 専用で CI が一度も実行しないため、release notes の要約だけでは「動くことの確認」になっていない、という指摘。CHARTER §4 の「CI が検証できない領域の変更を auto-merge してはならない」に抵触する形で進めていた。

対応として、4 つの Action それぞれの実ソース（action.yml 本体・changelog 原文）を読み、`release-image.yml` が実際に渡している input（特に `cachix-action` は `name:` のみで `authToken` 無し）に対して安全かを確認した。結論はすべて安全で、revert は不要:

- `cachix/cachix-action`: `authToken`/`signingKey` が無いと push を一切行わない（`pushMode=None`）ため、v17 で入った「push 失敗が job 失敗として伝播する」変更はこの workflow には影響しない
- `softprops/action-gh-release`: v2→v3 の `action.yml` で `tag_name`/`name`/`body`/`files`/`draft`/`prerelease`/`token` の名前・デフォルトに変更なし
- `DeterminateSystems/nix-installer-action`: `determinate: true` デフォルトは v22 固有ではなく、更新前の floating `@main` から既に同じ挙動だった
- `actions/checkout`: v4→v7 で `fetch-depth: 0` の意味論に変更なし。この repo の他ワークフローで既に実 exercise 済み

（作業中、同時に走っていた別セッションが `T-0049`（nixpkgs flake.lock の経年調査, #124）を先にマージしたため、このタスクは `T-0050` として採番し直した。ブランチ名に `T-0049` が残っているのはその名残り）

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 成功
- コードの動作自体は変更していない（コメント追加とドキュメントのみ）

## ロールバック手順

`git revert` で本 PR を打ち消せば CHARTER・inventory.json・コメントが元に戻るだけで、`release-image.yml` の実行結果には影響しない。

## backlog task id

T-0050