### PR TITLE
refactor(terraform): node01 の静的 IP の二重記述を locals に一本化する (T-0053)

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 53,
-  "updated": "2026-08-05T02:19:00Z",
+  "next_id": 54,
+  "updated": "2026-08-05T03:10:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -948,6 +948,23 @@
       "created": "2026-08-05",
       "pr": 128,
       "notes": "run #21: find で secrets 関連ファイルを実測（`.sops.yaml` はリポジトリルート、暗号化データは `nix/images/proxmox-cloud/secrets.yaml` の 1 ファイルのみ。apps/*/*-external-secret.yaml は ExternalSecret リソースであり SOPS 暗号化ではないため対象外）。CLAUDE.md の該当行を実際のパスに書き換え、CHARTER §5 の該当行も同様に修正した"
+    },
+    {
+      "id": "T-0053",
+      "domain": "homelab",
+      "title": "terraform/proxmox/vm-nixos.tf の node01 静的 IP の二重記述を locals で一本化する",
+      "kind": "refactor",
+      "risk": "low",
+      "status": "done",
+      "priority": 8,
+      "why": "backlog の todo が 0 件だったため CHARTER §3 の調査（subagent 併用、run #22）で発見。`192.168.0.129` が `ip_config.ipv4.address` と `output \"node01_ip\"` の2箇所に独立したリテラルとして書かれていた。CHARTER §1 の『健全』の定義そのもの（同じ事実が2箇所に書かれていない）に反する。`terraform fmt`/`validate` はこの種の文字列重複を検出しない",
+      "dod": "IP アドレスの実体が `locals.node01_ip` の1箇所のみになり、`ip_config.ipv4.address` と `output` の両方がそれを参照する。値そのものは変更しない（純粋なリファクタ）",
+      "refs": [
+        "terraform/proxmox/vm-nixos.tf"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #22: subagent に新しい調査観点探しを投げ、terraform/proxmox/vm-nixos.tf 内の IP 重複を発見（リポジトリ全体を grep し他にこの IP を参照する箇所が無いことも確認済み）。`locals { node01_ip = \"192.168.0.129\" }` を追加し、`ip_config.ipv4.address = \"${local.node01_ip}/24\"` と `output \"node01_ip\" { value = local.node01_ip }` に置き換えた。値は不変のため CI (`terraform fmt -check`/`validate`) で挙動が変わらないことを確認できる想定"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -612,3 +612,20 @@
   `.sops.yaml`）に書き換えた。実害は小さいが、CHARTER §5 の記述はパス一致で機械的にガードする
   将来のツールが実ファイルを保護し損なう空振りになりうる点を why に明記した
 - 次の起動へ: backlog の todo は本 run 終了時点で 0 件。次も CHARTER §3 の調査から入る
+
+## 2026-08-05 03:10 UTC — run #22
+
+- 前回の中断確認: `autopilot/T-0052-secrets-path-doc-drift`（PR #128）がオープンのまま残っていた
+  （run #21 が時間切れで merge を見届けずに終えたと思われる）。auto-merge を有効化して購読し、
+  CI green → merge を確認してから新規タスクに着手した
+- 読んだフィードバック: issue #56 に未読なし（最新は run #21 時点の自分の返信 01:32:24Z のまま）
+- backlog の todo は 0 件（T-0012/T-0040 とも next_review は 2026-08-11 で未到来）。CHARTER §3
+  に従い subagent に新しい調査観点探しを投げた（既出の観点 — バージョン同期・CI Action・ドキュメント
+  ドリフト・nix flake 経年 等 — を避けるよう指示）
+- 発見: `terraform/proxmox/vm-nixos.tf` で node01 の静的 IP `192.168.0.129` が
+  `ip_config.ipv4.address` と `output \"node01_ip\"` の2箇所に独立したリテラルとして書かれていた。
+  CHARTER §1 の『健全』の定義（同じ事実が2箇所に書かれていない）に反する。repo 全体を grep し、
+  他にこの IP を参照する箇所が無いことも確認済み
+- やったこと: T-0053 として起票・完遂。`locals { node01_ip = \"192.168.0.129\" }` を追加し、
+  両箇所を `local.node01_ip` 参照に置き換えた（値は不変の純粋なリファクタ）
+- 次の起動へ: backlog の todo は本 run 終了時点で 0 件。次も CHARTER §3 の調査から入る

--- a/terraform/proxmox/vm-nixos.tf
+++ b/terraform/proxmox/vm-nixos.tf
@@ -25,6 +25,11 @@ resource "proxmox_virtual_environment_file" "node01_cloud_init" {
 }
 
 
+locals {
+  # node01 の静的 IP。ip_config と output の2箇所で同じ事実を書かないための単一情報源
+  node01_ip = "192.168.0.129"
+}
+
 resource "proxmox_virtual_environment_vm" "node01" {
   name      = "node01"
   node_name = var.proxmox_node
@@ -58,7 +63,7 @@ resource "proxmox_virtual_environment_vm" "node01" {
 
     ip_config {
       ipv4 {
-        address = "192.168.0.129/24"
+        address = "${local.node01_ip}/24"
         gateway = "192.168.0.1"
       }
     }
@@ -86,5 +91,5 @@ resource "proxmox_virtual_environment_vm" "node01" {
 }
 
 output "node01_ip" {
-  value = "192.168.0.129"
+  value = local.node01_ip
 }


### PR DESCRIPTION
## 変更点

`terraform/proxmox/vm-nixos.tf` で node01 の静的 IP `192.168.0.129` が `ip_config.ipv4.address` と `output "node01_ip"` の2箇所に独立したリテラルとして書かれていた。`locals { node01_ip = "192.168.0.129" }` を追加し、両方をそこから参照するように変更した。値そのものは変更していない（純粋なリファクタ）。

CHARTER §1 の「健全」の定義（同じ事実が2箇所に書かれていない）に沿った修正。`terraform fmt`/`validate` はこの種の文字列重複を検出しないため、backlog の todo が 0 件になったタイミングで subagent と一緒に新しい調査観点を探して見つけた。

## 検証したこと

- リポジトリ全体を grep し、この IP アドレスを参照する箇所が他に無いことを確認済み
- 値そのものは変わらないため、CI（`terraform fmt -check` / `terraform validate`）が green であれば挙動不変の裏付けになる。手元に terraform が無いため実行検証はできず CI 任せ（CHARTER §5.2）

## ロールバック手順

このコミットを revert すれば元の記述（2箇所への直書き）に戻る。インフラへの影響は無い（`terraform apply` は行っていない、`plan` 上も差分は出ないはず）。

## backlog task id

T-0053

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqqjZRHtiUWTUCGUKNWrGv)_