### PR TITLE
T-0051: check_version_sync.py の検証対象を inventory.json の mirrors 全件に揃える

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 51,
-  "updated": "2026-08-05T02:10:00Z",
+  "next_id": 52,
+  "updated": "2026-08-05T01:51:30Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -912,6 +912,24 @@
       "created": "2026-08-05",
       "pr": 125,
       "notes": "run #19: subagent に cachix/cachix-action・softprops/action-gh-release・DeterminateSystems/nix-installer-action・actions/checkout の実ソース/action.yml/changelog を原文確認させた。結論: 4 件とも現状の使い方（release-image.yml が実際に渡す input）に対して安全。cachix-action は authToken/signingKey が無いと pushMode=None で push を一切行わないため、v17 の『push 失敗が job 失敗として伝播する』変更はそもそも発火しない。revert は不要と判断し、CHARTER §5.4 として release-image.yml の CI 非カバレッジと今後の確認手順を明文化した。着手時点では T-0049 として起票したが、同時に走っていた別セッションが T-0049（nixpkgs flake.lock の経年、#124）を先にマージしたため、rebase 時に T-0050 へ採番し直した（本 run 自身も run #18 と自称したが同じ理由で run #19 に採番し直した）"
+    },
+    {
+      "id": "T-0051",
+      "domain": "homelab",
+      "title": "check_version_sync.py の検証対象を inventory.json の mirrors 全件に揃える",
+      "kind": "ci",
+      "risk": "low",
+      "status": "done",
+      "priority": 8,
+      "why": "backlog の todo が 0 件だったため CHARTER §3 の調査（run #20、subagent 併用）で発見。ops/inventory.json は mirrors を 4 件宣言している（argocd-chart, busybox, immich-server, gha-actions-checkout）が、ops/check_version_sync.py の PAIRS は argo-cd の 1 件しか実装していなかった。CHARTER §4『バージョン更新の作法』は『二重管理されている pin は同じ PR で全部揃える』と定めており、その機械的な担保がこのスクリプトのはずだったが、busybox（3 ファイル）・immich-server/machine-learning（同一ファイル内の別ブロック）・actions/checkout（3 ファイル、ci.yml だけで 6 箇所）のいずれかを片方だけ更新した PR が CI green のまま auto-merge されうる状態だった",
+      "dod": "ops/inventory.json の mirrors を持つ target 全件について、check_version_sync.py が不一致を検出できる。PAIRS を 2 者間限定の構造から N 者間のグループ検証（GROUPS）に一般化し、ファイル内に同じ値が複数回出現するケース（actions/checkout の ci.yml 内 6 箇所）もファイル内一致まで検証する。追加した各検証は、わざと値をずらして exit 1 になることを確認してから出す",
+      "refs": [
+        "ops/check_version_sync.py",
+        "ops/inventory.json"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #20: PAIRS を GROUPS（targets: [(path, fn), ...] を N 件受け付け、先頭を canonical として全件比較）に一般化。busybox は 3 ファイルとも extract_image_tag（単純な prefix 直後の値）、immich-server/machine-learning は同一ファイル内の 2 ブロックを新設の extract_yaml_top_level_block（0-indent のトップレベルキーで区切る、nix 側の brace 境界と同じ考え方）+ extract_tag_in_block で構造的に分離、actions/checkout は extract_all_action_tags で 1 ファイル内の全 `uses:` 出現を集めてファイル内不一致も検出できるようにした。4 グループとも意図的に値をずらして exit 1 になることを確認済み（busybox 3 ファイル中 1 つ、immich machine-learning のみ、ci.yml 内 1 箇所のみ、の 3 パターン）。手元で `python3 ops/check_version_sync.py` が exit 0 で通ることも確認済み（stdlib のみ、CHARTER §5.2 のサンドボックスでも検証可能）"
     }
   ]
 }

--- a/ops/check_version_sync.py
+++ b/ops/check_version_sync.py
@@ -7,7 +7,8 @@ CI (ops job) から実行する。不一致があれば非 0 で終了する。
 issue #56 2026-08-04 19:53:35 の指摘: pyyaml に依存すると autopilot のサンドボックスで
 手元検証できなくなる）。
 
-新しく二重管理の pin が見つかったら PAIRS にエントリを追加する（ops/CHARTER.md T-0002）。
+新しく二重管理の pin が見つかったら GROUPS にエントリを追加する（ops/CHARTER.md T-0002）。
+ops/inventory.json で "mirrors" を持つ target は、ここにも対応するエントリを持つこと（T-0051）。
 """
 import re
 import sys
@@ -18,6 +19,54 @@ ROOT = Path(__file__).resolve().parent.parent
 
 def read(path: str) -> str:
     return (ROOT / path).read_text()
+
+
+def extract_yaml_top_level_block(path: str, top_key: str) -> str:
+    """トップレベルキー（0-indent の `<top_key>:`）から、次のトップレベルキーまたは末尾までの
+    範囲をブロックとして返す。同じファイル内に複数の image/tag ペアがあっても、無関係な
+    トップレベルキーのものを誤って拾わないための構造的な境界（nix 側の brace 境界と同じ考え方）。
+    """
+    text = read(path)
+    top_re = re.compile(rf"^{re.escape(top_key)}:\s*$", re.MULTILINE)
+    m = top_re.search(text)
+    if not m:
+        raise ValueError(f"{path}: トップレベルキー {top_key}: が見つからない")
+    next_top_re = re.compile(r"^\S.*:\s*$", re.MULTILINE)
+    n = next_top_re.search(text, m.end())
+    end = n.start() if n else len(text)
+    return text[m.end() : end]
+
+
+def extract_image_tag(path: str, image_prefix: str) -> str:
+    """`<image_prefix><tag>` の形（例: `busybox:1.38.0`）を 1 箇所だけ含む前提で tag を拾う。"""
+    text = read(path)
+    m = re.search(rf"{re.escape(image_prefix)}(\S+)", text)
+    if not m:
+        raise ValueError(f"{path}: {image_prefix} が見つからない")
+    return m.group(1)
+
+
+def extract_tag_in_block(path: str, top_key: str) -> str:
+    """`extract_yaml_top_level_block` で絞った範囲内の最初の `tag:` を拾う。"""
+    block = extract_yaml_top_level_block(path, top_key)
+    v = re.search(r"^\s*tag:\s*(\S+)\s*$", block, re.MULTILINE)
+    if not v:
+        raise ValueError(f"{path}: トップレベルキー {top_key}: の範囲内に tag: が見つからない")
+    return v.group(1)
+
+
+def extract_all_action_tags(path: str, action_name: str) -> str:
+    """`uses: <action_name>@<tag>` を全箇所拾い、ファイル内で全て一致することを確認して返す。
+    1 ファイルに同じ Action が複数回 (`uses:`) 出てくる場合（例: ci.yml の複数 job）でも、
+    ファイル内の割れをそのまま見逃さない。"""
+    text = read(path)
+    matches = re.findall(rf"{re.escape(action_name)}@(\S+)", text)
+    if not matches:
+        raise ValueError(f"{path}: {action_name}@ が見つからない")
+    uniq = sorted(set(matches))
+    if len(uniq) > 1:
+        raise ValueError(f"{path}: {action_name} のタグがファイル内で不一致 ({uniq})")
+    return uniq[0]
 
 
 def extract_yaml_helm_chart_version(path: str, chart_name: str) -> str:
@@ -85,39 +134,85 @@ def extract_nix_helmchart_version(path: str, chart_name: str) -> str:
     return v.group(1)
 
 
-PAIRS = [
+# 各エントリの "targets" は 2 件以上の (path, 抽出関数) のリスト。全 target のバージョンが
+# 一致することを検証する（2 件限定の PAIRS ではなく N 件のグループとして扱う。
+# ops/inventory.json の各 target の "mirrors" と 1:1 で対応させる — T-0051）。
+GROUPS = [
     {
-        "name": "argo-cd chart version (T-0002)",
-        "a": ("apps/argocd/kustomization.yaml", lambda: extract_yaml_helm_chart_version(
-            "apps/argocd/kustomization.yaml", "argo-cd"
-        )),
-        "b": ("nix/images/proxmox-cloud/k3s-manifests.nix", lambda: extract_nix_helmchart_version(
-            "nix/images/proxmox-cloud/k3s-manifests.nix", "argo-cd"
-        )),
+        "name": "argo-cd chart version (T-0002, inventory: argocd-chart)",
+        "targets": [
+            ("apps/argocd/kustomization.yaml", lambda: extract_yaml_helm_chart_version(
+                "apps/argocd/kustomization.yaml", "argo-cd"
+            )),
+            ("nix/images/proxmox-cloud/k3s-manifests.nix", lambda: extract_nix_helmchart_version(
+                "nix/images/proxmox-cloud/k3s-manifests.nix", "argo-cd"
+            )),
+        ],
+    },
+    {
+        "name": "busybox initContainer tag (T-0003, inventory: busybox)",
+        "targets": [
+            ("apps/vaultwarden/deployment.yaml", lambda: extract_image_tag(
+                "apps/vaultwarden/deployment.yaml", "busybox:"
+            )),
+            ("apps/coder/postgres.yaml", lambda: extract_image_tag(
+                "apps/coder/postgres.yaml", "busybox:"
+            )),
+            ("apps/immich/postgres.yaml", lambda: extract_image_tag(
+                "apps/immich/postgres.yaml", "busybox:"
+            )),
+        ],
+    },
+    {
+        "name": "immich server / machine-learning tag (inventory: immich-server, immich-machine-learning)",
+        "targets": [
+            ("apps/immich/values.yaml (controllers.main, server)", lambda: extract_tag_in_block(
+                "apps/immich/values.yaml", "controllers"
+            )),
+            ("apps/immich/values.yaml (machine-learning)", lambda: extract_tag_in_block(
+                "apps/immich/values.yaml", "machine-learning"
+            )),
+        ],
+    },
+    {
+        "name": "actions/checkout tag (T-0043/T-0044, inventory: gha-actions-checkout)",
+        "targets": [
+            (".github/workflows/ci.yml", lambda: extract_all_action_tags(
+                ".github/workflows/ci.yml", "actions/checkout"
+            )),
+            (".github/workflows/direct-push-guard.yml", lambda: extract_all_action_tags(
+                ".github/workflows/direct-push-guard.yml", "actions/checkout"
+            )),
+            (".github/workflows/release-image.yml", lambda: extract_all_action_tags(
+                ".github/workflows/release-image.yml", "actions/checkout"
+            )),
+        ],
     },
 ]
 
 
 def main() -> int:
     fail = False
-    for pair in PAIRS:
-        a_path, a_fn = pair["a"]
-        b_path, b_fn = pair["b"]
-        try:
-            a_ver = a_fn()
-            b_ver = b_fn()
-        except Exception as e:
-            print(f"::error::{pair['name']}: 抽出に失敗しました: {e}")
-            fail = True
+    for group in GROUPS:
+        versions = []
+        group_failed = False
+        for path, fn in group["targets"]:
+            try:
+                versions.append((path, fn()))
+            except Exception as e:
+                print(f"::error::{group['name']}: {path}: 抽出に失敗しました: {e}")
+                fail = True
+                group_failed = True
+        if group_failed:
             continue
-        if a_ver != b_ver:
-            print(
-                f"::error::{pair['name']}: バージョンが一致しません "
-                f"({a_path}={a_ver} != {b_path}={b_ver})"
-            )
+        canonical = versions[0][1]
+        mismatches = [(p, v) for p, v in versions if v != canonical]
+        if mismatches:
+            detail = ", ".join(f"{p}={v}" for p, v in versions)
+            print(f"::error::{group['name']}: バージョンが一致しません ({detail})")
             fail = True
         else:
-            print(f"ok: {pair['name']} = {a_ver}")
+            print(f"ok: {group['name']} = {canonical}")
     return 1 if fail else 0
 
 

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -565,3 +565,31 @@
   採番し直しで解消できたが、頻発するなら backlog の id 発行を PR マージ時点で確定させる（起票時点では
   仮 id にする）等の対策を検討する価値がある。今回は 1 回限りの事象のため backlog には起票しない
 - 次の起動へ: backlog の todo は本 run 終了時点で 0 件。CHARTER §3 の調査から入ること
+
+## 2026-08-05 01:51 UTC — run #20
+
+- 前回の中断確認: `git fetch` 後 `git branch -r | grep autopilot/` はヒット無し、
+  `mcp__github__list_pull_requests`（state: open）も 0 件。中断なし
+- 読んだフィードバック: issue #56 の最新コメント（2026-08-04T23:59:38Z）は前回 run #19 の
+  `last_read`（02:10:00Z より前に読了済み）以前のもの。未読なし
+- backlog の todo は 0 件（T-0040/T-0012 とも next_review は 2026-08-11 で未到来）。
+  CHARTER §3 に従い subagent に新しい調査観点探しを投げた
+- subagent が 2 件発見。(1) `ops/check_version_sync.py` の検証対象が `ops/inventory.json` の
+  `mirrors` 宣言（4 件: argocd-chart, busybox, immich-server, gha-actions-checkout）のうち
+  argo-cd の 1 件しかカバーしておらず、busybox（3 ファイル）・immich-server/machine-learning・
+  actions/checkout を片方だけ更新した PR が CI green のまま auto-merge されうる状態だった。
+  (2) `CLAUDE.md`/`ops/CHARTER.md` が実在しない `secrets/` ディレクトリを参照している（実際は
+  `nix/images/proxmox-cloud/secrets.yaml` という単一ファイル）。低リスクで実害は無いため今回は
+  見送り、次に backlog が空になったときの候補として journal に残す
+- やったこと: T-0051 として (1) に着手・完遂。`check_version_sync.py` の `PAIRS`（2 者間限定）を
+  `GROUPS`（N 者間、targets リスト）に一般化し、busybox・immich-server/machine-learning・
+  actions/checkout の 3 グループを追加した。immich の 2 タグは同一ファイル内の別ブロックのため、
+  トップレベル YAML キー（0-indent）で範囲を区切る `extract_yaml_top_level_block` を新設（nix 側の
+  brace 境界と同じ「固定 window ではなく構造で区切る」考え方）。actions/checkout は 1 ファイル内に
+  複数回 (`uses:`) 出現する（ci.yml で 6 箇所）ため `extract_all_action_tags` でファイル内一致も
+  検証する。4 グループとも意図的に値をずらして exit 1 になることを確認済み（#77/#98 のときと同じ
+  「検出器は正しく落ちることを確かめてから出す」を踏襲）
+- 見つけたこと: CLAUDE.md/CHARTER.md の `secrets/` ディレクトリ記述が実態（単一ファイル）とずれている
+  （backlog には起票せず、次回の調査候補として記録のみ）
+- 次の起動へ: backlog の todo は本 run 終了時点で 0 件。次に空になったら `secrets/` の記述ずれ
+  （CLAUDE.md 30 行目・ops/CHARTER.md §5）を候補にしてよい


### PR DESCRIPTION
## 変更点

`ops/check_version_sync.py` はリポジトリ内で二重管理されているバージョン pin の不一致を CI で検出する仕組みだが、`ops/inventory.json` が宣言する `mirrors`（同じバージョンを複数箇所に書いている target）4 件のうち、argo-cd chart の 1 件しか実際には検証していなかった。残り 3 件（busybox / immich-server・machine-learning / actions/checkout）は、片方だけ更新した PR でも CI が気づかず green のまま auto-merge されうる状態だった。

- `PAIRS`（2 者間限定）を `GROUPS`（N 者間のグループ検証）に一般化
- busybox（`apps/vaultwarden/deployment.yaml` / `apps/coder/postgres.yaml` / `apps/immich/postgres.yaml` の 3 箇所）を追加
- immich server / machine-learning（`apps/immich/values.yaml` 内の 2 ブロック）を追加。同一ファイル内の別ブロックを構造的に区別するため、0-indent のトップレベル YAML キーで範囲を区切る `extract_yaml_top_level_block` を新設（固定 window ではなく構造で範囲を決める。nix 側の brace 境界と同じ考え方）
- actions/checkout（`ci.yml` / `direct-push-guard.yml` / `release-image.yml`、うち `ci.yml` は 1 ファイル内に 6 箇所出現）を追加。`extract_all_action_tags` で 1 ファイル内の複数出現も一致検証する

## 検証したこと

- `python3 ops/check_version_sync.py` が exit 0 で通ることを手元で確認（stdlib のみ、CI 専用ではなくこのサンドボックスでも実行可能）
- 4 グループそれぞれについて、意図的に値をずらして **exit 1 になること**を確認してから復元した:
  - busybox: 3 ファイル中 1 つだけ `1.37.0` に変更 → 検出
  - immich: machine-learning のタグだけ `v2.7.0` に変更 → 検出
  - actions/checkout: `ci.yml` 内 1 箇所だけ `@v6` に変更（ファイル内不一致） → 検出

## ロールバック手順

`ops/check_version_sync.py` のみの変更（CI スクリプト、実インフラには一切影響しない）。問題があれば revert するだけで元の挙動（argo-cd のみ検証）に戻る。

## backlog task id

T-0051 (risk: low, repo 内で閉じる CI 変更)

---
_Generated by [Claude Code](https://claude.ai/code/session_015F2viDKESmwhKeWahEjSUf)_