### PR TITLE
security(postgres): コンテナに securityContext を追加する (T-0058)

### DIFF
--- a/apps/coder/postgres.yaml
+++ b/apps/coder/postgres.yaml
@@ -44,6 +44,16 @@ spec:
       containers:
         - name: postgres
           image: postgres:17.10
+          # 公式 postgres イメージは UID/GID 999 で postgres ユーザーを作成する
+          # (docker-library/postgres Dockerfile: groupadd -r postgres --gid=999,
+          # useradd -r -g postgres --uid=999)。init-permissions の chown 999:999 と揃える。
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+            runAsGroup: 999
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           env:
             - name: POSTGRES_USER
               value: coder

--- a/apps/immich/postgres.yaml
+++ b/apps/immich/postgres.yaml
@@ -47,6 +47,17 @@ spec:
       containers:
         - name: postgres
           image: ghcr.io/tensorchord/cloudnative-vectorchord:16.9-0.4.3
+          # このイメージは CloudNativePG operand イメージ (postgres-containers)
+          # を継承しており、ベースの Debian postgres ユーザー (UID/GID 999) に
+          # usermod -u 26 postgres で UID のみ 26 に変更している (GID は 999 のまま)。
+          # 上の fsGroup / chown コメントの UID 26 / GID 999 と一致させる。
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 26
+            runAsGroup: 999
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           args:
             - -c
             - shared_preload_libraries=vchord.so

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1043,7 +1043,7 @@
       "title": "coder-postgres / immich-postgres コンテナに securityContext (runAsNonRoot 等) を追加できるか検証する",
       "kind": "security",
       "risk": "medium",
-      "status": "todo",
+      "status": "in_progress",
       "priority": 20,
       "why": "run #24: subagent の調査で発見。同じ手書き Deployment でも vaultwarden/coder のコンテナは runAsNonRoot/allowPrivilegeEscalation/seccompProfile をコンテナレベルで明示しているのに対し、apps/coder/postgres.yaml と apps/immich/postgres.yaml の postgres コンテナには Pod レベルの fsGroup しか無く、コンテナレベルの securityContext が丸ごと無い",
       "dod": "postgres 公式イメージの実行 UID（通常 999）を確認したうえで、runAsNonRoot: true 等を追加してもコンテナが正常に起動することが分かる形に落とす。immich-postgres は既存の initContainer が chown で UID 26/999 を使い分けているため、その整合も確認する。CI (manifest-diff) で意図しないオブジェクト削除が無いことも確認する",

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1054,6 +1054,7 @@
         "apps/coder/deployment.yaml"
       ],
       "created": "2026-08-05",
+      "pr": 137,
       "notes": "run #24: coder-postgres は公式 postgres イメージが UID/GID 999 で postgres ユーザーを作る (docker-library/postgres Dockerfile の groupadd/useradd --uid=999/--gid=999) ことを WebFetch で確認し、runAsUser/runAsGroup: 999 を設定（既存の chown 999:999 と一致）。immich-postgres (cloudnative-vectorchord) は subagent に Dockerfile 2本 (tensorchord/cloudnative-vectorchord と ベースの cloudnative-pg/postgres-containers) を直接確認させ、Debian の postgres ユーザー (UID/GID 999) に usermod -u 26 postgres で UID のみ 26 に変更（GID は 999 のまま）と判明。既存コメント (UID 26 / GID 999) と一致したため runAsUser: 26 / runAsGroup: 999 を設定。両ファイルとも allowPrivilegeEscalation: false / seccompProfile: RuntimeDefault も vaultwarden/coder に倣って追加。実イメージの /etc/passwd 直接確認はできなかった（docker daemon 不在、レジストリ blob 取得も proxy 制約で失敗）が、ビルドソース2段の裏取りで確度は十分と判断した。実際に Pod が起動することはこのサンドボックスから確認できない（クラスタ非到達）ため、異常の兆候があれば最優先で拾うこと"
     }
   ]

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1043,7 +1043,7 @@
       "title": "coder-postgres / immich-postgres コンテナに securityContext (runAsNonRoot 等) を追加できるか検証する",
       "kind": "security",
       "risk": "medium",
-      "status": "in_progress",
+      "status": "done",
       "priority": 20,
       "why": "run #24: subagent の調査で発見。同じ手書き Deployment でも vaultwarden/coder のコンテナは runAsNonRoot/allowPrivilegeEscalation/seccompProfile をコンテナレベルで明示しているのに対し、apps/coder/postgres.yaml と apps/immich/postgres.yaml の postgres コンテナには Pod レベルの fsGroup しか無く、コンテナレベルの securityContext が丸ごと無い",
       "dod": "postgres 公式イメージの実行 UID（通常 999）を確認したうえで、runAsNonRoot: true 等を追加してもコンテナが正常に起動することが分かる形に落とす。immich-postgres は既存の initContainer が chown で UID 26/999 を使い分けているため、その整合も確認する。CI (manifest-diff) で意図しないオブジェクト削除が無いことも確認する",
@@ -1053,7 +1053,8 @@
         "apps/vaultwarden/deployment.yaml",
         "apps/coder/deployment.yaml"
       ],
-      "created": "2026-08-05"
+      "created": "2026-08-05",
+      "notes": "run #24: coder-postgres は公式 postgres イメージが UID/GID 999 で postgres ユーザーを作る (docker-library/postgres Dockerfile の groupadd/useradd --uid=999/--gid=999) ことを WebFetch で確認し、runAsUser/runAsGroup: 999 を設定（既存の chown 999:999 と一致）。immich-postgres (cloudnative-vectorchord) は subagent に Dockerfile 2本 (tensorchord/cloudnative-vectorchord と ベースの cloudnative-pg/postgres-containers) を直接確認させ、Debian の postgres ユーザー (UID/GID 999) に usermod -u 26 postgres で UID のみ 26 に変更（GID は 999 のまま）と判明。既存コメント (UID 26 / GID 999) と一致したため runAsUser: 26 / runAsGroup: 999 を設定。両ファイルとも allowPrivilegeEscalation: false / seccompProfile: RuntimeDefault も vaultwarden/coder に倣って追加。実イメージの /etc/passwd 直接確認はできなかった（docker daemon 不在、レジストリ blob 取得も proxy 制約で失敗）が、ビルドソース2段の裏取りで確度は十分と判断した。実際に Pod が起動することはこのサンドボックスから確認できない（クラスタ非到達）ため、異常の兆候があれば最優先で拾うこと"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -686,3 +686,11 @@
   apps/kustomization.yaml の resources を実際に確認（8件: argocd, agent-rbac, dex,
   external-secrets, tailscale-operator, immich, vaultwarden, coder）し、apps/README.md の
   ディレクトリ構造図を一致させた
+- T-0057（#136）のマージを見届けた後、続けて T-0058（postgres securityContext）に着手・完遂。
+  coder-postgres は WebFetch で docker-library/postgres の Dockerfile を確認し、公式 postgres
+  イメージが UID/GID 999 で postgres ユーザーを作ることを裏取り（既存の chown 999:999 と一致）。
+  immich-postgres (cloudnative-vectorchord) は subagent に Dockerfile を2段（イメージ本体 +
+  ベースの cloudnative-pg/postgres-containers）遡らせ、Debian の postgres ユーザー(999/999)に
+  usermod -u 26 postgres で UID のみ 26 に変更（GID は999のまま）という経緯を確認し、既存コメント
+  (UID 26 / GID 999) と一致することを確かめてから runAsUser/runAsGroup を設定した。両ファイルとも
+  vaultwarden/coder に倣い allowPrivilegeEscalation: false / seccompProfile: RuntimeDefault も追加


### PR DESCRIPTION
## 変更点

`apps/coder/postgres.yaml` と `apps/immich/postgres.yaml` の `postgres` コンテナに、コンテナレベルの `securityContext` を追加した。同じリポジトリの手書き Deployment（vaultwarden, coder）は `runAsNonRoot` / `allowPrivilegeEscalation: false` / `seccompProfile: RuntimeDefault` をコンテナレベルで明示しているが、この2つの postgres コンテナには Pod レベルの `fsGroup` しか無く、root 実行を止める指定が丸ごと欠けていた。

- `coder-postgres`: `runAsUser: 999` / `runAsGroup: 999`（公式 `postgres` イメージが UID/GID 999 で `postgres` ユーザーを作成することを確認。既存の `init-permissions` initContainer の `chown 999:999` と一致）
- `immich-postgres`: `runAsUser: 26` / `runAsGroup: 999`（`cloudnative-vectorchord` イメージの Dockerfile とベースの `cloudnative-pg/postgres-containers` を確認。Debian の `postgres` ユーザー（UID/GID 999）に対して `usermod -u 26 postgres` で UID のみ 26 に変更した経緯を確認済み。既存の `chown 26:999` コメントと一致）

## 検証したこと

- `docker-library/postgres` の Dockerfile（`groupadd -r postgres --gid=999` / `useradd -r -g postgres --uid=999`）を WebFetch で直接確認
- `tensorchord/cloudnative-vectorchord` の Dockerfile と、そのベースである `cloudnative-pg/postgres-containers` の Dockerfile を subagent 経由で直接確認し、UID 26 / GID 999 の組み合わせの出どころ（`usermod -u 26 postgres`、GID は変更なし）を裏取り済み
- 両ファイルとも既存の `initContainer` の `chown` 先 UID/GID と、追加した `runAsUser`/`runAsGroup` が一致することを確認済み
- このサンドボックスには `kustomize`/`kubectl` が無いため、実際に Pod が起動することの確認はできない（CI の `manifest-diff` job でオブジェクトの意図しない削除が無いことのみ機械検証される）

## ロールバック手順

`git revert` で `securityContext` ブロックを削除するだけで即座に戻せる。ArgoCD の sync で反映される。万一 Pod が `CrashLoopBackOff` になった場合も、この revert が唯一の復旧経路になる（このサンドボックスからはクラスタの状態を確認できないため、異常の兆候は次回起動時の issue #56 フィードバックや人間からの報告に依存する）。

## backlog task id

T-0058

---
_Generated by [Claude Code](https://claude.ai/code/session_01Etw2U7RqqhYFqcZNbbFXZU)_