### PR TITLE
ops: run #29 の記録をまとめ、ダッシュボードを再生成する

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,49 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 152,
+      "title": "docs: terraform plan の CI 化を調査する (T-0073)",
+      "url": "https://github.com/hikuohiku/homelab/pull/152",
+      "isDraft": false,
+      "createdAt": "2026-08-05T05:07:23Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "PENDING"
+        }
+      ],
+      "headRefName": "autopilot/T-0073-terraform-plan-ci-feasibility",
+      "autoMergeRequest": null
+    },
+    {
+      "number": 153,
+      "title": "T-0015: ArgoCD/k8s の健全性を homelab から repo へ書き戻す CronJob を追加",
+      "url": "https://github.com/hikuohiku/homelab/pull/153",
+      "isDraft": false,
+      "createdAt": "2026-08-05T05:10:53Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "PENDING"
+        }
+      ],
+      "headRefName": "autopilot/T-0015-ops-health-reporter",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 151,
+      "title": "T-0011: vaultwarden ADMIN_TOKEN の Argon2 PHC 化を完了扱いにする",
+      "url": "https://github.com/hikuohiku/homelab/pull/151",
+      "mergedAt": "2026-08-05T05:06:53Z",
+      "headRefName": "autopilot/T-0011-vaultwarden-admin-token-done"
+    },
+    {
+      "number": 150,
+      "title": "ops: run #28 の記録をまとめる（T-0064 merge、backup 方針転換の反映）",
+      "url": "https://github.com/hikuohiku/homelab/pull/150",
+      "mergedAt": "2026-08-05T04:59:11Z",
+      "headRefName": "autopilot/run28-wrapup"
+    },
     {
       "number": 149,
       "title": "T-0064: proxmox_virtual_environment_download_file を proxmox_download_file に改名",
@@ -406,20 +449,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/91",
       "mergedAt": "2026-08-04T21:34:45Z",
       "headRefName": "autopilot/t-0020-busybox-patch"
-    },
-    {
-      "number": 90,
-      "title": "T-0019: immich の valkey を 9.1-alpine → 9.1.1-alpine に上げる",
-      "url": "https://github.com/hikuohiku/homelab/pull/90",
-      "mergedAt": "2026-08-04T21:32:13Z",
-      "headRefName": "autopilot/t-0019-immich-valkey-patch"
-    },
-    {
-      "number": 89,
-      "title": "T-0016: ダッシュボードの PR 一覧を gh CLI 非依存にする",
-      "url": "https://github.com/hikuohiku/homelab/pull/89",
-      "mergedAt": "2026-08-04T21:29:16Z",
-      "headRefName": "autopilot/t-0016-dashboard-pr-list-mcp"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -878,3 +878,24 @@
   文字列に差し替え済み。manifest 側の変更は不要（ExternalSecret は既存キーを参照、vaultwarden も
   PHC を自動判別）と確認し `done` にした（PR なし、backlog notes に理由記載。`Maintenance.md` の
   2026-08-03 持ち越し項目も解消済みとして更新）
+- 同コメントの T-0015 分を反映: `GITHUB_HEALTH_REPORTER_TOKEN`（Contents: Read and write のみの
+  fine-grained PAT）が Doppler に登録されたため着手。`apps/ops-health-reporter/` に Namespace・
+  ServiceAccount・ClusterRole(get/list のみ)・ClusterRoleBinding・ExternalSecret・CronJob（30分毎、
+  `python:3.12-alpine`、標準ライブラリのみのスクリプト）を実装した。スクリプトは k8s API
+  （ArgoCD `Application` CRD / Pods / PVC / Nodes）を ServiceAccount トークンで直接読み、GitHub
+  Contents API で `ops-health-report` という main とは別の専用ブランチの `ops/health/latest.json`
+  を作成・更新する。`git` バイナリは使わず GitHub REST API のみで完結させた（PR #153）
+- CronJob に memory limits（256Mi、緩い安全上限）と securityContext（runAsNonRoot/runAsUser: 65534）を
+  新設しており、CHARTER §4「縛る変更には実測か裏付けが要る」のクールダウン対象と判断。CI green でも
+  **この起動では merge しない**。次回起動が issue #56 に新しい異議が無いことを確認してから拾うこと
+- 作業中に別セッション（session_014CPcSgC5y5Zhb94LtVzBpE）が並行して T-0073（terraform plan の CI 化調査）
+  に着手し、PR #152 を自分より先に作っていたことが判明。両セッションが同時に `next_id: 74` を読んでいたため
+  `T-0074` が重複した。自分の側（未マージの PR #153）を `T-0075` に採番し直して衝突を回避した
+  （PR #152 の T-0074 はそのまま。#153 に追加コミットで修正、PR コメントで経緯を記録）
+- 残った不確実性（backlog T-0075、todo）: `python:3.12-alpine` を非 root UID で起動できるか、
+  fine-grained PAT の Contents 権限でブランチ作成ができるか、node01 から `api.github.com` への
+  到達性、のいずれも実機未確認。`ops-health-report` ブランチの有無は次回以降の起動が
+  `git fetch`/`git ls-remote`（クラスタ非依存）で確認できる
+- 次の起動へ: PR #152（他セッション、T-0073）と PR #153（自分、T-0015、cooldown 中）の2件が open。
+  §2 の中断検知で両方拾うこと。#153 は issue #56 に新しい異議が無ければ merge してよい。
+  T-0075 は #153 merge 後、CronJob が最低 1〜2 回まわってから確認する

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-05T05:10:00Z",
+  "updated": "2026-08-05T05:20:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-05T04:45:21Z"
+    "last_read": "2026-08-05T04:51:25Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -345,6 +345,17 @@
       "prs": [
         149,
         150
+      ]
+    },
+    {
+      "n": 29,
+      "at": "2026-08-05T05:20:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし（ローカル origin/main の参照キャッシュが古いままだったため git fetch で追従、run #25 と同型）。issue #56 の未読フィードバック1件（04:51:25、構築セッション経由）を反映: (1) T-0011（vaultwarden ADMIN_TOKEN）→ 人間が Doppler の値を Argon2 PHC に差し替え済みと判明、manifest 変更不要のため done（#151, auto-merged）。(2) T-0015（ArgoCD/k8s 健全性の書き戻し）→ GITHUB_HEALTH_REPORTER_TOKEN が Doppler に登録され着手。apps/ops-health-reporter/ に Namespace・RBAC(get/list のみ)・ExternalSecret・CronJob（30分毎、python:3.12-alpine、標準ライブラリのみ）を実装し、k8s API から ArgoCD Application/Pod/PVC/Node の状態を GitHub Contents API 経由で ops-health-report という専用ブランチへ書き戻す仕組みを作った（#153）。CronJob に memory limits と securityContext(runAsNonRoot) を新設したため CHARTER §4 の『縛る変更』クールダウン対象と判断し、この起動では merge していない。作業中に別セッション（T-0073, #152）と next_id の重複（T-0074）が判明し、自分側を T-0075 に採番し直して回避した",
+      "prs": [
+        151,
+        153
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

- `ops/journal/2026-08.md` に run #29 の記録を追記（T-0011 完了、T-0015 実装・cooldown 中、T-0075 起票、
  並行 PR とのタスク ID 衝突の解消）
- `ops/state.json` の `runs` に run #29 を追記、`feedback.last_read` を更新
- `ops/dashboard/prs.json` を最新化（open: #152, #153 / merged: 直近60件）

コードの挙動は変わりません（記録更新のみ）。

## 検証したこと

`python3 ops/validate.py` → 0 error、`python3 ops/dashboard/build.py` → 生成成功

## ロールバック手順

`git revert`。記録ファイルのみのため実インフラへの影響はありません。

backlog task id: (記録のみ、対象タスクなし)

---
_Generated by [Claude Code](https://claude.ai/code/session_012QAq7mJt1a8nA62iZn7hbN)_