### PR TITLE
T-0015: ArgoCD/k8s の健全性を homelab から repo へ書き戻す CronJob を追加

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -147,7 +147,8 @@ apps/
 ├── tailscale-operator/
 ├── immich/
 ├── vaultwarden/
-└── coder/
+├── coder/
+└── ops-health-reporter/
 ```
 
 各アプリは以下の構造:

--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -10,4 +10,5 @@ resources:
   - immich/application.yaml
   - vaultwarden/application.yaml
   - coder/application.yaml
+  - ops-health-reporter/application.yaml
 

--- a/apps/ops-health-reporter/application.yaml
+++ b/apps/ops-health-reporter/application.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ops-health-reporter
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/hikuohiku/homelab.git
+    targetRevision: HEAD
+    path: apps/ops-health-reporter
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ops-health-reporter
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/ops-health-reporter/cronjob.yaml
+++ b/apps/ops-health-reporter/cronjob.yaml
@@ -1,0 +1,72 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ops-health-reporter
+  namespace: ops-health-reporter
+spec:
+  # autopilot は1時間ごとに起動するため、それより短い周期でクラスタ側の状態を先に
+  # 更新しておく。前回実行が長引いても重ならないよう concurrencyPolicy: Forbid にする
+  schedule: "*/30 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 120
+      template:
+        spec:
+          serviceAccountName: ops-health-reporter
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: report
+              image: python:3.12-alpine
+              command: ["python", "/scripts/report.py"]
+              env:
+                - name: GITHUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: github-health-reporter-token
+                      key: token
+                - name: GITHUB_REPO
+                  value: hikuohiku/homelab
+                - name: REPORT_BRANCH
+                  value: ops-health-report
+                - name: BASE_BRANCH
+                  value: main
+                - name: PYTHONDONTWRITEBYTECODE
+                  value: "1"
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              # このジョブが実際に使うメモリは JSON を組み立てて HTTP でやり取りする程度で
+              # 数十MB規模に収まる見込み。256Mi は実測ではなく「暴走しても他 Pod を巻き込まない」
+              # 目的の緩い上限（CHARTER §4「縛る変更には実測か裏付けが要る」— 実使用量に張り付いた
+              # 値ではないため、OOMKill を誘発するリスクは低いと判断した）
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: script
+              configMap:
+                name: ops-health-reporter-script
+            - name: tmp
+              emptyDir: {}

--- a/apps/ops-health-reporter/external-secret.yaml
+++ b/apps/ops-health-reporter/external-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-health-reporter-token
+  namespace: ops-health-reporter
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler
+  target:
+    name: github-health-reporter-token
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: token
+      remoteRef:
+        key: GITHUB_HEALTH_REPORTER_TOKEN

--- a/apps/ops-health-reporter/kustomization.yaml
+++ b/apps/ops-health-reporter/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - rbac.yaml
+  - external-secret.yaml
+  - cronjob.yaml
+
+configMapGenerator:
+  - name: ops-health-reporter-script
+    namespace: ops-health-reporter
+    files:
+      - report.py
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/apps/ops-health-reporter/namespace.yaml
+++ b/apps/ops-health-reporter/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ops-health-reporter

--- a/apps/ops-health-reporter/rbac.yaml
+++ b/apps/ops-health-reporter/rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ops-health-reporter
+  namespace: ops-health-reporter
+---
+# autopilot (クラウドサンドボックス) が読める場所に、クラスタの状態を書き戻すための
+# 読み取り専用ロール。get/list のみで write 系動詞は一切含まない。
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ops-health-reporter-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "persistentvolumeclaims", "nodes"]
+    verbs: ["get", "list"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ops-health-reporter-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ops-health-reporter-reader
+subjects:
+  - kind: ServiceAccount
+    name: ops-health-reporter
+    namespace: ops-health-reporter

--- a/apps/ops-health-reporter/report.py
+++ b/apps/ops-health-reporter/report.py
@@ -1,0 +1,218 @@
+"""クラスタ内から ArgoCD/Pod/PVC/Node の状態を集め、GitHub の専用ブランチへ書き戻す。
+
+標準ライブラリのみで動く（イメージに pip install を要求しない）。
+k8s API へは ServiceAccount トークン（自動マウント）、GitHub API へは
+Doppler 経由の GITHUB_HEALTH_REPORTER_TOKEN（Contents: Read and write のみ）で到達する。
+"""
+
+import base64
+import datetime
+import json
+import os
+import ssl
+import urllib.error
+import urllib.request
+
+SA_DIR = "/var/run/secrets/kubernetes.io/serviceaccount"
+K8S_HOST = os.environ.get("KUBERNETES_SERVICE_HOST", "kubernetes.default.svc")
+K8S_PORT = os.environ.get("KUBERNETES_SERVICE_PORT", "443")
+K8S_BASE = "https://{}:{}".format(K8S_HOST, K8S_PORT)
+
+with open(os.path.join(SA_DIR, "token")) as f:
+    SA_TOKEN = f.read().strip()
+SSL_CTX = ssl.create_default_context(cafile=os.path.join(SA_DIR, "ca.crt"))
+
+
+def k8s_get(path):
+    req = urllib.request.Request(
+        K8S_BASE + path, headers={"Authorization": "Bearer " + SA_TOKEN}
+    )
+    with urllib.request.urlopen(req, context=SSL_CTX, timeout=15) as resp:
+        return json.load(resp)
+
+
+def collect(fn):
+    try:
+        return fn()
+    except Exception as e:  # noqa: BLE001 — レポートの1項目が壊れても残りは出したい
+        return {"error": "{}: {}".format(type(e).__name__, e)}
+
+
+def collect_applications():
+    data = k8s_get("/apis/argoproj.io/v1alpha1/applications")
+    out = []
+    for item in data.get("items", []):
+        meta = item.get("metadata", {})
+        status = item.get("status", {})
+        out.append(
+            {
+                "name": meta.get("name"),
+                "namespace": meta.get("namespace"),
+                "sync": status.get("sync", {}).get("status"),
+                "health": status.get("health", {}).get("status"),
+            }
+        )
+    return out
+
+
+def collect_pod_issues():
+    data = k8s_get("/api/v1/pods")
+    issues = []
+    for item in data.get("items", []):
+        meta = item.get("metadata", {})
+        status = item.get("status", {})
+        phase = status.get("phase")
+        cs_list = status.get("containerStatuses") or []
+        restarts = sum(cs.get("restartCount", 0) for cs in cs_list)
+        waiting_reasons = [
+            cs["state"]["waiting"]["reason"]
+            for cs in cs_list
+            if "waiting" in cs.get("state", {})
+        ]
+        if phase not in ("Running", "Succeeded") or restarts > 3 or waiting_reasons:
+            issues.append(
+                {
+                    "name": meta.get("name"),
+                    "namespace": meta.get("namespace"),
+                    "phase": phase,
+                    "restarts": restarts,
+                    "waiting_reasons": waiting_reasons,
+                }
+            )
+    return issues
+
+
+def collect_pvcs():
+    data = k8s_get("/api/v1/persistentvolumeclaims")
+    out = []
+    for item in data.get("items", []):
+        meta = item.get("metadata", {})
+        spec = item.get("spec", {})
+        status = item.get("status", {})
+        out.append(
+            {
+                "name": meta.get("name"),
+                "namespace": meta.get("namespace"),
+                "phase": status.get("phase"),
+                "requested": spec.get("resources", {}).get("requests", {}).get("storage"),
+                "capacity": status.get("capacity", {}).get("storage"),
+            }
+        )
+    return out
+
+
+def collect_nodes():
+    data = k8s_get("/api/v1/nodes")
+    out = []
+    for item in data.get("items", []):
+        meta = item.get("metadata", {})
+        status = item.get("status", {})
+        conditions = {c["type"]: c["status"] for c in status.get("conditions", [])}
+        out.append(
+            {
+                "name": meta.get("name"),
+                "allocatable": status.get("allocatable"),
+                "capacity": status.get("capacity"),
+                "ready": conditions.get("Ready"),
+                "diskPressure": conditions.get("DiskPressure"),
+                "memoryPressure": conditions.get("MemoryPressure"),
+            }
+        )
+    return out
+
+
+def github_request(method, path, token, body=None):
+    url = "https://api.github.com" + path
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Authorization": "Bearer " + token,
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "homelab-ops-health-reporter",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            raw = resp.read()
+            return resp.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        return e.code, (json.loads(raw) if raw else None)
+
+
+def ensure_branch(token, repo, branch, base_branch):
+    status, _ = github_request("GET", "/repos/{}/git/ref/heads/{}".format(repo, branch), token)
+    if status == 200:
+        return
+    status, base = github_request(
+        "GET", "/repos/{}/git/ref/heads/{}".format(repo, base_branch), token
+    )
+    if status != 200:
+        raise RuntimeError("base branch ref の取得に失敗: {} {}".format(status, base))
+    base_sha = base["object"]["sha"]
+    status, resp = github_request(
+        "POST",
+        "/repos/{}/git/refs".format(repo),
+        token,
+        {"ref": "refs/heads/{}".format(branch), "sha": base_sha},
+    )
+    if status not in (200, 201):
+        raise RuntimeError("branch 作成に失敗: {} {}".format(status, resp))
+
+
+def put_file(token, repo, branch, path, content_bytes, message):
+    status, existing = github_request(
+        "GET", "/repos/{}/contents/{}?ref={}".format(repo, path, branch), token
+    )
+    sha = existing.get("sha") if status == 200 and isinstance(existing, dict) else None
+    payload = {
+        "message": message,
+        "content": base64.b64encode(content_bytes).decode(),
+        "branch": branch,
+    }
+    if sha:
+        payload["sha"] = sha
+    status, resp = github_request(
+        "PUT", "/repos/{}/contents/{}".format(repo, path), token, payload
+    )
+    if status not in (200, 201):
+        raise RuntimeError("{} の書き込みに失敗: {} {}".format(path, status, resp))
+
+
+def main():
+    token = os.environ["GITHUB_TOKEN"]
+    repo = os.environ.get("GITHUB_REPO", "hikuohiku/homelab")
+    branch = os.environ.get("REPORT_BRANCH", "ops-health-report")
+    base_branch = os.environ.get("BASE_BRANCH", "main")
+
+    generated_at = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    report = {
+        "generated_at": generated_at,
+        "applications": collect(collect_applications),
+        "pod_issues": collect(collect_pod_issues),
+        "pvcs": collect(collect_pvcs),
+        "nodes": collect(collect_nodes),
+        "notes": (
+            "実使用量（ディスク/メモリの実消費）は metrics-server / kubelet stats 依存のため未収集。"
+            "RBAC は get/list のみ、write 系の verb は含まない。"
+        ),
+    }
+
+    ensure_branch(token, repo, branch, base_branch)
+    put_file(
+        token,
+        repo,
+        branch,
+        "ops/health/latest.json",
+        json.dumps(report, ensure_ascii=False, indent=2).encode("utf-8"),
+        "health report {}".format(generated_at),
+    )
+    print("ops/health/latest.json を {} ブランチへ書き込みました ({})".format(branch, generated_at))
+
+
+if __name__ == "__main__":
+    main()

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 74,
+  "next_id": 75,
   "updated": "2026-08-05T05:10:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
@@ -261,18 +261,35 @@
       "title": "ArgoCD/k8s の健全性を homelab 側から repo に書き戻す経路を作る（T-0010 の解決策）",
       "kind": "feature",
       "risk": "medium",
-      "status": "needs-human",
+      "status": "in_progress",
       "priority": 11,
       "why": "issue #56 (2026-08-04 19:12:21) で設計方向のフィードバックを受けた。クラウドから homelab へは到達できないが、逆にクラスタ内 CronJob が状態を repo へ push する方向なら到達性の制約を回避できる。medium リスクの auto-merge を続ける以上、効いたかを確認する経路が要る",
       "dod": "クラスタ内 CronJob が ArgoCD Application ごとの sync/health 状態、Pod 異常、ディスク空きなどを集めて repo（専用ブランチ or 状態報告用 issue）に書き戻す。autopilot が起動のたびにそれを読み、直前の auto-merge 後に異常が無いか確認できる。manifest は apps/ に置くだけで良く、クラスタ credential は不要。書き戻し用の GitHub token は Doppler → External Secrets 経由",
-      "needs_human_reason": "書き戻しに使う GitHub token の発行と Doppler への登録。必要スコープ: 対象 repo への contents:write（専用ブランチのみで良ければ fine-grained PAT で branch 制限可）。登録先キー名は実装時に backlog へ追記する。token 自体の発行はエージェントから手が届かない",
       "refs": [
         "ops/CHARTER.md",
-        "apps/"
+        "apps/ops-health-reporter/"
       ],
       "created": "2026-08-04",
-      "pr": null,
-      "notes": "T-0010 を置き換える形の具体案。manifest の設計・実装自体は着手できるので、token 待ちの間に CronJob 用 manifest の下書きを進めてよい"
+      "pr": 152,
+      "notes": "T-0010 を置き換える形の具体案。run #29: issue #56 (04:51:25、構築セッション経由) で GITHUB_HEALTH_REPORTER_TOKEN が Doppler に登録されたと判明し着手。apps/ops-health-reporter/ に Namespace・ServiceAccount・ClusterRole(get/list のみ)・ClusterRoleBinding・ExternalSecret・CronJob（30分毎, python:3.12-alpine, 標準ライブラリのみ）を実装した。スクリプトは k8s API (Application CRD / Pods / PVC / Nodes) を SA トークンで直接読み、GitHub Contents API で ops-health-report ブランチ (main と別、専用) の ops/health/latest.json を作成・更新する。CronJob に memory limits (256Mi) と securityContext (runAsNonRoot/runAsUser: 65534) を新設したため CHARTER §4 の『縛る変更』クールダウンの対象と判断し、この起動では merge しない（PR #152 open のまま）。DoD のうち『autopilot が起動のたびにそれを読む』は未実施 — CronJob が実際に動作し書き込めることを確認してから CHARTER §2 に読む手順を追加する（T-0074）。実使用量（ディスク/メモリ）は metrics-server 依存のため今回のスコープ外とし、応答スクリプトの notes フィールドに明記した"
+    },
+    {
+      "id": "T-0074",
+      "domain": "homelab",
+      "title": "ops-health-reporter CronJob が実際に動作し ops-health-report ブランチへ書き込めているか確認する",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "todo",
+      "priority": 12,
+      "why": "T-0015 (#152) で実装した CronJob は python:3.12-alpine の runAsUser: 65534 での起動可否、GITHUB_HEALTH_REPORTER_TOKEN の Contents:write 権限での branch 作成可否、node01 から api.github.com への到達性のいずれもこのクラウドサンドボックスからは検証できず未確認のまま",
+      "dod": "`git fetch origin ops-health-report` (または `git ls-remote origin ops-health-report`) でブランチの存在と `ops/health/latest.json` の `generated_at` が直近であることを確認する。存在すれば CHARTER §2 に『書き戻された状態を読む』手順を追加し（issue #56 の 04:51:25 コメントが依頼した内容）、存在しない・古いままなら CronJob の失敗を疑い調査する（このクラウドサンドボックスから Pod ログは見られないため、症状を記録した上で needs-human に切り替える判断も検討する）",
+      "blocked_by": "T-0015（#152）が merge され、CronJob のスケジュール（30分毎）が最低 1〜2 回まわる時間が経ってから確認する",
+      "refs": [
+        "apps/ops-health-reporter/",
+        "ops/CHARTER.md"
+      ],
+      "created": "2026-08-05",
+      "pr": null
     },
     {
       "id": "T-0016",

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 75,
+  "next_id": 76,
   "updated": "2026-08-05T05:10:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
@@ -271,10 +271,10 @@
       ],
       "created": "2026-08-04",
       "pr": 153,
-      "notes": "T-0010 を置き換える形の具体案。run #29: issue #56 (04:51:25、構築セッション経由) で GITHUB_HEALTH_REPORTER_TOKEN が Doppler に登録されたと判明し着手。apps/ops-health-reporter/ に Namespace・ServiceAccount・ClusterRole(get/list のみ)・ClusterRoleBinding・ExternalSecret・CronJob（30分毎, python:3.12-alpine, 標準ライブラリのみ）を実装した。スクリプトは k8s API (Application CRD / Pods / PVC / Nodes) を SA トークンで直接読み、GitHub Contents API で ops-health-report ブランチ (main と別、専用) の ops/health/latest.json を作成・更新する。CronJob に memory limits (256Mi) と securityContext (runAsNonRoot/runAsUser: 65534) を新設したため CHARTER §4 の『縛る変更』クールダウンの対象と判断し、この起動では merge しない（PR #153 open のまま）。DoD のうち『autopilot が起動のたびにそれを読む』は未実施 — CronJob が実際に動作し書き込めることを確認してから CHARTER §2 に読む手順を追加する（T-0074）。実使用量（ディスク/メモリ）は metrics-server 依存のため今回のスコープ外とし、応答スクリプトの notes フィールドに明記した"
+      "notes": "T-0010 を置き換える形の具体案。run #29: issue #56 (04:51:25、構築セッション経由) で GITHUB_HEALTH_REPORTER_TOKEN が Doppler に登録されたと判明し着手。apps/ops-health-reporter/ に Namespace・ServiceAccount・ClusterRole(get/list のみ)・ClusterRoleBinding・ExternalSecret・CronJob（30分毎, python:3.12-alpine, 標準ライブラリのみ）を実装した。スクリプトは k8s API (Application CRD / Pods / PVC / Nodes) を SA トークンで直接読み、GitHub Contents API で ops-health-report ブランチ (main と別、専用) の ops/health/latest.json を作成・更新する。CronJob に memory limits (256Mi) と securityContext (runAsNonRoot/runAsUser: 65534) を新設したため CHARTER §4 の『縛る変更』クールダウンの対象と判断し、この起動では merge しない（PR #153 open のまま）。DoD のうち『autopilot が起動のたびにそれを読む』は未実施 — CronJob が実際に動作し書き込めることを確認してから CHARTER §2 に読む手順を追加する（T-0075）。実使用量（ディスク/メモリ）は metrics-server 依存のため今回のスコープ外とし、応答スクリプトの notes フィールドに明記した"
     },
     {
-      "id": "T-0074",
+      "id": "T-0075",
       "domain": "homelab",
       "title": "ops-health-reporter CronJob が実際に動作し ops-health-report ブランチへ書き込めているか確認する",
       "kind": "investigate",

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -270,8 +270,8 @@
         "apps/ops-health-reporter/"
       ],
       "created": "2026-08-04",
-      "pr": 152,
-      "notes": "T-0010 を置き換える形の具体案。run #29: issue #56 (04:51:25、構築セッション経由) で GITHUB_HEALTH_REPORTER_TOKEN が Doppler に登録されたと判明し着手。apps/ops-health-reporter/ に Namespace・ServiceAccount・ClusterRole(get/list のみ)・ClusterRoleBinding・ExternalSecret・CronJob（30分毎, python:3.12-alpine, 標準ライブラリのみ）を実装した。スクリプトは k8s API (Application CRD / Pods / PVC / Nodes) を SA トークンで直接読み、GitHub Contents API で ops-health-report ブランチ (main と別、専用) の ops/health/latest.json を作成・更新する。CronJob に memory limits (256Mi) と securityContext (runAsNonRoot/runAsUser: 65534) を新設したため CHARTER §4 の『縛る変更』クールダウンの対象と判断し、この起動では merge しない（PR #152 open のまま）。DoD のうち『autopilot が起動のたびにそれを読む』は未実施 — CronJob が実際に動作し書き込めることを確認してから CHARTER §2 に読む手順を追加する（T-0074）。実使用量（ディスク/メモリ）は metrics-server 依存のため今回のスコープ外とし、応答スクリプトの notes フィールドに明記した"
+      "pr": 153,
+      "notes": "T-0010 を置き換える形の具体案。run #29: issue #56 (04:51:25、構築セッション経由) で GITHUB_HEALTH_REPORTER_TOKEN が Doppler に登録されたと判明し着手。apps/ops-health-reporter/ に Namespace・ServiceAccount・ClusterRole(get/list のみ)・ClusterRoleBinding・ExternalSecret・CronJob（30分毎, python:3.12-alpine, 標準ライブラリのみ）を実装した。スクリプトは k8s API (Application CRD / Pods / PVC / Nodes) を SA トークンで直接読み、GitHub Contents API で ops-health-report ブランチ (main と別、専用) の ops/health/latest.json を作成・更新する。CronJob に memory limits (256Mi) と securityContext (runAsNonRoot/runAsUser: 65534) を新設したため CHARTER §4 の『縛る変更』クールダウンの対象と判断し、この起動では merge しない（PR #153 open のまま）。DoD のうち『autopilot が起動のたびにそれを読む』は未実施 — CronJob が実際に動作し書き込めることを確認してから CHARTER §2 に読む手順を追加する（T-0074）。実使用量（ディスク/メモリ）は metrics-server 依存のため今回のスコープ外とし、応答スクリプトの notes フィールドに明記した"
     },
     {
       "id": "T-0074",
@@ -281,9 +281,9 @@
       "risk": "low",
       "status": "todo",
       "priority": 12,
-      "why": "T-0015 (#152) で実装した CronJob は python:3.12-alpine の runAsUser: 65534 での起動可否、GITHUB_HEALTH_REPORTER_TOKEN の Contents:write 権限での branch 作成可否、node01 から api.github.com への到達性のいずれもこのクラウドサンドボックスからは検証できず未確認のまま",
+      "why": "T-0015 (#153) で実装した CronJob は python:3.12-alpine の runAsUser: 65534 での起動可否、GITHUB_HEALTH_REPORTER_TOKEN の Contents:write 権限での branch 作成可否、node01 から api.github.com への到達性のいずれもこのクラウドサンドボックスからは検証できず未確認のまま",
       "dod": "`git fetch origin ops-health-report` (または `git ls-remote origin ops-health-report`) でブランチの存在と `ops/health/latest.json` の `generated_at` が直近であることを確認する。存在すれば CHARTER §2 に『書き戻された状態を読む』手順を追加し（issue #56 の 04:51:25 コメントが依頼した内容）、存在しない・古いままなら CronJob の失敗を疑い調査する（このクラウドサンドボックスから Pod ログは見られないため、症状を記録した上で needs-human に切り替える判断も検討する）",
-      "blocked_by": "T-0015（#152）が merge され、CronJob のスケジュール（30分毎）が最低 1〜2 回まわる時間が経ってから確認する",
+      "blocked_by": "T-0015（#153）が merge され、CronJob のスケジュール（30分毎）が最低 1〜2 回まわる時間が経ってから確認する",
       "refs": [
         "apps/ops-health-reporter/",
         "ops/CHARTER.md"

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -280,6 +280,18 @@
       "policy": "auto",
       "note": "T-0042 (run #16) で @main の floating ref から固定した。Action 自体の pin と、実際にインストールされる Nix のバージョンは無関係（upstream README に明記）",
       "observability_impact": "release-image.yml（workflow_dispatch 専用、CI 非カバレッジ。CHARTER §5.4）が使用。CI では検証されないため壊れても次の手動実行まで気づけない"
+    },
+    {
+      "id": "ops-health-reporter-image",
+      "kind": "image",
+      "name": "python (ops-health-reporter CronJob)",
+      "current": "3.12-alpine",
+      "file": "apps/ops-health-reporter/cronjob.yaml",
+      "match": "image: python:",
+      "upstream": "dockerhub:library/python",
+      "policy": "auto",
+      "note": "T-0015 (run #29) で新設。標準ライブラリのみで動くスクリプトのため minor/patch 更新はほぼ無害",
+      "observability_impact": "壊れると ops-health-report ブランチへの書き戻しが止まり、autopilot が直前の auto-merge 後の ArgoCD/Pod/PVC 状態を確認できなくなる。ただし読み取り専用 CronJob であり、壊れても homelab 本体の到達性・稼働には影響しない"
     }
   ]
 }


### PR DESCRIPTION
## 変更点

新しい ArgoCD Application `apps/ops-health-reporter/` を追加した。

- `Namespace` (`ops-health-reporter`)
- `ServiceAccount` + `ClusterRole`(get/list のみ) + `ClusterRoleBinding` — Pod / PVC / Node / ArgoCD
  `Application` (argoproj.io) を読む権限のみ。write 系の動詞は一切含まない
- `ExternalSecret` — Doppler の `GITHUB_HEALTH_REPORTER_TOKEN`（Contents: Read and write のみの
  fine-grained PAT）を `github-health-reporter-token` として取り込む
- `CronJob`（30分毎、`python:3.12-alpine`、標準ライブラリのみで動くスクリプト）— k8s API から
  ArgoCD Application の sync/health、異常 Pod（Running/Succeeded 以外、再起動過多、waiting 理由あり）、
  PVC の要求/容量、Node の allocatable/capacity/条件を集め、GitHub Contents API で
  **`ops-health-report` という main とは別の専用ブランチ**の `ops/health/latest.json` を作成・更新する

`main` へは一切書き込まない。`git` バイナリは使わず、GitHub REST API（Contents API + Git Data API
でのブランチ作成）のみで完結させた。

## 背景

issue #56 (2026-08-04 19:12:21) の設計フィードバックに基づく T-0010 の解決策（T-0015）。
クラウドサンドボックスから homelab（Tailscale 越しの k8s/ArgoCD）には到達できないが、
逆方向（クラスタ内 CronJob → repo）なら到達性の制約を回避できる。2026-08-05 04:51:25 に
構築セッション経由で `GITHUB_HEALTH_REPORTER_TOKEN` が Doppler に登録されたと報告があり着手した。

## 検証したこと

- `python3 -c "import ast; ast.parse(...)"` で `report.py` の構文を確認
- 全 YAML を `yaml.safe_load_all` でパース確認、`apps/kustomization.yaml` と
  `apps/ops-health-reporter/kustomization.yaml` の構文を確認
- `python3 ops/validate.py` → 0 error
- `python3 ops/check_version_sync.py` → 全 4 グループ一致
- RBAC は get/list のみで構成し、書き込み系の verb を含めていないことを目視確認
- ArgoCD `Application` CRD の apiVersion/plural (`argoproj.io/v1alpha1` / `applications`) は
  `apps/*/application.yaml` の既存記述と一致させた

このサンドボックスに `kustomize`/`kubectl` が無いため、実際のレンダリング結果・クラスタでの動作は
CI (`kustomize build --enable-helm`, `manifest-diff`) と次回以降の起動での確認に委ねる。

## 残った不確実性（実機で確認できていない点）

1. `python:3.12-alpine` を `runAsUser: 65534`（非 root）で起動できるか。イメージの実 UID 構成までは
   確認していない
2. `GITHUB_HEALTH_REPORTER_TOKEN`（Contents: Read and write の fine-grained PAT）で Git Data API
   による**新規ブランチ作成**ができるか。GitHub の権限モデル上は Contents 権限に含まれる想定だが、
   実地検証はしていない
3. node01（homelab クラスタ）から `api.github.com` への到達性そのものが未確認
4. 実使用量（ディスク/メモリの実消費）は未収集（`metrics-server`/kubelet stats 依存のため今回のスコープ外、
   スクリプトの `notes` フィールドに明記した）

上記はすべて T-0074（このリポジトリの backlog、todo）として起票済み。`ops-health-report` ブランチの
有無と `ops/health/latest.json` の `generated_at` を次回以降の起動が `git fetch`/`git ls-remote` で
確認する（クラスタ到達は不要）。

## この PR を今回の起動では merge しない理由

`CronJob` に memory limits（256Mi、実測ではなく緩い安全上限）と `securityContext`
（`runAsNonRoot`/`runAsUser: 65534`）を新設しており、CHARTER §4「縛る変更には実測か裏付けが要る」の
定義（memory limits の新設、securityContext の runAsNonRoot/runAsUser 等）に該当する。CI が green
でも作成した起動の中では merge せず、次回起動が issue #56 に新しい異議が来ていないことを確認してから
merge する。

## 到達性への影響

対象は新規リソースのみで、Tailscale / Coder / ArgoCD / Dex/OIDC / GitHub Actions など既存の
観測・操作経路には触れていない。この CronJob 自体が壊れても、書き戻しが止まるだけで homelab 本体の
到達性・稼働には影響しない。

## ロールバック手順

この PR を revert すれば `apps/ops-health-reporter/` 一式が消え、ArgoCD の `apps` Application が
`prune: true` のため次回 sync で自動的に片付く。他アプリへの依存は無い。

backlog task id: T-0015（followup: T-0074）

---
_Generated by [Claude Code](https://claude.ai/code/session_012QAq7mJt1a8nA62iZn7hbN)_