### PR TITLE
ops: run #23 の記録をまとめ、ダッシュボードを再生成する

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 56,
-  "updated": "2026-08-05T03:10:00Z",
+  "updated": "2026-08-05T02:52:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,10 +2,31 @@
   "open": [],
   "merged": [
     {
+      "number": 132,
+      "title": "refactor(immich): server/machine-learning/valkey に resources を設定する (T-0055)",
+      "url": "https://github.com/hikuohiku/homelab/pull/132",
+      "mergedAt": "2026-08-05T02:51:02Z",
+      "headRefName": "autopilot/T-0055-immich-resources"
+    },
+    {
+      "number": 131,
+      "title": "docs: .gitignore の secrets/ エントリを実態に合わせる (T-0054)",
+      "url": "https://github.com/hikuohiku/homelab/pull/131",
+      "mergedAt": "2026-08-05T02:48:13Z",
+      "headRefName": "autopilot/T-0054-gitignore-secrets-path"
+    },
+    {
+      "number": 130,
+      "title": "ops: run #22 の記録をまとめ、ダッシュボードを再生成する",
+      "url": "https://github.com/hikuohiku/homelab/pull/130",
+      "mergedAt": "2026-08-05T02:27:08Z",
+      "headRefName": "autopilot/run22-wrapup"
+    },
+    {
       "number": 129,
       "title": "refactor(terraform): node01 の静的 IP の二重記述を locals に一本化する (T-0053)",
       "url": "https://github.com/hikuohiku/homelab/pull/129",
-      "mergedAt": "2026-08-05T02:25:00Z",
+      "mergedAt": "2026-08-05T02:25:20Z",
       "headRefName": "autopilot/T-0053-node01-ip-dedup"
     },
     {
@@ -392,41 +413,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/73",
       "mergedAt": "2026-08-04T19:56:23Z",
       "headRefName": "autopilot/feedback-tool-availability"
-    },
-    {
-      "number": 72,
-      "title": "fix(ops): PR 一覧がキャッシュのときダッシュボードに明示する",
-      "url": "https://github.com/hikuohiku/homelab/pull/72",
-      "mergedAt": "2026-08-04T19:42:31Z",
-      "headRefName": "autopilot/dashboard-stale-warning"
-    },
-    {
-      "number": 71,
-      "title": "fix(tailscale): k8s-nameserver の floating tag unstable を固定する",
-      "url": "https://github.com/hikuohiku/homelab/pull/71",
-      "mergedAt": "2026-08-04T19:40:33Z",
-      "headRefName": "autopilot/T-0001-pin-tailscale-nameserver"
-    },
-    {
-      "number": 70,
-      "title": "fix(ci): direct-push-guard のレビュー指摘3点を修正",
-      "url": "https://github.com/hikuohiku/homelab/pull/70",
-      "mergedAt": "2026-08-04T19:34:27Z",
-      "headRefName": "autopilot/T-0014-fix-direct-push-guard-review"
-    },
-    {
-      "number": 69,
-      "title": "fix(ops): ダッシュボードに起動間隔が出ない退行を直す",
-      "url": "https://github.com/hikuohiku/homelab/pull/69",
-      "mergedAt": "2026-08-04T19:26:25Z",
-      "headRefName": "autopilot/fix-dashboard-cadence"
-    },
-    {
-      "number": 68,
-      "title": "fix(terraform): .terraform.lock.hcl から未宣言の tailscale provider を除去する",
-      "url": "https://github.com/hikuohiku/homelab/pull/68",
-      "mergedAt": "2026-08-04T19:25:17Z",
-      "headRefName": "autopilot/T-0004-tf-lock-cleanup"
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T03:10:00Z",
+  "updated": "2026-08-05T02:52:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -277,6 +277,17 @@
       "summary": "前回の中断（PR #128, T-0052）がオープンのまま残っていたのを拾い、auto-merge 有効化・購読して merge を見届けた。issue #56 に未読フィードバックなし。backlog の todo が 0 件だったため subagent に新しい調査観点探しを投げ、terraform/proxmox/vm-nixos.tf で node01 の静的 IP が ip_config と output の2箇所に独立したリテラルとして書かれている重複を発見。T-0053 として起票・完遂し、locals に一本化した（#129, auto-merge）",
       "prs": [
         129
+      ]
+    },
+    {
+      "n": 23,
+      "at": "2026-08-05T02:47:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。backlog の todo が 0 件だったため subagent に新しい調査観点探しを投げ、2 件発見。T-0054: .gitignore の secrets/ エントリが T-0052 で直したドキュメントと同型に実在しないパスを指したまま残っていた。削除し実際の secrets.yaml が意図的に git 管理されている旨のコメントに置き換えた（#131, auto-merge）。T-0055: apps/immich/values.yaml だけ他コンポーネント（vaultwarden/coder/coder-postgres/immich-postgres/argocd）と違って resources（requests/limits）が未設定で、node01（4c/11.7GiB 単一ノード）上で無制限にリソースを使いうる状態だった。immich-server・machine-learning・valkey に requests/limits を追加し、既存 requests 合計に対して余裕があることを確認した上で着手（#132, auto-merge）",
+      "prs": [
+        131,
+        132
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

run #23 の記録（`ops/state.json` の runs、PR キャッシュ `ops/dashboard/prs.json`）をまとめ、ダッシュボードを再生成しました。journal は各タスク PR（#131, #132）に既に相乗り済みです。

- T-0054（#131, merged）: `.gitignore` の `secrets/` エントリが実在しないパスを指していた記述ずれを修正
- T-0055（#132, merged）: immich（server/machine-learning/valkey）に resources（requests/limits）を追加

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 生成成功

## ロールバック手順

`git revert`。運用記録のみで実インフラには影響しません。

## backlog task id

なし（run のまとめ）

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7mn78Yg2uJryNc2mb2hno)_