### PR TITLE
docs: apps/README.md のディレクトリ構造図をアプリ追加に追随させる (T-0057)

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -139,10 +139,15 @@ just inject-secrets
 ```
 apps/
 ├── apps.yaml              # App of Apps ルート
-├── kustomization.yaml     # Application 一覧
+├── kustomization.yaml     # Application 一覧（実体はこのファイルの resources を参照）
 ├── argocd/
+├── agent-rbac/
+├── dex/
 ├── external-secrets/
-└── tailscale-operator/
+├── tailscale-operator/
+├── immich/
+├── vaultwarden/
+└── coder/
 ```
 
 各アプリは以下の構造:

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1025,7 +1025,7 @@
       "title": "apps/README.md のディレクトリ構造図をアプリ追加に追随させる",
       "kind": "docs",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 8,
       "why": "run #24: subagent の調査で発見。apps/README.md の『ディレクトリ構造』節が apps.yaml/kustomization.yaml/argocd/external-secrets/tailscale-operator の5項目のみを挙げているが、実際の apps/kustomization.yaml には agent-rbac/dex/immich/vaultwarden/coder も登録済みで計8アプリある",
       "dod": "apps/README.md のディレクトリ構造図が apps/kustomization.yaml の resources と一致する（または『詳細は kustomization.yaml 参照』に置き換える）",
@@ -1033,7 +1033,8 @@
         "apps/README.md",
         "apps/kustomization.yaml"
       ],
-      "created": "2026-08-05"
+      "created": "2026-08-05",
+      "notes": "run #24: apps/kustomization.yaml の resources（8件: argocd, agent-rbac, dex, external-secrets, tailscale-operator, immich, vaultwarden, coder）を確認し、apps/README.md のディレクトリ構造図を一致させた"
     },
     {
       "id": "T-0058",

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1034,6 +1034,7 @@
         "apps/kustomization.yaml"
       ],
       "created": "2026-08-05",
+      "pr": 136,
       "notes": "run #24: apps/kustomization.yaml の resources（8件: argocd, agent-rbac, dex, external-secrets, tailscale-operator, immich, vaultwarden, coder）を確認し、apps/README.md のディレクトリ構造図を一致させた"
     },
     {

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -680,6 +680,9 @@
   コンテナに、同じ手書き Deployment である vaultwarden/coder とは異なりコンテナレベルの
   securityContext（runAsNonRoot 等）が丸ごと無い
 - T-0056/T-0057/T-0058 として起票。T-0056（README.md drift）は即完遂（ファイル構成節・前提
-  バージョンを実態に合わせた）。T-0057（apps/README.md drift）は同型で低リスクのため続けて着手予定。
-  T-0058（postgres securityContext）は postgres 公式イメージの実行 UID 確認が要るため medium とし、
-  次回以降に回す判断もありうる
+  バージョンを実態に合わせた、#135, merged）。T-0058（postgres securityContext）は postgres
+  公式イメージの実行 UID 確認が要るため medium とし、次回以降に回す判断もありうる
+- T-0056（#135）のマージを見届けた後、続けて T-0057（apps/README.md drift）に着手・完遂。
+  apps/kustomization.yaml の resources を実際に確認（8件: argocd, agent-rbac, dex,
+  external-secrets, tailscale-operator, immich, vaultwarden, coder）し、apps/README.md の
+  ディレクトリ構造図を一致させた


### PR DESCRIPTION
## 変更点

`apps/README.md` の「ディレクトリ構造」節が古いアプリ一覧（5項目）のままだったのを、実際の `apps/kustomization.yaml` の内容（8項目）に合わせた。

## 検証したこと

- `apps/kustomization.yaml` の `resources` を実際に確認し、8個の Application（argocd, agent-rbac, dex, external-secrets, tailscale-operator, immich, vaultwarden, coder）が登録されていることを確認済み
- ドキュメントのみの変更で、コード・インフラへの影響なし

## ロールバック手順

`git revert` で即座に戻せる。ドキュメントのみの変更なので実インフラへの影響はない。

## backlog task id

T-0057

---
_Generated by [Claude Code](https://claude.ai/code/session_01Etw2U7RqqhYFqcZNbbFXZU)_