### PR TITLE
docs: README.md の Terraform ファイル構成・前提バージョンを実態に合わせる (T-0056)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Proxmox VE環境をTerraformで管理するためのIaCリポジトリです。
 
 ## 前提条件
 
-- Terraform 1.14.0
+- Terraform 1.15 系（`terraform/proxmox/providers.tf` の `required_version = "~> 1.15"`）
 - Proxmox VE 8.x以上
 - Tailscale経由でProxmoxに接続
 - Proxmox `local` ストレージで `import` コンテンツタイプが有効化されていること
@@ -62,12 +62,13 @@ just apply
 
 ```
 .
-├── README.md     # このファイル
-├── providers.tf  # Terraformプロバイダー設定
-├── variables.tf  # 共通変数定義
-├── main.tf       # カスタムVM構成ファイル
-├── pbs.tf.ignore # PBS VM構成の記録（手動管理・Terraform管理対象外）
-└── .gitignore    # Git除外設定
+├── README.md          # このファイル
+├── providers.tf       # Terraformプロバイダー設定
+├── variables.tf       # 共通変数定義
+├── vm-nixos.tf         # node01 VM構成ファイル
+├── nixos-image.tf      # NixOSイメージのダウンロード
+├── pbs.tf.ignore       # PBS VM構成の記録（手動管理・Terraform管理対象外）
+└── .terraform.lock.hcl # プロバイダーのバージョンロック
 ```
 
 ## よく使うコマンド

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 56,
+  "next_id": 59,
   "updated": "2026-08-05T02:52:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
@@ -1000,6 +1000,57 @@
       "created": "2026-08-05",
       "pr": 132,
       "notes": "run #23: immich-server（requests 150m/256Mi, limits 1500m/2Gi）・valkey（requests 25m/32Mi, limits 250m/256Mi）・machine-learning（requests 200m/512Mi, limits 2000m/3Gi）に resources を追加。既存コンポーネントの requests 合計（約700m/1.2GiB）に今回の追加分（約375m/800Mi）を足しても node01 の 4c/11.7GiB に対して余裕があることを確認。immich chart（bjw-s app-template ベース）自体はデフォルトで resources を設定していないことを WebFetch で確認済み（controllers.<name>.containers.main.resources が正しいキー、既存の image/env と同じ階層）。limits 合計は既存分と合わせても memory 側で概ね9GiB程度に収まり、全コンポーネントが同時に上限まで張り付く想定はしていない"
+    },
+    {
+      "id": "T-0056",
+      "domain": "homelab",
+      "title": "README.md の Terraform ファイル構成・前提バージョン記載を実態に合わせる",
+      "kind": "docs",
+      "risk": "low",
+      "status": "done",
+      "priority": 8,
+      "why": "run #24: subagent の調査で発見。README.md の『ファイル構成』節が `main.tf`（実在しない、実際は `vm-nixos.tf`）を挙げ、`nixos-image.tf` が抜け、存在しない `terraform/proxmox/.gitignore` を挙げていた。前提条件の `Terraform 1.14.0` も `providers.tf` の `required_version = \"~> 1.15\"` と食い違っていた",
+      "dod": "README.md のファイル構成節が実際の terraform/proxmox/ 配下のファイルと一致し、前提条件の Terraform バージョンが providers.tf と一致する",
+      "refs": [
+        "README.md",
+        "terraform/proxmox/providers.tf"
+      ],
+      "created": "2026-08-05",
+      "notes": "run #24: terraform/proxmox/ を ls して実ファイル（providers.tf, variables.tf, vm-nixos.tf, nixos-image.tf, pbs.tf.ignore, .terraform.lock.hcl）を確認し、README.md のファイル構成節と前提条件を書き換えた"
+    },
+    {
+      "id": "T-0057",
+      "domain": "homelab",
+      "title": "apps/README.md のディレクトリ構造図をアプリ追加に追随させる",
+      "kind": "docs",
+      "risk": "low",
+      "status": "todo",
+      "priority": 8,
+      "why": "run #24: subagent の調査で発見。apps/README.md の『ディレクトリ構造』節が apps.yaml/kustomization.yaml/argocd/external-secrets/tailscale-operator の5項目のみを挙げているが、実際の apps/kustomization.yaml には agent-rbac/dex/immich/vaultwarden/coder も登録済みで計8アプリある",
+      "dod": "apps/README.md のディレクトリ構造図が apps/kustomization.yaml の resources と一致する（または『詳細は kustomization.yaml 参照』に置き換える）",
+      "refs": [
+        "apps/README.md",
+        "apps/kustomization.yaml"
+      ],
+      "created": "2026-08-05"
+    },
+    {
+      "id": "T-0058",
+      "domain": "homelab",
+      "title": "coder-postgres / immich-postgres コンテナに securityContext (runAsNonRoot 等) を追加できるか検証する",
+      "kind": "security",
+      "risk": "medium",
+      "status": "todo",
+      "priority": 20,
+      "why": "run #24: subagent の調査で発見。同じ手書き Deployment でも vaultwarden/coder のコンテナは runAsNonRoot/allowPrivilegeEscalation/seccompProfile をコンテナレベルで明示しているのに対し、apps/coder/postgres.yaml と apps/immich/postgres.yaml の postgres コンテナには Pod レベルの fsGroup しか無く、コンテナレベルの securityContext が丸ごと無い",
+      "dod": "postgres 公式イメージの実行 UID（通常 999）を確認したうえで、runAsNonRoot: true 等を追加してもコンテナが正常に起動することが分かる形に落とす。immich-postgres は既存の initContainer が chown で UID 26/999 を使い分けているため、その整合も確認する。CI (manifest-diff) で意図しないオブジェクト削除が無いことも確認する",
+      "refs": [
+        "apps/coder/postgres.yaml",
+        "apps/immich/postgres.yaml",
+        "apps/vaultwarden/deployment.yaml",
+        "apps/coder/deployment.yaml"
+      ],
+      "created": "2026-08-05"
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1016,6 +1016,7 @@
         "terraform/proxmox/providers.tf"
       ],
       "created": "2026-08-05",
+      "pr": 135,
       "notes": "run #24: terraform/proxmox/ を ls して実ファイル（providers.tf, variables.tf, vm-nixos.tf, nixos-image.tf, pbs.tf.ignore, .terraform.lock.hcl）を確認し、README.md のファイル構成節と前提条件を書き換えた"
     },
     {

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -661,3 +661,25 @@
   次の起動へ: backlog の todo は本 run 終了時点で 0 件。T-0055 マージ後、実際に immich の Pod が
   正常に起動すること自体はこのサンドボックスから確認できない（クラスタ非到達、T-0015 未解決）。
   異常の兆候（issue #56 へのフィードバック等）があれば最優先で拾うこと
+
+## 2026-08-05 (継続) — run #24
+
+- 前回の中断確認: `git branch -r | grep autopilot/` はヒット無し、オープン PR も 0 件。中断なし
+- 読んだフィードバック: issue #56 の全コメントの `created_at` が `last_read`（2026-08-05T01:32:24Z）
+  より前で、未読なし
+- backlog の todo は 0 件（T-0012/T-0040 とも next_review は 2026-08-11 で未到来）。CHARTER §3 に
+  従い subagent に新しい調査観点探しを投げた（既出の観点 — バージョン同期・GitHub Actions棚卸し・
+  ドキュメントドリフト・nix flake 経年・IP重複・resources未設定 等 — を避けるよう指示し、報告前に
+  実ファイルを Read して裏取りするよう指示）
+- subagent が 3 件発見（いずれも実ファイル確認済み）: (1) README.md の Terraform セクションが
+  `main.tf`（実在しない、実際は `vm-nixos.tf`）・`nixos-image.tf` の欠落・存在しない
+  `terraform/proxmox/.gitignore`・古い Terraform バージョン記載（1.14.0、実際は providers.tf の
+  `~> 1.15`）を含んでいた。(2) apps/README.md のディレクトリ構造図が5アプリのみを挙げ、実際に
+  apps/kustomization.yaml に登録されている agent-rbac/dex/immich/vaultwarden/coder（計8アプリ）に
+  追随していなかった。(3) apps/coder/postgres.yaml と apps/immich/postgres.yaml の postgres
+  コンテナに、同じ手書き Deployment である vaultwarden/coder とは異なりコンテナレベルの
+  securityContext（runAsNonRoot 等）が丸ごと無い
+- T-0056/T-0057/T-0058 として起票。T-0056（README.md drift）は即完遂（ファイル構成節・前提
+  バージョンを実態に合わせた）。T-0057（apps/README.md drift）は同型で低リスクのため続けて着手予定。
+  T-0058（postgres securityContext）は postgres 公式イメージの実行 UID 確認が要るため medium とし、
+  次回以降に回す判断もありうる


### PR DESCRIPTION
## 変更点

`README.md` の Terraform セクションが実態とずれていたのを修正した。

- 「ファイル構成」節: 実在しない `main.tf` を `vm-nixos.tf` に修正、`nixos-image.tf` を追加、存在しない `terraform/proxmox/.gitignore` を `.terraform.lock.hcl` に差し替え
- 前提条件の Terraform バージョン記載（`1.14.0`）を、`providers.tf` の `required_version = "~> 1.15"` に合わせて修正

## 検証したこと

- `ls terraform/proxmox/` で実在するファイル一覧を確認済み
- `providers.tf` の `required_version` を確認済み
- ドキュメントのみの変更で、コード・インフラへの影響なし

## ロールバック手順

`git revert` で即座に戻せる。ドキュメントのみの変更なので実インフラへの影響はない。

## backlog task id

T-0056

---
_Generated by [Claude Code](https://claude.ai/code/session_01Etw2U7RqqhYFqcZNbbFXZU)_