### PR TITLE
docs: .gitignore の secrets/ エントリを実態に合わせる (T-0054)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,10 @@ terraform.rc
 
 result
 
-# Secrets (not tracked in git)
-secrets/
+# SOPS 暗号化データは nix/images/proxmox-cloud/secrets.yaml の単一ファイルで、
+# 意図的に git 管理されている（トップレベルの secrets/ ディレクトリは存在しない。
+# T-0052, CLAUDE.md 参照）。以前ここにあった `secrets/` エントリは実在しないパスを
+# 無効に ignore していただけだったため削除した（T-0054）
 apps/*/charts/
 
 # direnv (credentials via Doppler)

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 54,
+  "next_id": 56,
   "updated": "2026-08-05T03:10:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
@@ -965,6 +965,40 @@
       "created": "2026-08-05",
       "pr": 129,
       "notes": "run #22: subagent に新しい調査観点探しを投げ、terraform/proxmox/vm-nixos.tf 内の IP 重複を発見（リポジトリ全体を grep し他にこの IP を参照する箇所が無いことも確認済み）。`locals { node01_ip = \"192.168.0.129\" }` を追加し、`ip_config.ipv4.address = \"${local.node01_ip}/24\"` と `output \"node01_ip\" { value = local.node01_ip }` に置き換えた。値は不変のため CI (`terraform fmt -check`/`validate`) で挙動が変わらないことを確認できる想定"
+    },
+    {
+      "id": "T-0054",
+      "domain": "homelab",
+      "title": ".gitignore の `secrets/` エントリが実在しないパスを指したまま残っている（T-0052 の続き）",
+      "kind": "docs",
+      "risk": "low",
+      "status": "done",
+      "priority": 8,
+      "why": "T-0052（run #21）で CLAUDE.md / ops/CHARTER.md の `secrets/` 記述は実在パス（`nix/images/proxmox-cloud/secrets.yaml`）に修正したが、`.gitignore` 自身の `secrets/` エントリは直していなかった。トップレベルに `secrets/` ディレクトリは存在しないため、このパターンは一度も何かを ignore したことが無い死んだルールで、コメント「Secrets (not tracked in git)」も実態（SOPS 暗号化ファイルは意図的に git 管理されている）と矛盾している",
+      "dod": ".gitignore の該当行が実在しないパスを参照しない。実際の secrets.yaml が意図的に追跡対象であることが分かるコメントに置き換える",
+      "refs": [
+        ".gitignore"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #23: subagent に新しい調査観点探しを投げて発見。`secrets/` エントリを削除し、実際の SOPS 暗号化ファイル（nix/images/proxmox-cloud/secrets.yaml）は意図的に git 管理されている旨のコメントに置き換えた"
+    },
+    {
+      "id": "T-0055",
+      "domain": "homelab",
+      "title": "immich (server / machine-learning / valkey) に CPU/メモリの requests・limits を設定する",
+      "kind": "refactor",
+      "risk": "medium",
+      "status": "todo",
+      "priority": 20,
+      "why": "run #23: subagent の調査で発見。この repo の手書き Deployment（vaultwarden, coder, coder-postgres, immich-postgres）と argocd の Helm values はすべて resources.requests/limits を設定しているが、apps/immich/values.yaml だけ controllers.main（server）・machine-learning.controllers.main・valkey.controllers.main のいずれも resources ブロックが無い。node01 は 4c/11.7GiB の単一ノードで、他コンポーネントの requests 合計は約 700m/1.2GiB（vaultwarden 50m/128Mi + coder-postgres 50m/128Mi + coder 100m/256Mi + argocd server/controller/repoServer 400m/448Mi + immich-postgres 100m/256Mi）に留まり、まだ十分な余地がある。とくに immich-machine-learning は CLIP 等のモデルをロードするため、requests/limits が無いと単一ノード上の他 Pod（vaultwarden や coder 含む、自分や人間の観測経路も同居している）を無制限に圧迫しうる",
+      "dod": "apps/immich/values.yaml の controllers.main（immich-server）・machine-learning.controllers.main・valkey.controllers.main に requests/limits を追加する。既存コンポーネント（coder の実装コメントが参考になる: requests は保証したい最低限、limits は他 Pod を圧迫しない上限）に倣い、node01 の総容量（4c/11.7GiB）に対して既存 requests 合計＋追加分が安全に収まることを PR 本文に書く。kustomize build --enable-helm apps/immich が CI で green であること（このサンドボックスには kustomize が無いため手元検証は不可、CHARTER §5.2）",
+      "refs": [
+        "apps/immich/values.yaml",
+        "apps/coder/deployment.yaml"
+      ],
+      "created": "2026-08-05",
+      "pr": null
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -980,7 +980,7 @@
         ".gitignore"
       ],
       "created": "2026-08-05",
-      "pr": null,
+      "pr": 131,
       "notes": "run #23: subagent に新しい調査観点探しを投げて発見。`secrets/` エントリを削除し、実際の SOPS 暗号化ファイル（nix/images/proxmox-cloud/secrets.yaml）は意図的に git 管理されている旨のコメントに置き換えた"
     },
     {

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -629,3 +629,26 @@
 - やったこと: T-0053 として起票・完遂。`locals { node01_ip = \"192.168.0.129\" }` を追加し、
   両箇所を `local.node01_ip` 参照に置き換えた（値は不変の純粋なリファクタ）
 - 次の起動へ: backlog の todo は本 run 終了時点で 0 件。次も CHARTER §3 の調査から入る
+
+## 2026-08-05 (継続) — run #23
+
+- 前回の中断確認: `git branch -r | grep autopilot/` はヒット無し、`mcp__github__list_pull_requests`
+  （state: open）も 0 件。中断なし
+- 読んだフィードバック: issue #56 の最新コメント（2026-08-05T01:32:24Z、自分の返信）が `last_read`
+  と一致。他者からの未読なし
+- backlog の todo は 0 件（T-0012/T-0040 とも next_review は 2026-08-11 で未到来）。CHARTER §3
+  に従い subagent に新しい調査観点探しを投げた（backlog.json 全件・CHARTER・journal を先に読ませ、
+  既出の観点と重複しないことを確認させた上で）
+- subagent が 2 件発見。(1) `.gitignore` の `secrets/` エントリが T-0052（run #21）で直した
+  CLAUDE.md/CHARTER.md の記述ずれと同型で、実在しないトップレベル `secrets/` ディレクトリを
+  指したまま残っていた（一度も何も ignore していない死んだルール）。(2) `apps/immich/values.yaml`
+  の `controllers.main`（server）・`machine-learning.controllers.main`・`valkey.controllers.main`
+  のいずれにも `resources`（requests/limits）が無く、この repo の他の手書き Deployment
+  （vaultwarden, coder, coder-postgres, immich-postgres）や argocd の Helm values とは異なり
+  単一ノード（4c/11.7GiB）上で無制限にリソースを使いうる
+- T-0054（.gitignore の secrets/ 記述ずれ）を起票・完遂。エントリを削除し、実際の secrets.yaml が
+  意図的に git 管理されている旨のコメントに置き換えた
+- T-0055（immich の resources 追加）を起票。risk=medium（実インフラへの実効果があるが、
+  requests/limits の追加は git revert で即座に戻せる純粋な追加）。他コンポーネントの requests
+  合計を grep で実測（約 700m/1.2GiB、node01 の 4c/11.7GiB に対して余裕あり）した上で todo に置いた。
+  次の起動（または本 run の続き）で着手する


### PR DESCRIPTION
## 変更点

`.gitignore` の `secrets/` エントリを削除し、実際の SOPS 暗号化ファイル（`nix/images/proxmox-cloud/secrets.yaml`）が意図的に git 管理されている旨のコメントに置き換えました。

T-0052（#128）で `CLAUDE.md` / `ops/CHARTER.md` の「トップレベルに `secrets/` ディレクトリがある」という実態とずれた記述を修正しましたが、`.gitignore` 自身のエントリは直っていませんでした。トップレベルに `secrets/` ディレクトリは存在しないため、このエントリは一度も何かを ignore したことが無い死んだルールで、コメント「Secrets (not tracked in git)」も実態（暗号化済みファイルは意図的に追跡対象）と矛盾していました。

## 検証したこと

- `find` で secrets 関連ファイルを再確認し、`nix/images/proxmox-cloud/secrets.yaml` の単一ファイルのみが存在することを確認（T-0052 時点と同じ）
- 挙動を変える変更ではない（存在しないパスの ignore ルールを消すだけ）ため `git status` の追跡状態に影響なし

## ロールバック手順

`git revert`。`.gitignore` の記述のみで実インフラ・到達性には影響しません。

## backlog task id

T-0054

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7mn78Yg2uJryNc2mb2hno)_