### PR TITLE
docs: secrets/ ディレクトリ記述を実態に合わせる (T-0052)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,8 @@ apps/                — Kubernetes manifests (ArgoCD applications)
   dex/               — Dex OIDC provider
   external-secrets/  — External Secrets Operator
   tailscale-operator/ — Tailscale networking
-secrets/             — Encrypted secrets (SOPS)
+.sops.yaml            — SOPS 設定（暗号鍵の対象範囲）
+nix/images/proxmox-cloud/secrets.yaml — SOPS 暗号化ファイル（単一ファイル、トップレベルの secrets/ ディレクトリは存在しない）
 ```
 
 ## Development Commands

--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -184,7 +184,7 @@ high に該当するのは、失敗したときに元へ戻せないもの。**�
 
 ## 5. 触ってはいけないもの
 
-- `secrets/` 配下、SOPS 暗号化ファイル、`.sops.yaml`
+- SOPS 暗号化ファイル（`nix/images/proxmox-cloud/secrets.yaml`）、`.sops.yaml`。トップレベルの `secrets/` ディレクトリは存在しない（CLAUDE.md 参照、T-0052）
 - クラスタへの書き込み操作（`kubectl apply/delete/patch/exec/cp`、`argocd app sync`）。**変更は必ず Git 経由で ArgoCD に反映させる**
 - `terraform apply` / `destroy`（`plan` の結果を読むのは可）
 - 実データ（PVC の中身、DB、バックアップ）

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 52,
-  "updated": "2026-08-05T01:51:30Z",
+  "next_id": 53,
+  "updated": "2026-08-05T02:19:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -930,6 +930,24 @@
       "created": "2026-08-05",
       "pr": 126,
       "notes": "run #20: PAIRS を GROUPS（targets: [(path, fn), ...] を N 件受け付け、先頭を canonical として全件比較）に一般化。busybox は 3 ファイルとも extract_image_tag（単純な prefix 直後の値）、immich-server/machine-learning は同一ファイル内の 2 ブロックを新設の extract_yaml_top_level_block（0-indent のトップレベルキーで区切る、nix 側の brace 境界と同じ考え方）+ extract_tag_in_block で構造的に分離、actions/checkout は extract_all_action_tags で 1 ファイル内の全 `uses:` 出現を集めてファイル内不一致も検出できるようにした。4 グループとも意図的に値をずらして exit 1 になることを確認済み（busybox 3 ファイル中 1 つ、immich machine-learning のみ、ci.yml 内 1 箇所のみ、の 3 パターン）。手元で `python3 ops/check_version_sync.py` が exit 0 で通ることも確認済み（stdlib のみ、CHARTER §5.2 のサンドボックスでも検証可能）"
+    },
+    {
+      "id": "T-0052",
+      "domain": "homelab",
+      "title": "CLAUDE.md / ops/CHARTER.md の `secrets/` ディレクトリ記述を実態に合わせる",
+      "kind": "docs",
+      "risk": "low",
+      "status": "done",
+      "priority": 8,
+      "why": "run #20 の調査で発見（backlog には未起票のまま journal に候補として残っていた）。CLAUDE.md の Directory Structure がトップレベルに `secrets/ — Encrypted secrets (SOPS)` という架空のディレクトリを記載しているが、実際の SOPS 暗号化ファイルは `nix/images/proxmox-cloud/secrets.yaml` という単一ファイルで、トップレベルの `secrets/` は存在しない。ops/CHARTER.md §5『触ってはいけないもの』も `secrets/` 配下という文言で、実在しないパスを指しているため、パス一致で機械的にガードするツールを将来作ったときに実際のファイルを保護し損なう空振りの記述になっていた",
+      "dod": "CLAUDE.md の Directory Structure と ops/CHARTER.md §5 が、実際のパス（`nix/images/proxmox-cloud/secrets.yaml`, `.sops.yaml`）を指す",
+      "refs": [
+        "CLAUDE.md",
+        "ops/CHARTER.md"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #21: find で secrets 関連ファイルを実測（`.sops.yaml` はリポジトリルート、暗号化データは `nix/images/proxmox-cloud/secrets.yaml` の 1 ファイルのみ。apps/*/*-external-secret.yaml は ExternalSecret リソースであり SOPS 暗号化ではないため対象外）。CLAUDE.md の該当行を実際のパスに書き換え、CHARTER §5 の該当行も同様に修正した"
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -946,7 +946,7 @@
         "ops/CHARTER.md"
       ],
       "created": "2026-08-05",
-      "pr": null,
+      "pr": 128,
       "notes": "run #21: find で secrets 関連ファイルを実測（`.sops.yaml` はリポジトリルート、暗号化データは `nix/images/proxmox-cloud/secrets.yaml` の 1 ファイルのみ。apps/*/*-external-secret.yaml は ExternalSecret リソースであり SOPS 暗号化ではないため対象外）。CLAUDE.md の該当行を実際のパスに書き換え、CHARTER §5 の該当行も同様に修正した"
     }
   ]

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,28 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 128,
+      "title": "docs: secrets/ ディレクトリ記述を実態に合わせる (T-0052)",
+      "url": "https://github.com/hikuohiku/homelab/pull/128",
+      "isDraft": false,
+      "createdAt": "2026-08-05T02:18:15Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "PENDING"
+        }
+      ],
+      "headRefName": "autopilot/T-0052-secrets-path-doc-drift",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 127,
+      "title": "ops: run #20 の記録をまとめ、ダッシュボードを再生成する",
+      "url": "https://github.com/hikuohiku/homelab/pull/127",
+      "mergedAt": "2026-08-05T02:00:17Z",
+      "headRefName": "autopilot/run20-wrapup"
+    },
     {
       "number": 126,
       "title": "T-0051: check_version_sync.py の検証対象を inventory.json の mirrors 全件に揃える",
@@ -17,9 +39,9 @@
     },
     {
       "number": 124,
-      "title": "ops: nixpkgs flake.lock の経年を調査し T-0049 として起票する",
+      "title": "ops: nixpkgs flake.lock の経年放置を発見し T-0049 として起票する (T-0049)",
       "url": "https://github.com/hikuohiku/homelab/pull/124",
-      "mergedAt": "2026-08-05T01:30:00Z",
+      "mergedAt": "2026-08-05T01:30:01Z",
       "headRefName": "autopilot/T-0049-nixpkgs-pin-staleness"
     },
     {
@@ -385,6 +407,27 @@
       "url": "https://github.com/hikuohiku/homelab/pull/71",
       "mergedAt": "2026-08-04T19:40:33Z",
       "headRefName": "autopilot/T-0001-pin-tailscale-nameserver"
+    },
+    {
+      "number": 70,
+      "title": "fix(ci): direct-push-guard のレビュー指摘3点を修正",
+      "url": "https://github.com/hikuohiku/homelab/pull/70",
+      "mergedAt": "2026-08-04T19:34:27Z",
+      "headRefName": "autopilot/T-0014-fix-direct-push-guard-review"
+    },
+    {
+      "number": 69,
+      "title": "fix(ops): ダッシュボードに起動間隔が出ない退行を直す",
+      "url": "https://github.com/hikuohiku/homelab/pull/69",
+      "mergedAt": "2026-08-04T19:26:25Z",
+      "headRefName": "autopilot/fix-dashboard-cadence"
+    },
+    {
+      "number": 68,
+      "title": "fix(terraform): .terraform.lock.hcl から未宣言の tailscale provider を除去する",
+      "url": "https://github.com/hikuohiku/homelab/pull/68",
+      "mergedAt": "2026-08-04T19:25:17Z",
+      "headRefName": "autopilot/T-0004-tf-lock-cleanup"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -593,3 +593,22 @@
   （backlog には起票せず、次回の調査候補として記録のみ）
 - 次の起動へ: backlog の todo は本 run 終了時点で 0 件。次に空になったら `secrets/` の記述ずれ
   （CLAUDE.md 30 行目・ops/CHARTER.md §5）を候補にしてよい
+
+## 2026-08-05 02:19 UTC — run #21
+
+- 前回の中断確認: `git branch -r | grep autopilot/` はヒット無し、`mcp__github__list_pull_requests`
+  （state: open）も 0 件。中断なし
+- 読んだフィードバック: issue #56 の最新コメント（2026-08-05T01:32:24Z、自分の返信）が `last_read`
+  （01:18:49Z）より新しいが自分自身の投稿のため対応不要。他者からの未読なし
+- backlog の todo は 0 件（T-0012/T-0040 とも next_review は 2026-08-11 で未到来）。run #20 が
+  journal に残していた調査候補（CLAUDE.md/CHARTER.md の `secrets/` ディレクトリ記述ずれ）を拾った
+- 実測して確認: `find` で secrets 関連ファイルを洗い出すと、SOPS 暗号化データは
+  `nix/images/proxmox-cloud/secrets.yaml` という単一ファイルのみで、トップレベルの `secrets/`
+  ディレクトリは存在しなかった。`.sops.yaml` はリポジトリルートに存在（こちらは記述どおり）。
+  `apps/*/*-external-secret.yaml` は External Secrets Operator の `ExternalSecret` リソースで
+  SOPS 暗号化ファイルではないため対象外
+- やったこと: T-0052 として起票・完遂。CLAUDE.md の Directory Structure と ops/CHARTER.md §5
+  『触ってはいけないもの』の該当行を、実在するパス（`nix/images/proxmox-cloud/secrets.yaml`,
+  `.sops.yaml`）に書き換えた。実害は小さいが、CHARTER §5 の記述はパス一致で機械的にガードする
+  将来のツールが実ファイルを保護し損なう空振りになりうる点を why に明記した
+- 次の起動へ: backlog の todo は本 run 終了時点で 0 件。次も CHARTER §3 の調査から入る

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-05T01:58:51Z",
+  "updated": "2026-08-05T02:19:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-05T01:18:49Z"
+    "last_read": "2026-08-05T01:32:24Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -258,6 +258,14 @@
       "prs": [
         126
       ]
+    },
+    {
+      "n": 21,
+      "at": "2026-08-05T02:19:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし（最新は自分自身の返信）。backlog の todo が 0 件だったため run #20 が journal に残した調査候補（CLAUDE.md/CHARTER.md の `secrets/` ディレクトリ記述が実態とずれている）を拾った。find で実測し、SOPS 暗号化データは `nix/images/proxmox-cloud/secrets.yaml` という単一ファイルのみでトップレベルの `secrets/` は存在しないと確認。T-0052 として起票・完遂し、CLAUDE.md と ops/CHARTER.md §5 の該当行を実在パスに書き換えた",
+      "prs": []
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -265,7 +265,9 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし（最新は自分自身の返信）。backlog の todo が 0 件だったため run #20 が journal に残した調査候補（CLAUDE.md/CHARTER.md の `secrets/` ディレクトリ記述が実態とずれている）を拾った。find で実測し、SOPS 暗号化データは `nix/images/proxmox-cloud/secrets.yaml` という単一ファイルのみでトップレベルの `secrets/` は存在しないと確認。T-0052 として起票・完遂し、CLAUDE.md と ops/CHARTER.md §5 の該当行を実在パスに書き換えた",
-      "prs": []
+      "prs": [
+        128
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`CLAUDE.md`（Directory Structure）と `ops/CHARTER.md`（§5 触ってはいけないもの）が、存在しないトップレベルの `secrets/` ディレクトリを参照していた。実際の SOPS 暗号化ファイルは `nix/images/proxmox-cloud/secrets.yaml` という単一ファイルのみで、トップレベルの `secrets/` は存在しない。両ファイルの記述を実在するパス（`nix/images/proxmox-cloud/secrets.yaml`, `.sops.yaml`）に書き換えた。

## 検証したこと

- `find` で secrets 関連ファイルを実測: SOPS 暗号化データは `nix/images/proxmox-cloud/secrets.yaml` の 1 ファイルのみ、`.sops.yaml` はリポジトリルートに存在。`apps/*/*-external-secret.yaml` は External Secrets Operator の `ExternalSecret` リソースであり SOPS 暗号化ファイルではないため対象外と確認した
- ドキュメントのみの変更で、manifest・CI 設定には触れていない

## ロールバック手順

このコミットを revert すれば元の記述に戻る。インフラへの影響は無い。

## backlog task id

T-0052

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVix9M7cRXrdxYBTcSSb27)_