### PR TITLE
ops: run #22 の記録をまとめ、ダッシュボードを再生成する

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -963,7 +963,7 @@
         "terraform/proxmox/vm-nixos.tf"
       ],
       "created": "2026-08-05",
-      "pr": null,
+      "pr": 129,
       "notes": "run #22: subagent に新しい調査観点探しを投げ、terraform/proxmox/vm-nixos.tf 内の IP 重複を発見（リポジトリ全体を grep し他にこの IP を参照する箇所が無いことも確認済み）。`locals { node01_ip = \"192.168.0.129\" }` を追加し、`ip_config.ipv4.address = \"${local.node01_ip}/24\"` と `output \"node01_ip\" { value = local.node01_ip }` に置き換えた。値は不変のため CI (`terraform fmt -check`/`validate`) で挙動が変わらないことを確認できる想定"
     }
   ]

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,20 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
+    {
+      "number": 129,
+      "title": "refactor(terraform): node01 の静的 IP の二重記述を locals に一本化する (T-0053)",
+      "url": "https://github.com/hikuohiku/homelab/pull/129",
+      "mergedAt": "2026-08-05T02:25:00Z",
+      "headRefName": "autopilot/T-0053-node01-ip-dedup"
+    },
     {
       "number": 128,
       "title": "docs: secrets/ ディレクトリ記述を実態に合わせる (T-0052)",
       "url": "https://github.com/hikuohiku/homelab/pull/128",
-      "isDraft": false,
-      "createdAt": "2026-08-05T02:18:15Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "PENDING"
-        }
-      ],
-      "headRefName": "autopilot/T-0052-secrets-path-doc-drift",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-05T02:20:35Z",
+      "headRefName": "autopilot/T-0052-secrets-path-doc-drift"
+    },
     {
       "number": 127,
       "title": "ops: run #20 の記録をまとめ、ダッシュボードを再生成する",

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T02:19:00Z",
+  "updated": "2026-08-05T03:10:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -267,6 +267,16 @@
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし（最新は自分自身の返信）。backlog の todo が 0 件だったため run #20 が journal に残した調査候補（CLAUDE.md/CHARTER.md の `secrets/` ディレクトリ記述が実態とずれている）を拾った。find で実測し、SOPS 暗号化データは `nix/images/proxmox-cloud/secrets.yaml` という単一ファイルのみでトップレベルの `secrets/` は存在しないと確認。T-0052 として起票・完遂し、CLAUDE.md と ops/CHARTER.md §5 の該当行を実在パスに書き換えた",
       "prs": [
         128
+      ]
+    },
+    {
+      "n": 22,
+      "at": "2026-08-05T03:10:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "前回の中断（PR #128, T-0052）がオープンのまま残っていたのを拾い、auto-merge 有効化・購読して merge を見届けた。issue #56 に未読フィードバックなし。backlog の todo が 0 件だったため subagent に新しい調査観点探しを投げ、terraform/proxmox/vm-nixos.tf で node01 の静的 IP が ip_config と output の2箇所に独立したリテラルとして書かれている重複を発見。T-0053 として起票・完遂し、locals に一本化した（#129, auto-merge）",
+      "prs": [
+        129
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

run #22 の記録をまとめる運用上の更新（コード変更なし）。

- `ops/backlog.json` の T-0053 に PR 番号（#129, merged）を反映
- `ops/state.json` の `runs` に run #22 のエントリを追加
- `ops/dashboard/prs.json` の PR キャッシュを最新化（#128, #129 を merged に反映）

## 検証したこと

- `python3 ops/validate.py` → 0 error（既存警告 1 件 + todo 0 件の情報警告、いずれも本 PR と無関係）
- `python3 ops/dashboard/build.py` → 正常終了、Artifact に再公開済み

## ロールバック手順

`ops/` の記録データのみの変更で実インフラへの影響はない。revert すれば元に戻る。

## backlog task id

なし（run #22 の記録作業そのもの、CHARTER §4 の相乗り例外）

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqqjZRHtiUWTUCGUKNWrGv)_