### PR TITLE
chore(nix): flake.lock を更新する（nixpkgs 2025-12-08 → 2026-08-04）

### DIFF
--- a/nix/images/proxmox-cloud/flake.lock
+++ b/nix/images/proxmox-cloud/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1763759067,
-        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765186076,
-        "narHash": "sha256-hM20uyap1a0M9d344I692r+ik4gTMyj60cQWO+hAYP8=",
+        "lastModified": 1785828668,
+        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "addf7cf5f383a3101ecfba091b98d0a1263dc9b8",
+        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1761765539,
-        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
+        "lastModified": 1785031560,
+        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
+        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765553226,
-        "narHash": "sha256-Ii16Nq5jL2wURXpV3D3tOM3vPpbKh18roHLkyZCHK4Q=",
+        "lastModified": 1783174389,
+        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "496a6f625f63b780ce849891868f2fad22fd49c6",
+        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
autopilot のサンドボックスに `nix` が無いため `needs-human` になっていた T-0049 の実行部分です。8 ヶ月分の経年放置を解消します。

## 更新内容

| input | 変更前 | 変更後 |
|---|---|---|
| nixpkgs | 2025-12-08 | **2026-08-04** |
| sops-nix | 2025-12-12 | 2026-07-04 |
| flake-parts | 2025-11-21 | 2026-08-01 |
| nixpkgs-lib | 2025-10-29 | 2026-07-26 |

## ⚠️ この更新は k3s を 1.34.2 → 1.35.6 に動かします

`configuration.nix` は `services.k3s` のバージョンを pin していないため、**nixpkgs の更新がそのまま Kubernetes のマイナー更新になります**。`nix flake check` の成功ではこれは検出できません（評価が通ることと、上げてよいことは別）。

**ただし、この PR 単体ではクラスタに一切影響しません。** 実際に届くまでに 3 段階あります。

1. `release-image` workflow を手動実行して新しいイメージをリリース
2. `nixos_image_version` / `nixos_image_checksum` を更新
3. `terraform apply`

つまり **k8s 1.35 への移行を実行するかどうかは、次にイメージをリリースする時点で改めて判断できます。** その判断材料（1.34 → 1.35 の非推奨 API がこのリポジトリの manifest に影響するか）は別タスクとして起票させます。

## 検証したこと

- `nix flake update` → 4 input すべて更新
- `nix flake check --no-build` → **all checks passed**（`nixosConfigurations.proxmox-cloud` の評価、`packages.x86_64-linux.qcow2` の derivation 解決を含む）
- k3s のバージョン差分を `nix eval` で直接確認（1.34.2+k3s1 → 1.35.6+k3s1）
- **イメージのビルド自体は行っていません。** 評価は通りますが、ビルド時にしか出ない失敗は検出できていません

## ロールバック

`git revert` で元の lock に戻ります。実インフラには影響していないため、戻しても副作用はありません。