### PR TITLE
T-0011: vaultwarden ADMIN_TOKEN の Argon2 PHC 化を完了扱いにする

### DIFF
--- a/Maintenance.md
+++ b/Maintenance.md
@@ -29,7 +29,11 @@ vaultwarden 1.36.0 の据え置きにより、web 以外の全クライアント
 - ノードのディスク空き 4.23GB / 20GB。3GB を切る前に対処。Plans.md M2 もこれで停止中
   → **解消（2026-08-04）**: node01 を 256 GiB へ拡張（上記エントリ参照）。M2 の保留理由は
     P2P 特性の移行可否検討のみに変更（Plans.md 反映済み）
-- `ADMIN_TOKEN` が平文（起動ログに警告）。Argon2 PHC 化は今回見送り → `ops/backlog.json` T-0011（needs-human、Doppler への登録待ち）
+- `ADMIN_TOKEN` が平文（起動ログに警告）。Argon2 PHC 化は今回見送り → **解消（2026-08-05）**:
+  人間が Doppler の `VAULTWARDEN_ADMIN_TOKEN` を Argon2 PHC 文字列に差し替えた。
+  `apps/vaultwarden/admin-token-external-secret.yaml` は既にこのキーを参照しており、vaultwarden 側も
+  PHC 形式を自動判別するため manifest の変更は不要だった（`ops/backlog.json` T-0011, done）。
+  反映後に `/admin` へログインできるかの確認は人間側の作業として残る
 - 1.37.0 でレート制限が追加された。全クライアントが Tailscale プロキシ経由で同一
   送信元 IP に見えるため、429 が出ないか要確認 → **解消（2026-08-05）**: 懸念どおり、
   Tailscale Ingress はリバースプロキシとして自 Pod から接続するため raw peer IP は全クライアントで

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -186,7 +186,7 @@
       "title": "vaultwarden の ADMIN_TOKEN を Argon2 ハッシュ化する（Doppler への登録をお願いしたい）",
       "kind": "security",
       "risk": "high",
-      "status": "needs-human",
+      "status": "done",
       "priority": 11,
       "why": "Maintenance.md 2026-08-03 の持ち越し。Argon2 PHC 形式へのハッシュ化が見送られたまま",
       "dod": "ADMIN_TOKEN が Argon2 PHC ハッシュとして保存されている、または admin パネル自体が無効化されている",
@@ -196,7 +196,8 @@
         "apps/vaultwarden/"
       ],
       "created": "2026-08-04",
-      "pr": null
+      "pr": null,
+      "notes": "run #29: issue #56 (2026-08-05 04:51:25、構築セッション経由) で人間が Doppler の VAULTWARDEN_ADMIN_TOKEN を Argon2 PHC 文字列に差し替えたと報告。apps/vaultwarden/admin-token-external-secret.yaml は既に同じキーを参照しており vaultwarden 側も PHC 形式を自動判別するため manifest 変更は不要。PR を伴わないタスク完了のため pr は null のまま。反映後に /admin へログインできるかの実機確認は人間側に残った（Maintenance.md に記載）"
     },
     {
       "id": "T-0012",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -868,3 +868,13 @@
   （terraform plan CI 化調査）の2件。次はこれを進める
 - 次の起動へ: T-0060（Dex/ArgoCD OIDC secret）・T-0063（cgroup v2）・T-0066・T-0067 が needs-human。
   backup 系タスク（T-0068〜T-0072）は T-0067 のクレデンシャル待ちで直列にブロックされている
+
+## 2026-08-05 14:19 JST — run #29
+
+- 前回の中断: オープン PR・autopilot ブランチとも無く中断なし（ローカル `origin/main` の参照キャッシュが
+  #150 より古いまま残っていたため `git fetch origin main` で追従。run #25 と同型の事象）
+- issue #56 の未読フィードバック1件（04:51:25、構築セッション経由）のうち T-0011 分を反映:
+  T-0011（vaultwarden ADMIN_TOKEN）→ 人間が Doppler の `VAULTWARDEN_ADMIN_TOKEN` を Argon2 PHC
+  文字列に差し替え済み。manifest 側の変更は不要（ExternalSecret は既存キーを参照、vaultwarden も
+  PHC を自動判別）と確認し `done` にした（PR なし、backlog notes に理由記載。`Maintenance.md` の
+  2026-08-03 持ち越し項目も解消済みとして更新）


### PR DESCRIPTION
## 変更点

- `ops/backlog.json` T-0011 を `needs-human` → `done` に変更（manifest 側の変更は無し）
- `Maintenance.md` の 2026-08-03 持ち越し項目（ADMIN_TOKEN 平文）を解消済みとして更新

## 背景

issue #56（2026-08-05 04:51:25、構築セッション経由）で、人間が Doppler の
`VAULTWARDEN_ADMIN_TOKEN` を Argon2 PHC 文字列に差し替えたと報告があった。
`apps/vaultwarden/admin-token-external-secret.yaml` は既にこのキーを参照しており、
vaultwarden 本体も PHC 形式を自動判別するため、manifest の変更は不要と判断した。
ExternalSecret の `refreshInterval: 1h` で Doppler 側の新しい値が自動的に反映される。

## 検証したこと

- `apps/vaultwarden/admin-token-external-secret.yaml` の `remoteRef.key` が `VAULTWARDEN_ADMIN_TOKEN`
  のままで変更不要であることを確認
- `python3 ops/validate.py` → 0 error（T-0011 が pr なしで done になったことに対する warning が
  1件出るが、これは想定どおりの状態）

## 残った不確実性

- 反映後に `/admin` パネルへログインできるかは、このクラウド実行環境からは確認できない。
  `Maintenance.md` に「人間に確認してほしいこと」として明記した（新規タスクの起票はしない —
  確認自体は人間側の一度きりの動作確認であり、恒常的な監視対象ではないため）

## ロールバック手順

- `ops/backlog.json` の T-0011 を `needs-human` に戻し、`Maintenance.md` の当該行を revert すれば元に戻る。
  manifest 変更が無いため実インフラへの影響は無い

backlog task id: T-0011

---
_Generated by [Claude Code](https://claude.ai/code/session_012QAq7mJt1a8nA62iZn7hbN)_