### PR TITLE
fix(immich): 実測なしの memory limits を外す

### DIFF
--- a/apps/immich/values.yaml
+++ b/apps/immich/values.yaml
@@ -21,9 +21,11 @@ controllers:
           requests:
             cpu: 150m
             memory: 256Mi
+          # memory の limits は入れない。超えると throttle ではなく OOMKill になり、
+          # 現に動いているサービスに「死ぬ条件」を与えることになる。実使用量を観測できる
+          # ようになってから（T-0015 の後）検討する（issue #56, 2026-08-05）
           limits:
             cpu: 1500m
-            memory: 2Gi
 
 immich:
   persistence:
@@ -46,7 +48,6 @@ valkey:
               memory: 32Mi
             limits:
               cpu: 250m
-              memory: 256Mi
   persistence:
     data:
       enabled: true
@@ -83,7 +84,6 @@ machine-learning:
               memory: 512Mi
             limits:
               cpu: 2000m
-              memory: 3Gi
   persistence:
     cache:
       enabled: true


### PR DESCRIPTION
#132 で immich の 3 コンポーネントに `resources` が追加されましたが、**memory の limits には実使用量の裏付けがありません**。

## なぜ戻すか

- **memory limits の超過は throttle ではなく OOMKill です。** これまで無制限で正常に動いていた Pod に、初めて「死ぬ条件」を与えることになります
- 値の根拠は「repo に書かれた他コンポーネントの requests の合計」であって、immich 自身の実使用量ではありません。クラウド実行環境からクラスタに到達できないため測れません
- 足りなければ写真ライブラリを持つサービスが CrashLoopBackOff に入りますが、**観測手段が無いので誰も気づけません**

## 何を残すか

- **requests は全て残します。** スケジューリングにのみ影響し OOMKill しないので、「他コンポーネントの居場所を確保する」という #132 の目的は達成できます
- **CPU limits も残します。** 超過しても throttle されるだけで回復します

memory limits を入れるのは、実使用量を観測できるようになってから（T-0015 の後）が正しい順序です。

## ロールバック

`git revert` で #132 の状態に戻ります。