### PR TITLE
ops: run #26 の記録をまとめ、T-0060 を起票する

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 60,
-  "updated": "2026-08-05T04:05:00Z",
+  "next_id": 61,
+  "updated": "2026-08-05T04:11:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -1074,6 +1074,26 @@
       "created": "2026-08-05",
       "pr": 140,
       "notes": "run #25: ops/inventory.json に observability_impact フィールドを追加。CHARTER §4 で名指しされている観測・操作経路（ArgoCD, Dex, Tailscale operator/nameserver, Coder, coder-postgres, GitHub Actions 7件）に該当する対象にのみ設定し、該当しないものは省略（無指定＝未評価であって『影響なし確認済み』ではないと _comment に明記）。自動チェックまでは実装せず、まず判断材料として持たせる段階に留めた（DoD どおり）"
+    },
+    {
+      "id": "T-0060",
+      "domain": "homelab",
+      "title": "Dex↔ArgoCD の OIDC client secret がプレーンテキストでハードコード・2箇所重複している（Doppler 経由に切り替える）",
+      "kind": "security",
+      "risk": "high",
+      "status": "needs-human",
+      "priority": 20,
+      "why": "run #26: subagent の調査で発見。apps/dex/values.yaml の staticClients[0].secret と apps/argocd/values.yaml の configs.cm.oidc.config.clientSecret が、どちらも同じリテラル文字列 `argocd-dex-client-secret` を平文でハードコードしている（ランダム値ではなく名前のような文字列で、実質的に推測可能な固定値）。この repo の他の全credential（Google OAuth, Tailscale OAuth, vaultwarden ADMIN_TOKEN, coder/immich の postgres パスワード）は Doppler → ExternalSecret 経由で調達しており、CLAUDE.md の『シークレットは SOPS で暗号化して Git 管理』という方針にも反する唯一の例外。dex/values.yaml 自身も2行上で Google コネクタの clientID/clientSecret を `$GOOGLE_CLIENT_ID`/`$GOOGLE_CLIENT_SECRET`（envFrom 経由）にしており、この staticClients エントリだけが取り残されている",
+      "dod": "apps/dex と apps/argocd 双方が Doppler 由来の ExternalSecret を経由して client secret を取得し、git 管理下のファイルにプレーンテキストの秘密値が存在しない。実装は次の順で行う（詳細は notes の一次ソース調査結果を参照）:\n1. (needs-human, このタスク自体) 新しいランダムな秘密文字列を生成し、Doppler に新規キー DEX_ARGOCD_CLIENT_SECRET として登録する\n2. Doppler 登録確認後、次の変更を1PRで行う:\n   - apps/dex: 新しい ExternalSecret（またはdex-google-oauthへのキー追加）で Secret を作り、dex Deployment の envFrom に追加。apps/dex/values.yaml の staticClients エントリは `secret: <literal>` ではなく `secretEnv: DEX_ARGOCD_CLIENT_SECRET` を使う（`secret: $VAR` ではない。dex は connector config にしか $VAR 展開をせず、staticClients は idEnv/secretEnv という別フィールドで env var 名を直接指定する専用の仕組み。ソース: dexidp/dex の cmd/dex/config.go, storage/storage.go, cmd/dex/serve.go）\n   - apps/argocd: 新しい ExternalSecret で Secret `argocd-dex-client-secret`（key: `secret`）を作り、target.template.metadata.labels に `app.kubernetes.io/part-of: argocd` を必ず付ける（このラベルが無いと ArgoCD の secret informer から見えず解決されない）。apps/argocd/values.yaml の oidc.config.clientSecret を `$argocd-dex-client-secret:secret` にする（argocd-secret 本体は触らない。ソース: argoproj/argo-cd の util/settings/settings.go の oidcConfig()/ReplaceMapSecrets/getSecrets/partOfArgoCDSelector）\n3. 適用順序に注意: dex 側は envFrom が参照する Secret が存在しないと Pod が CreateContainerConfigError で起動しない（Dex 自体が全ログインの単一障害点になるため、Doppler 登録が先に完了していることが必須）。ArgoCD 側は secret が無くても argocd-server はクラッシュせず OIDC ログインだけが失敗する（グレースフル）ので dex 側ほど繊細ではない。したがって Doppler 登録（手順1）が確実に完了してから手順2に進むこと\n4. PR 本文に CHARTER §4『到達性を失いうる変更』の復旧手順を明記する: 失敗した場合は git revert + ArgoCD self-heal で旧設定（同じ弱い共有値だが動作する）に戻せる。Dex が起動しなくなった場合、autopilot はクラスタに到達できないため自分では直せず、人間が Tailscale 経由の kubectl で Secret を作るか revert の反映を確認する必要がある旨も明記する",
+      "needs_human_reason": "手順1（Doppler への新しい秘密値の登録）はエージェントから手が届かない、CHARTER §4 の『人間に渡してよいもの』の credential 登録に該当する。任意の強いランダム文字列で構わないので、Doppler の homelab/prd プロジェクトに新規シークレット `DEX_ARGOCD_CLIENT_SECRET` として登録してほしい（既存の External Secrets Operator の ClusterSecretStore が読む場所と同じプロジェクト）。登録が確認でき次第、手順2以降（ExternalSecret 追加 + values.yaml 切り替え、1PR）はこちらで実施する",
+      "refs": [
+        "apps/dex/values.yaml",
+        "apps/argocd/values.yaml",
+        "apps/dex/dex-google-oauth-external-secret.yaml"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #26: subagent 2件で調査。(1) 発見自体は repo 横断調査の subagent（apps/dex, apps/argocd の値ファイルを実際に Read して確認）。(2) 修正方式は別の subagent に dexidp/dex と argoproj/argo-cd の実ソース（GitHub 上のソースコード、changelogではなく）を直接確認させた。dex の $VAR 展開が staticClients には効かない（idEnv/secretEnv という別フィールドが必要、dexidp/dex#4212 で明示的に未実装と確認された既知のギャップ）という誤りやすい落とし穴を事前に潰せた。ArgoCD 側は `$secret-name:key` 構文と `app.kubernetes.io/part-of=argocd` ラベル要件をソースコード（util/settings/settings.go）で確認済み。着手前に Doppler 登録が必須という順序性（dex の envFrom は Secret 不在だと Pod が起動しないため）が高リスクの核心なので、needs-human とし、手順2以降はこちらの続きの起動で行う"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,20 @@
   "open": [],
   "merged": [
     {
+      "number": 143,
+      "title": "feat(ops): ダッシュボードにストリーム分類とガントを追加する",
+      "url": "https://github.com/hikuohiku/homelab/pull/143",
+      "mergedAt": "2026-08-05T04:05:35Z",
+      "headRefName": "autopilot/dashboard-streams-gantt"
+    },
+    {
+      "number": 142,
+      "title": "ops: run #25 の PR 番号一覧・キャッシュを確定させる",
+      "url": "https://github.com/hikuohiku/homelab/pull/142",
+      "mergedAt": "2026-08-05T04:00:22Z",
+      "headRefName": "autopilot/run25-wrapup-final"
+    },
+    {
       "number": 141,
       "title": "ops: run #25 の記録をまとめ、ダッシュボードを再生成する",
       "url": "https://github.com/hikuohiku/homelab/pull/141",
@@ -9,18 +23,18 @@
       "headRefName": "autopilot/run25-wrapup"
     },
     {
-      "number": 139,
-      "title": "ops: issue #56 のフィードバックを反映する (T-0059)",
-      "url": "https://github.com/hikuohiku/homelab/pull/139",
-      "mergedAt": "2026-08-05T03:53:59Z",
-      "headRefName": "autopilot/T-0059-feedback-cooldown-pagination"
-    },
-    {
       "number": 140,
       "title": "feat(ops): inventory.json に observability_impact フィールドを追加する (T-0059)",
       "url": "https://github.com/hikuohiku/homelab/pull/140",
       "mergedAt": "2026-08-05T03:57:19Z",
       "headRefName": "autopilot/T-0059-inventory-observability-impact"
+    },
+    {
+      "number": 139,
+      "title": "ops: issue #56 のフィードバックを反映する (T-0059)",
+      "url": "https://github.com/hikuohiku/homelab/pull/139",
+      "mergedAt": "2026-08-05T03:53:59Z",
+      "headRefName": "autopilot/T-0059-feedback-cooldown-pagination"
     },
     {
       "number": 138,
@@ -406,20 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/83",
       "mergedAt": "2026-08-04T20:50:52Z",
       "headRefName": "autopilot/fix-dashboard-numbers"
-    },
-    {
-      "number": 82,
-      "title": "ops: run #7 の記録をまとめ、ダッシュボードを再生成する",
-      "url": "https://github.com/hikuohiku/homelab/pull/82",
-      "mergedAt": "2026-08-04T20:34:49Z",
-      "headRefName": "autopilot/run-7-wrapup"
-    },
-    {
-      "number": 81,
-      "title": "T-0007: Maintenance.md の持ち越し課題を backlog に取り込む",
-      "url": "https://github.com/hikuohiku/homelab/pull/81",
-      "mergedAt": "2026-08-04T20:33:11Z",
-      "headRefName": "autopilot/T-0007-maintenance-backlog"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -756,3 +756,42 @@
   次の起動へ: backlog の todo は 0 件（validate.py が「todo が1件も無い」警告を出すのは意図どおり
   CHARTER §3 の調査トリガー）。次回は新しい調査観点を探すか、cooldown ルールの実地での効き方を
   確認すること
+
+## 2026-08-05 04:11 UTC — run #26
+
+- 前回の中断確認: `git branch -r | grep autopilot/` はヒット無し、オープン PR も 0 件。中断なし。
+  ただし state.json 記録済みの run #25 (#139-141) より後に #142（run25-wrapup-final）・#143（ダッシュボードに
+  ストリーム分類とガントを追加）が既に merge 済みだった。journal に対応する記述が無く、自分のこの起動が
+  始まる前に別セッション（構築セッションと思われる）が完了させたものと判断。ローカル main が古いキャッシュの
+  ままだったため `git checkout -B main origin/main` で追従し、prs.json のキャッシュにも 2 件を反映した
+- 読んだフィードバック: issue #56 に last_read（03:45:46Z）より新しいコメントは1件あったが、内容は自分自身
+  （run #25）の返信（03:50:30Z）だった。人間からの新規フィードバックなし。last_read を更新
+- backlog の todo は 0 件（T-0012/T-0040 とも next_review は 2026-08-11 で未到来）。CHARTER §3 に従い
+  subagent に新しい調査観点探しを投げた。既出の観点（バージョン同期、GitHub Actions棚卸し、README/CLAUDE.md
+  ドキュメントドリフト、terraform IP重複、immich resources、postgres securityContext、observability_impact、
+  nix flake 経年、vaultwarden rate limit 等）を避け、apps/dex・apps/argocd・apps/external-secrets・
+  apps/tailscale-operator・apps/agent-rbac の未読マニフェスト、terraform の残り .tf ファイル、ops/*.py の
+  ロジック等、未踏の領域を優先するよう指示
+- 発見: apps/dex/values.yaml の `staticClients[0].secret` と apps/argocd/values.yaml の
+  `configs.cm.oidc.config.clientSecret` が、どちらも同一のリテラル文字列 `argocd-dex-client-secret` を
+  平文でハードコードし、2ファイルに重複していた。この repo の他の全 credential（Google OAuth, Tailscale
+  OAuth, vaultwarden ADMIN_TOKEN, postgres パスワード）は Doppler → ExternalSecret 経由で、CLAUDE.md の
+  方針（シークレットは SOPS 管理）にも反する例外。dex/values.yaml 自身、2行上の Google コネクタは
+  `$GOOGLE_CLIENT_ID`/`$GOOGLE_CLIENT_SECRET`（envFrom）を使っており、この1エントリだけ取り残されていた
+- 修正方式の確定のため2件目の subagent で dexidp/dex・argoproj/argo-cd の実ソースを直接確認させた。
+  重要な落とし穴を発見: dex の `$VAR` 展開は connector config にしか効かず、staticClients には効かない
+  （dexidp/dex#4212 で未実装と明示された既知のギャップ）。正しくは `idEnv`/`secretEnv` という専用フィールドで
+  env var 名を直接指定する（cmd/dex/serve.go で `os.Getenv` 呼び出しを確認）。もし `secret: $VAR` と誤って
+  書いていたら、dex はリテラル文字列 `"$VAR"` をそのまま secret として使ってしまい、気づかれないまま
+  脆弱な設定が残っていた。ArgoCD 側は `$<secret-name>:<key>` 構文（`app.kubernetes.io/part-of=argocd`
+  ラベル必須）で任意の Secret を参照でき、argocd-secret 本体には触れずに済むことも util/settings/settings.go
+  で確認した
+- 判断: Dex は全ログインの単一障害点で、envFrom が参照する Secret が無いと Pod が
+  CreateContainerConfigError で起動しなくなる（ArgoCD 側は secret 欠如でもサーバは落ちずログインのみ失敗、
+  グレースフル）。CHARTER §4『到達性を失いうる変更（Dex/OIDC, ArgoCD 自身）』に該当し、かつ Doppler への
+  新しい秘密値の登録という credential 手作業が手順の先頭に必須のため、T-0060 として起票し needs-human とした。
+  manifest 側の実装手順（ExternalSecret の作り方、values.yaml の具体的な書き換え内容、適用順序の注意）は
+  一次ソース調査の結果とあわせて notes に全て書き残し、Doppler 登録確認後にすぐ実装に移れる状態にしてある
+- 次の起動へ: T-0060 は Doppler に `DEX_ARGOCD_CLIENT_SECRET` が登録されたことを確認してから着手する
+  （手順1）。登録済みなら手順2（ExternalSecret 追加 + values.yaml 切り替え、1PR）に進んでよい。backlog の
+  todo は依然 0 件

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-05T03:30:00Z",
+  "updated": "2026-08-05T04:11:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-05T03:45:46Z"
+    "last_read": "2026-08-05T03:50:30Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -313,6 +313,14 @@
         140,
         141
       ]
+    },
+    {
+      "n": 26,
+      "at": "2026-08-05T04:11:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "前回の中断: state.json 記録済みの run #25 (#139-141) より後に #142/#143 が別セッションと思われる主体により既に merge 済みだったが journal に記述が無かった。ローカル main を追従させ prs.json キャッシュに反映。issue #56 に人間からの新規フィードバックなし（last_read 以降の唯一のコメントは run #25 自身の返信）。backlog の todo が 0 件だったため subagent 2件（発見 → 修正方式の一次ソース検証）を直列に投入し、apps/dex/values.yaml と apps/argocd/values.yaml が同一の Dex↔ArgoCD OIDC client secret を平文で2箇所に重複ハードコードしていることを発見。dexidp/dex と argoproj/argo-cd の実ソースを確認し、dex の $VAR 展開は staticClients には効かず idEnv/secretEnv という専用フィールドが必要という誤りやすい落とし穴を事前に特定できた。Dex が全ログインの単一障害点であり、Doppler への新しい秘密値の登録という credential 手作業が手順の先頭に必須のため T-0060 として起票し needs-human とした（コード変更は無し、記録更新のみ）",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

- run #26 の journal / state.json / backlog.json の記録更新（コード変更なし）
- T-0060 を起票（`needs-human`）: `apps/dex/values.yaml` の `staticClients[0].secret` と `apps/argocd/values.yaml` の `configs.cm.oidc.config.clientSecret` が、同一のリテラル文字列 `argocd-dex-client-secret` を平文でハードコードし2箇所に重複していることを発見。この repo の他の全 credential（Google OAuth, Tailscale OAuth, vaultwarden ADMIN_TOKEN, postgres パスワード）は Doppler → ExternalSecret 経由で調達しており、この1箇所だけが例外
- Doppler への新しい秘密値の登録が必要なため（credential 手作業、エージェントからは手が届かない）、T-0060 は `needs-human` とした。実装手順（dex は `secretEnv` フィールドを使う必要があり `secret: $VAR` 形式では動かないこと、ArgoCD は `$<secret-name>:<key>` 構文で `app.kubernetes.io/part-of=argocd` ラベルが必須なこと等、dexidp/dex・argoproj/argo-cd の実ソースで確認済みの内容）は `ops/backlog.json` の T-0060 に書き残してあり、Doppler 登録確認後すぐ実装に移れる
- `ops/dashboard/prs.json` のキャッシュを最新化（前回 run #25 の記録後に別セッションで merge された #142, #143 を反映）

## 検証したこと

- `python3 ops/validate.py` → 0 error（既知の warning 3件のみ、内容不変）
- `python3 ops/dashboard/build.py` → 成功、ダッシュボードを同じ URL に再公開済み

## ロールバック手順

`ops/` 配下の記録更新のみで、実インフラ・アプリケーションへの変更は無い。問題があれば本 PR を revert するだけで良い。

## backlog task id

T-0060 (needs-human, 新規起票)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQHyujLyNHtN21iMgtzngy)_