### PR TITLE
ops: run #25 の記録をまとめ、ダッシュボードを再生成する

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,23 +1,20 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 139,
       "title": "ops: issue #56 のフィードバックを反映する (T-0059)",
       "url": "https://github.com/hikuohiku/homelab/pull/139",
-      "isDraft": false,
-      "createdAt": "2026-08-05T03:52:00Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "PENDING"
-        }
-      ],
-      "headRefName": "autopilot/T-0059-feedback-cooldown-pagination",
-      "autoMergeRequest": {
-        "mergeMethod": "MERGE"
-      }
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-05T03:53:59Z",
+      "headRefName": "autopilot/T-0059-feedback-cooldown-pagination"
+    },
+    {
+      "number": 140,
+      "title": "feat(ops): inventory.json に observability_impact フィールドを追加する (T-0059)",
+      "url": "https://github.com/hikuohiku/homelab/pull/140",
+      "mergedAt": "2026-08-05T03:57:19Z",
+      "headRefName": "autopilot/T-0059-inventory-observability-impact"
+    },
     {
       "number": 138,
       "title": "ops: run #24 の記録をまとめ、ダッシュボードを再生成する",
@@ -423,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/80",
       "mergedAt": "2026-08-04T20:28:44Z",
       "headRefName": "autopilot/T-0006-plans-md-syncthing-status"
-    },
-    {
-      "number": 79,
-      "title": "T-0018: dex chart を 0.24.0 → 0.24.1 に上げる",
-      "url": "https://github.com/hikuohiku/homelab/pull/79",
-      "mergedAt": "2026-08-04T20:22:07Z",
-      "headRefName": "autopilot/T-0018-dex-chart-patch"
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`ops/dashboard/prs.json` のキャッシュを run #25 完了時点（#139, #140 マージ済み、open PR 無し）に最新化する。ダッシュボード HTML は生成物のため Git 管理していない（T-0035）。

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 正常終了、Artifact に再公開済み（同一 URL）

## ロールバック手順

`git revert` で本コミットを打ち消すだけで良い。キャッシュのみの変更で実インフラへの影響は無い。

## backlog task id

なし（ops/ 運用記録の相乗り、CHARTER §4 の例外規定）

---
_Generated by [Claude Code](https://claude.ai/code/session_016midwFaVguKX9k8qq1vYd4)_