### PR TITLE
T-0062: k3s 1.34→1.35の非推奨API影響確認、および人間merge分の記録同期

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 62,
-  "updated": "2026-08-05T04:21:00Z",
+  "next_id": 65,
+  "updated": "2026-08-05T04:40:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -555,7 +555,7 @@
       "title": "terraform bpg/proxmox provider の pin (0.89.1) を見直す（現在 v0.111.1 まで進んでいる）",
       "kind": "investigate",
       "risk": "medium",
-      "status": "needs-human",
+      "status": "done",
       "priority": 25,
       "why": "T-0005 の調査 (run #6) で判明。約 22 リリース分の差。意図的な完全一致 pin（理由コメントあり）なので、まず pin した理由が今も成り立つか確認するのが先。v0.109.0 のリリースノートに VM agent の IP 待機設定まわりの breaking change の言及がある",
       "dod": "providers.tf の pin 理由コメントを再確認し、今も成り立つか判断する。上げる場合は 0.89.1 から v0.111.1 までのリリースノートを原文で読み、breaking change を洗い出す。terraform apply は autopilot が実行できないため、実際の反映は人間の作業になる旨を PR に明記する",
@@ -565,8 +565,8 @@
         "terraform/proxmox/.terraform.lock.hcl"
       ],
       "created": "2026-08-04",
-      "pr": null,
-      "notes": "run #13: subagent に `.tf` ファイル全体（3 リソースタイプのみ使用: download_file, file, virtual_environment_vm）と v0.89.2〜v0.111.1 の CHANGELOG.md / upgrade guide を原文で照合させた。**結論: v0.111.1 への一段更新で安全、.tf ファイルの変更は不要。** 懸念されていた v0.109.0 の `agent.wait_for_ip` 反転（enabled→disabled）は、このリポジトリが `agent.wait_for_ip` を一切設定しておらず（`agent.enabled` のみ使用）、IP 出力（`node01_ip`）もハードコードされた文字列で `ipv4_addresses` を参照していないため無関係と確認。他の breaking change（network_device.enabled 非推奨、LXC cpu.units、VM/container 名の DNS 検証等）もすべて未使用のリソース/属性。providers.tf 冒頭のコメント（`完全一致 pin は nix 管理の terraform と噛み合わないため範囲指定`）は `required_version`（terraform 本体）についての説明で、`bpg/proxmox` provider の pin 理由コメントは別途存在しない（浅いクローンのため元コミットの経緯も確認できず）。terraform 本体が無いため lock file の regenerate ができず、version 変更だけでは CI が落ちる（`.terraform.lock.hcl` はハッシュの手書き生成ができない）ため needs-human とした"
+      "pr": 145,
+      "notes": "run #13: subagent に `.tf` ファイル全体（3 リソースタイプのみ使用: download_file, file, virtual_environment_vm）と v0.89.2〜v0.111.1 の CHANGELOG.md / upgrade guide を原文で照合させた。**結論: v0.111.1 への一段更新で安全、.tf ファイルの変更は不要。** 懸念されていた v0.109.0 の `agent.wait_for_ip` 反転（enabled→disabled）は、このリポジトリが `agent.wait_for_ip` を一切設定しておらず（`agent.enabled` のみ使用）、IP 出力（`node01_ip`）もハードコードされた文字列で `ipv4_addresses` を参照していないため無関係と確認。他の breaking change（network_device.enabled 非推奨、LXC cpu.units、VM/container 名の DNS 検証等）もすべて未使用のリソース/属性。providers.tf 冒頭のコメント（`完全一致 pin は nix 管理の terraform と噛み合わないため範囲指定`）は `required_version`（terraform 本体）についての説明で、`bpg/proxmox` provider の pin 理由コメントは別途存在しない（浅いクローンのため元コミットの経緯も確認できず）。terraform 本体が無いため lock file の regenerate ができず、version 変更だけでは CI が落ちる（`.terraform.lock.hcl` はハッシュの手書き生成ができない）ため needs-human とした | run #27: 人間が直接 `terraform init -upgrade` を実行し #145 として merge した。`providers.tf` を 0.111.1 に、`.terraform.lock.hcl` を再生成し、`terraform validate` が成功することを確認済み。副産物として `proxmox_virtual_environment_download_file` が v1.0 で削除予定という新しい非推奨警告が出るようになったと判明。state 移行を伴うため PR には含めず「issue #56 経由で別タスクとして起票させる」と PR 本文に明記されていたため T-0064 として起票した"
     },
     {
       "id": "T-0031",
@@ -881,7 +881,7 @@
       "title": "nix/images/proxmox-cloud/flake.lock（nixpkgs 等）を `nix flake update` で最新化してほしい",
       "kind": "upgrade",
       "risk": "medium",
-      "status": "needs-human",
+      "status": "done",
       "priority": 28,
       "why": "backlog の todo が 0 件だったため CHARTER §3 の調査（run #18）。`ops/inventory.json` の nixpkgs エントリは `policy: manual` かつ『離散リリースが無いので T-0005/T-0040 の対象外』とされているが、これは経年チェックそのものも免除している訳ではなかった。`flake.lock` に埋め込まれた `locked.lastModified` を実際に読むと、4 入力（flake-parts, nixpkgs, nixpkgs-lib, sops-nix）とも 2025-11〜12 更新止まりで、今日時点で約 8 ヶ月放置されている。離散リリースが無いことを理由に誰も経年を見ていなかっただけで、CLAUDE.md の Maintenance 節にある vaultwarden 放置（#49）と同型のリスク（気づかれないまま塩漬けになる）に該当する",
       "dod": "`nix/images/proxmox-cloud` で `nix flake update` を実行し、更新後の `flake.lock` をコミットする。CI（`nix flake check`）が green であることを確認する。configuration.nix / k3s-manifests.nix が参照する NixOS モジュールオプションに 8 ヶ月分の破壊的変更が無いか目視で確認する（nixos-unstable のリリースノート相当は無いため、`nixpkgs` の変更ログではなく実際に使っているオプション — `proxmox.cloudInit`, `services.cloud-init`, `services.k3s` 相当, `sops` 等 — の evaluation が通ることで代用可）。実機（node01）へは自動反映されない（CLAUDE.md: NixOS イメージのビルド・入れ替えは手動運用）ため、イメージの再ビルド・差し替え自体は別途人間の判断でよい",
@@ -891,8 +891,8 @@
         "ops/inventory.json"
       ],
       "created": "2026-08-05",
-      "pr": null,
-      "notes": "run #18: flake.lock の `locked.lastModified`（unix epoch）を4入力とも確認し、2025-11-21〜2025-12-12 止まりと判明。T-0040 の DoD に『manual policy かつ離散リリース無しの対象も経年チェックだけは行う』を追記し、今後は自動的に再検出されるようにした"
+      "pr": 146,
+      "notes": "run #18: flake.lock の `locked.lastModified`（unix epoch）を4入力とも確認し、2025-11-21〜2025-12-12 止まりと判明。T-0040 の DoD に『manual policy かつ離散リリース無しの対象も経年チェックだけは行う』を追記し、今後は自動的に再検出されるようにした | run #27: 人間が直接 `nix flake update` を実行し #146 として merge した（needs-human の引き継ぎ経路を経ず、人間がこの起動の前に直接対応）。nixpkgs 2025-12-08→2026-08-04 ほか3入力を更新、`nix flake check --no-build` が green であることを確認済み。副作用として `services.k3s` が 1.34.2+k3s1 → 1.35.6+k3s1 に上がることが判明（configuration.nix が k3s バージョンを pin していないため）。この bump 自体は次のイメージリリース（人間の手動操作、release-image workflow → terraform apply）まで実インフラに影響しない。PR 本文で人間からの依頼どおり、影響確認を T-0062 として起票した"
     },
     {
       "id": "T-0050",
@@ -1113,6 +1113,61 @@
       "created": "2026-08-05",
       "pr": 147,
       "notes": "run #27: (1) CHARTER §7.2『時刻表記』を新設。journal 見出し例を JST に更新、dashboard/build.py に JST = timezone(timedelta(hours=9)) を定義し generated/ガント目盛り/ツールチップを JST 表示に変更（rel_time() は相対表示のため対象外、変更なし）。(2) CHARTER §4 に『残った不確実性は同じ PR で backlog にも needs-human タスクとして起票する』運用を追記。(3) #100 の実機確認結果（DNS 解決 OK）を tailscale-operator-chart / k8s-nameserver の note に追記。#100 の PR 本文にあったもう1点（admissionregistration.k8s.io/v1）は未使用機能のため実害なしのまま据え置き、新規タスクは起票していない（人間の報告で既に決着済みのため）"
+    },
+    {
+      "id": "T-0062",
+      "domain": "homelab",
+      "title": "k3s 1.34.2 → 1.35.6（nixpkgs flake.lock 更新 #146 に伴う）の非推奨/削除APIが apps/ に影響しないか確認する",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "done",
+      "priority": 15,
+      "why": "PR #146（人間が直接実施した nixpkgs flake.lock 更新）で、configuration.nix が services.k3s のバージョンを pin していないため、次のイメージリリース時に k3s が 1.34.2→1.35.6 のマイナー更新として反映されることが判明した。PR 本文で人間から『判断材料は別タスクとして起票させる』と明記されていたため、apps/ 配下の manifest が 1.35 の非推奨/削除 API に影響を受けないか確認する。この PR #146 単体は実インフラに影響しない（イメージ再ビルド・terraform apply は別途人間の判断）",
+      "dod": "k8s 1.34→1.35 の deprecation guide / release notes を原文で確認し、apps/ 配下で使用中の apiVersion/kind・feature-gate 依存フィールドと照合する。影響があれば個別の修正タスクを起票する。影響がなければ結論を journal/backlog に記録する。このタスク自体は manifest を変更しない（調査のみ）",
+      "refs": [
+        "apps/",
+        "nix/images/proxmox-cloud/configuration.nix",
+        "nix/images/proxmox-cloud/k3s-manifests.nix"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #27: subagent に k8s 1.35 の公式リリースノート・deprecation guide の原文確認と、apps/ 全 8 アプリ・nix/images/proxmox-cloud の全 manifest とのクロスチェックを実施させた。結論: apps/ 配下で使われている apiVersion/kind（v1, apps/v1, rbac.authorization.k8s.io/v1, networking.k8s.io/v1, external-secrets.io/v1, tailscale.com/v1alpha1, argoproj.io/v1alpha1, helm.cattle.io/v1 等）はいずれも 1.35 の削除対象と無関係で、manifest 側の変更は不要。1.35 で唯一の破壊的変更は cgroup v1 サポート除去（KEP-5573、kubelet がノード起動時に cgroup v1 なら起動を拒否）で、これはノード/OS レベルの話であり manifest には現れない。nix/ 配下に cgroup ドライバ/バージョンの明示指定が無く NixOS/systemd の既定（v2 のはず）に暗黙依存しているため、実機確認が要る点のみ T-0063（needs-human）として切り出した。副次的な forward note（1.35 が containerd 1.x サポートの最終版、次のホップ k3s 1.36 で containerd 2.x が必須になる）は ops/inventory.json の nixpkgs エントリに記録した"
+    },
+    {
+      "id": "T-0063",
+      "domain": "homelab",
+      "title": "node01 が cgroup v2 で動いているか実機で確認してほしい（k3s 1.35 移行の前提条件）",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "needs-human",
+      "priority": 15,
+      "why": "T-0062 の調査で判明。k8s 1.35 の kubelet は cgroup v1 のノードで起動を拒否する破壊的変更が入っている（KEP-5573, failCgroupV1 既定 true）。nix/ 配下に cgroup ドライバ/バージョンの明示的な指定が無く、NixOS/systemd の既定（v2 のはず）に暗黙依存している。次に NixOS イメージを再ビルド・適用して k3s が 1.35 系に上がったとき、もし node01 が何らかの理由で cgroup v1 のままだと kubelet がまったく起動せずクラスタ全断になる（軟着陸できる警告ではなくハード失敗）",
+      "dod": "node01 で `stat -fc %T /sys/fs/cgroup`（`cgroup2fs` であること）または `mount | grep cgroup2` を実行し、cgroup v2 であることを確認する。確認結果を journal か docs/node01-storage.md 相当の場所に記録する。v1 だった場合は、イメージ更新前に cgroup v2 への切り替え手順を別途検討する",
+      "needs_human_reason": "node01 への到達（Tailscale 経由の SSH や Proxmox コンソール）が必要で、autopilot のクラウドサンドボックスは homelab 実機に到達できない（CHARTER §5.2）",
+      "refs": [
+        "nix/images/proxmox-cloud/configuration.nix"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #27: T-0062 の調査で発見。CHARTER §4（issue #56, 2026-08-05 04:18:44 の運用）に従い、実機確認が要る不確実性を独立した needs-human タスクとして起票した"
+    },
+    {
+      "id": "T-0064",
+      "domain": "homelab",
+      "title": "terraform: proxmox_virtual_environment_download_file → proxmox_download_file へのリソース改名に対応する（v1.0で削除予定の非推奨警告）",
+      "kind": "refactor",
+      "risk": "medium",
+      "status": "todo",
+      "priority": 30,
+      "why": "T-0030（#145, bpg/proxmox provider 0.89.1→0.111.1 更新）で新たに出るようになった非推奨警告。`proxmox_virtual_environment_download_file` は `proxmox_download_file` に改名され、旧リソース名は provider v1.0 で削除される予定。terraform/proxmox/vm-nixos.tf と terraform/proxmox/nixos-image.tf の2ファイルで使用中。リソースアドレスの変更を伴うため `moved` ブロックか `terraform state mv` による state 移行が必要で、#145 の PR 本文で人間から明示的に『issue #56 経由で別タスクとして起票させる』と依頼された",
+      "dod": "bpg/proxmox provider が新旧リソース間の state migration をどう扱うか（`moved` ブロックでのリソースタイプ変更をサポートしているか、provider の実ソース/CHANGELOG/upgrade guide で確認する）を調べる。安全に移行できる方法が分かれば `.tf` に反映し、`terraform validate`（CI, `-backend=false`）で構文エラーが無いことを確認する。**実際の state migration の反映確認（`terraform plan`/`apply`）は autopilot のサンドボックスに terraform CLI が無く実行できないため、反映確認は人間の作業になる旨を PR 本文に明記する**（T-0030 と同型の制約）",
+      "refs": [
+        "terraform/proxmox/vm-nixos.tf",
+        "terraform/proxmox/nixos-image.tf"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #27: #145（T-0030 の実行部分、人間が直接 terraform init -upgrade して merge）の PR 本文の依頼により起票"
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1130,7 +1130,7 @@
         "nix/images/proxmox-cloud/k3s-manifests.nix"
       ],
       "created": "2026-08-05",
-      "pr": null,
+      "pr": 148,
       "notes": "run #27: subagent に k8s 1.35 の公式リリースノート・deprecation guide の原文確認と、apps/ 全 8 アプリ・nix/images/proxmox-cloud の全 manifest とのクロスチェックを実施させた。結論: apps/ 配下で使われている apiVersion/kind（v1, apps/v1, rbac.authorization.k8s.io/v1, networking.k8s.io/v1, external-secrets.io/v1, tailscale.com/v1alpha1, argoproj.io/v1alpha1, helm.cattle.io/v1 等）はいずれも 1.35 の削除対象と無関係で、manifest 側の変更は不要。1.35 で唯一の破壊的変更は cgroup v1 サポート除去（KEP-5573、kubelet がノード起動時に cgroup v1 なら起動を拒否）で、これはノード/OS レベルの話であり manifest には現れない。nix/ 配下に cgroup ドライバ/バージョンの明示指定が無く NixOS/systemd の既定（v2 のはず）に暗黙依存しているため、実機確認が要る点のみ T-0063（needs-human）として切り出した。副次的な forward note（1.35 が containerd 1.x サポートの最終版、次のホップ k3s 1.36 で containerd 2.x が必須になる）は ops/inventory.json の nixpkgs エントリに記録した"
     },
     {

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,34 @@
   "open": [],
   "merged": [
     {
+      "number": 147,
+      "title": "T-0061: 時刻表示のJST化と、残った不確実性のbacklog追跡",
+      "url": "https://github.com/hikuohiku/homelab/pull/147",
+      "mergedAt": "2026-08-05T04:25:47Z",
+      "headRefName": "autopilot/T-0061-jst-time-and-uncertainty-tracking"
+    },
+    {
+      "number": 146,
+      "title": "chore(nix): flake.lock を更新する（nixpkgs 2025-12-08 → 2026-08-04）",
+      "url": "https://github.com/hikuohiku/homelab/pull/146",
+      "mergedAt": "2026-08-05T04:24:50Z",
+      "headRefName": "autopilot/T-0049-nix-flake-update"
+    },
+    {
+      "number": 145,
+      "title": "chore(terraform): bpg/proxmox provider を 0.89.1 → 0.111.1 に上げる",
+      "url": "https://github.com/hikuohiku/homelab/pull/145",
+      "mergedAt": "2026-08-05T04:22:12Z",
+      "headRefName": "autopilot/T-0030-tf-provider-0.111.1"
+    },
+    {
+      "number": 144,
+      "title": "ops: run #26 の記録をまとめ、T-0060 を起票する",
+      "url": "https://github.com/hikuohiku/homelab/pull/144",
+      "mergedAt": "2026-08-05T04:14:29Z",
+      "headRefName": "autopilot/T-0060-dex-argocd-secret-plaintext"
+    },
+    {
       "number": 143,
       "title": "feat(ops): ダッシュボードにストリーム分類とガントを追加する",
       "url": "https://github.com/hikuohiku/homelab/pull/143",
@@ -33,7 +61,7 @@
       "number": 139,
       "title": "ops: issue #56 のフィードバックを反映する (T-0059)",
       "url": "https://github.com/hikuohiku/homelab/pull/139",
-      "mergedAt": "2026-08-05T03:53:59Z",
+      "mergedAt": "2026-08-05T03:53:48Z",
       "headRefName": "autopilot/T-0059-feedback-cooldown-pagination"
     },
     {
@@ -392,34 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/87",
       "mergedAt": "2026-08-04T21:13:05Z",
       "headRefName": "autopilot/t-0013-pbs-backup-inventory"
-    },
-    {
-      "number": 86,
-      "title": "weekly-maintenance と CHARTER の役割を分ける (T-0009)",
-      "url": "https://github.com/hikuohiku/homelab/pull/86",
-      "mergedAt": "2026-08-04T21:08:55Z",
-      "headRefName": "autopilot/t-0009-weekly-maintenance-charter-roles"
-    },
-    {
-      "number": 85,
-      "title": "CI に nix flake check を追加する (T-0008)",
-      "url": "https://github.com/hikuohiku/homelab/pull/85",
-      "mergedAt": "2026-08-04T21:05:33Z",
-      "headRefName": "autopilot/t-0008-nix-flake-check-ci"
-    },
-    {
-      "number": 84,
-      "title": "ops/validate.py: git のコンフリクトマーカー残留を検出する (T-0033)",
-      "url": "https://github.com/hikuohiku/homelab/pull/84",
-      "mergedAt": "2026-08-04T20:54:36Z",
-      "headRefName": "autopilot/t-0033-conflict-marker-detection"
-    },
-    {
-      "number": 83,
-      "title": "fix(ops): ダッシュボードの数字が嘘をつかないようにする",
-      "url": "https://github.com/hikuohiku/homelab/pull/83",
-      "mergedAt": "2026-08-04T20:50:52Z",
-      "headRefName": "autopilot/fix-dashboard-numbers"
     }
   ]
 }

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -183,7 +183,7 @@
       "match": "nixpkgs",
       "upstream": "github:NixOS/nixpkgs",
       "policy": "manual",
-      "note": "unstable 追従。更新は NixOS イメージの再ビルド + node01 の入れ替えを伴うので人間へ"
+      "note": "unstable 追従。更新は NixOS イメージの再ビルド + node01 の入れ替えを伴うので人間へ。2026-08-05: 人間が nix flake update を実行（2025-12-08→2026-08-04、#146）。configuration.nix が services.k3s のバージョンを pin していないため、この更新が次のイメージリリース時に k3s 1.34.2→1.35.6 のマイナー更新として反映される。影響確認は T-0062（apps/ の manifest には影響なしと確認済み、node01 の cgroup v2 確認のみ T-0063 needs-human として残る）。次のホップ（k3s 1.36 系）では containerd 2.x が必須になる（1.35 が containerd 1.x をサポートする最終版）ため、その時点で改めて確認が要る"
     },
     {
       "id": "tf-provider-proxmox",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -806,6 +806,22 @@
     ops/inventory.json の tailscale-operator-chart/k8s-nameserver に実機確認済みの事実を追記。
     あわせて『PR の残った不確実性は同じ PR で backlog に needs-human タスクとして起票する』運用を
     CHARTER §4 に追加（今後は PR 本文に埋もれさせない）
-- やったこと: T-0061（上記2件の反映、#未確定→PR作成後に確定）
-- 次の起動へ: T-0060 は Doppler に `DEX_ARGOCD_CLIENT_SECRET` が登録されたか確認してから着手
-  （変更なし）。backlog の todo は T-0061 消化後は 0 件に戻る見込み
+- やったこと: T-0061（上記2件の反映、#147, auto-merged）
+- 前回の中断（続き）: #147 merge 後に main を追従したところ、#146（`chore(nix): flake.lock を更新する`）が
+  T-0049（nix flake update, needs-human）の作業として人間により直接 merge 済みだと判明した。backlog の
+  T-0049 が `needs-human` のまま乖離していたため `done`（pr: 146）に修正。#146 の PR 本文で人間から
+  「k3s 1.34.2→1.35.6 のマイナー更新が次のイメージリリース時に反映される影響確認は別タスクとして
+  起票させる」と明記されていたため、T-0062 として起票しその場で着手した
+- T-0062: subagent に k8s 1.35 の deprecation guide 原文確認と apps/ 全 8 アプリの manifest との
+  クロスチェックを行わせた。結論: apps/ の manifest 変更は不要（削除対象 API を使用している箇所なし）。
+  1.35 唯一の破壊的変更は cgroup v1 サポート除去（kubelet がノード起動時に拒否）で、nix/ 側に
+  明示指定が無く NixOS/systemd の既定（v2 のはず）に暗黙依存しているため、実機確認のみ T-0063
+  （needs-human）として切り出した。次のホップ（k3s 1.36、containerd 2.x 必須化）の forward note は
+  inventory.json の nixpkgs エントリに記録済み
+- 追加発見: T-0030（terraform bpg/proxmox provider 更新、needs-human）も同様に人間が直接 #145 として
+  merge 済みだったのに backlog が乖離していたため done（pr: 145）に修正。#145 の PR 本文で
+  「`proxmox_virtual_environment_download_file` が provider v1.0 で削除予定という新しい非推奨警告が
+  出るようになった、state 移行が要るので別タスクとして起票してほしい」と依頼されていたため T-0064 として
+  起票（todo、terraform CLI が無いため移行方法の調査までがこの起動でできる範囲）
+- 次の起動へ: T-0060（Dex/ArgoCD の OIDC secret、Doppler 登録待ち）・T-0063（node01 の cgroup v2 実機確認）
+  が needs-human で残っている。backlog の todo は T-0064（terraform リソース改名対応）の1件

--- a/ops/state.json
+++ b/ops/state.json
@@ -331,7 +331,8 @@
       "by": "cloud routine",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 の未読フィードバック2件を反映: (1) 時刻表記はJSTがいいという指摘を受け CHARTER §7.2 を新設し、journal 見出し・ダッシュボードの人間向け表示を JST に変更（内部データは UTC のまま）。(2) #100（tailscale-operator/k8s-nameserver）が実機で問題なかったという報告を受け inventory.json に確認済みの事実を記録し、『PR の残った不確実性は同じ PR で backlog に needs-human タスクとして起票する』運用を CHARTER §4 に追加した（T-0061, #147, auto-merged）。#147 merge 後、T-0049（nix flake update）と T-0030（terraform provider 更新）の2件が人間により直接 #146・#145 として merge 済みだったが、どちらも backlog が needs-human のまま乖離していたのを発見し done に修正。#146 の PR 本文の依頼どおり、伴う k3s 1.34.2→1.35.6 の影響確認を T-0062 として起票・subagent で調査し apps/ への影響なしと確認（manifest 変更不要）。唯一の懸念点（node01 の cgroup v2 実機確認）は T-0063 として needs-human に切り出した。#145 の PR 本文の依頼どおり、新たに出るようになった非推奨警告（proxmox_virtual_environment_download_file の改名）を T-0064 として起票した",
       "prs": [
-        147
+        147,
+        148
       ]
     }
   ]

--- a/ops/state.json
+++ b/ops/state.json
@@ -320,14 +320,16 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "前回の中断: state.json 記録済みの run #25 (#139-141) より後に #142/#143 が別セッションと思われる主体により既に merge 済みだったが journal に記述が無かった。ローカル main を追従させ prs.json キャッシュに反映。issue #56 に人間からの新規フィードバックなし（last_read 以降の唯一のコメントは run #25 自身の返信）。backlog の todo が 0 件だったため subagent 2件（発見 → 修正方式の一次ソース検証）を直列に投入し、apps/dex/values.yaml と apps/argocd/values.yaml が同一の Dex↔ArgoCD OIDC client secret を平文で2箇所に重複ハードコードしていることを発見。dexidp/dex と argoproj/argo-cd の実ソースを確認し、dex の $VAR 展開は staticClients には効かず idEnv/secretEnv という専用フィールドが必要という誤りやすい落とし穴を事前に特定できた。Dex が全ログインの単一障害点であり、Doppler への新しい秘密値の登録という credential 手作業が手順の先頭に必須のため T-0060 として起票し needs-human とした（コード変更は無し、記録更新のみ）",
-      "prs": []
+      "prs": [
+        144
+      ]
     },
     {
       "n": 27,
       "at": "2026-08-05T04:21:00Z",
       "kind": "scheduled",
       "by": "cloud routine",
-      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 の未読フィードバック2件を反映: (1) 時刻表記はJSTがいいという指摘を受け CHARTER §7.2 を新設し、journal 見出し・ダッシュボードの人間向け表示を JST に変更（内部データは UTC のまま）。(2) #100（tailscale-operator/k8s-nameserver）が実機で問題なかったという報告を受け inventory.json に確認済みの事実を記録し、『PR の残った不確実性は同じ PR で backlog に needs-human タスクとして起票する』運用を CHARTER §4 に追加した（T-0061）",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 の未読フィードバック2件を反映: (1) 時刻表記はJSTがいいという指摘を受け CHARTER §7.2 を新設し、journal 見出し・ダッシュボードの人間向け表示を JST に変更（内部データは UTC のまま）。(2) #100（tailscale-operator/k8s-nameserver）が実機で問題なかったという報告を受け inventory.json に確認済みの事実を記録し、『PR の残った不確実性は同じ PR で backlog に needs-human タスクとして起票する』運用を CHARTER §4 に追加した（T-0061, #147, auto-merged）。#147 merge 後、T-0049（nix flake update）と T-0030（terraform provider 更新）の2件が人間により直接 #146・#145 として merge 済みだったが、どちらも backlog が needs-human のまま乖離していたのを発見し done に修正。#146 の PR 本文の依頼どおり、伴う k3s 1.34.2→1.35.6 の影響確認を T-0062 として起票・subagent で調査し apps/ への影響なしと確認（manifest 変更不要）。唯一の懸念点（node01 の cgroup v2 実機確認）は T-0063 として needs-human に切り出した。#145 の PR 本文の依頼どおり、新たに出るようになった非推奨警告（proxmox_virtual_environment_download_file の改名）を T-0064 として起票した",
       "prs": [
         147
       ]


### PR DESCRIPTION
## 変更点

コード変更（manifest / terraform / nix）は含みません。すべて `ops/` の記録更新です。

1. **T-0062: k3s 1.34.2→1.35.6 の非推奨/削除API影響確認**（#146 の PR 本文の依頼）
   - `#146`（人間が直接実行した `nix flake update`）で、次のイメージリリース時に k3s が 1.34.2→1.35.6 に上がることが判明。PR 本文で「判断材料は別タスクとして起票させる」と依頼されていたため T-0062 として起票し、その場で subagent に k8s 1.35 の deprecation guide 原文確認と `apps/` 全マニフェストとのクロスチェックをさせた
   - **結論: `apps/` の manifest 変更は不要。** 1.35 で唯一の破壊的変更（cgroup v1 サポート除去、kubelet がノード起動時に拒否）はノード/OSレベルの話で manifest には現れない
   - 唯一の懸念点（node01 が実際に cgroup v2 で動いているかの実機確認）は T-0063（needs-human）として切り出した
   - 次のホップ（k3s 1.36、containerd 2.x 必須化）向けの forward note は `ops/inventory.json` の nixpkgs エントリに記録した

2. **人間が直接 merge した2件の記録同期**
   - T-0049（nix flake update）が `#146` として、T-0030（terraform provider 0.89.1→0.111.1）が `#145` として、それぞれ人間により直接 merge 済みだったが、backlog がどちらも `needs-human` のまま乖離していたのを発見し `done` に修正した
   - `#145` の PR 本文の依頼（`proxmox_virtual_environment_download_file` が provider v1.0 で削除予定という新しい非推奨警告が出るようになった、state 移行を伴うので別タスクにしてほしい）を受け、T-0064 として起票した（todo。terraform CLI が無いため、この起動では移行方法の調査までが限界）

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 例外なく生成、Artifact に再公開予定
- `ops/dashboard/prs.json` を `mcp__github__list_pull_requests` で最新化（#145/#146 を含む直近マージ分を反映）

## ロールバック手順

`ops/` 配下の記録のみで、実インフラ・アプリケーションへの変更は無い。問題があれば本 PR を revert するだけでよい。

## backlog task id

T-0062（完遂）、T-0049/T-0030（記録同期のみ）、T-0064（新規起票、未着手）

---
_Generated by [Claude Code](https://claude.ai/code/session_01FodZXUmKeNLCebUoGsRBhf)_