### PR TITLE
T-0065: IaC 完全性の棚卸し — node01 揮発時の未カバー領域を確認

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,8 +1,47 @@
-# バックアップ体制の棚卸し (2026-08-04)
+# バックアップ体制の棚卸し (2026-08-04, 2026-08-05 追記)
 
 `ops/backlog.json` T-0013 の調査記録。**設定変更は行っていない。** リポジトリ内の記録を
 横断的に確認しただけで、実機（Proxmox / PBS）には autopilot のクラウドサンドボックスから
 到達できない（`ops/CHARTER.md` §5.2）ため、この調査だけでは分からないことが多く残る。
+
+## 方針転換 (2026-08-05)
+
+issue #56 (2026-08-05 04:40:59) で人間から新方針: **PBS は重すぎる。k8s より上を IaC で完全に
+記述し、揮発しても大丈夫な状態にした上で、restic ベースのアプリ単位バックアップへ移行する。**
+以下の「わからないこと」節（PBS のジョブ設定確認）は T-0034 として起票していたが、この方針転換に
+伴い **dropped** にした（PBS に依存しない復旧経路を作る話に置き換わったため）。以後の一次情報源は
+`ops/backlog.json` の T-0065〜T-0073 系列（IaC 完全性の棚卸し・実サイズ測定・restic 保存先用意・
+アプリ別 backup CronJob・復元試験・PBS 退役判断）。
+
+## IaC 完全性の棚卸し (T-0065, run #30)
+
+「node01 が揮発しても Git/Doppler に無いものが残っていないか」を repo 横断で確認した。
+
+- **PVC を持つのは immich / vaultwarden / coder-postgres / immich-postgres の 4 アプリのみ**
+  （`immich-library`, `immich-postgres-data`, `vaultwarden-data`, `coder-postgres-data`）。
+  いずれも実データで再現不可。immich の valkey persistence・machine-learning cache persistence は
+  キャッシュ/ジョブキュー用途で再現可能なためバックアップ対象外でよい
+- **ArgoCD / Dex / external-secrets / tailscale-operator は PVC/StatefulSet を一切持たない。**
+  Pod を殺して ArgoCD が resync すればフルに復元可能なことを確認した（「持っていないことの確認」完了）
+- **ArgoCD 自身の設定（RBAC・OIDC 連携・agent アカウント宣言）は `apps/argocd/values.yaml` に
+  git 管理されており再現可能。** ただし `admin` ローカルアカウントの有効化制御が repo に無く、
+  UI/CLI 経由でパスワードを変更していればその値は git にも Doppler にも無い（実害は薄い。Dex OIDC
+  ログインが主経路のため）
+- **新規発見（バックアップ対象の抜け）**: `apps/coder/templates/personal/main.tf` が Coder の
+  Terraform プロビジョナー経由で workspace 作成のたびに `coder-<workspace-id>-home` という PVC を
+  動的に作成している（`/home/coder` にマウント、dotfiles・`ghq` clone・code-server 設定等）。
+  これは ArgoCD が同期する静的マニフェスト（`apps/coder/*.yaml`）には現れず、`apps/` を読むだけでは
+  発見できない。**実データを持つ 5 つ目のバックアップ対象**として下の一覧に追加した
+
+## バックアップ対象一覧（2026-08-05 時点、T-0065 で確定）
+
+| PVC / データ | 用途 | backup CronJob タスク |
+|---|---|---|
+| `immich-library` | 写真/動画原本・サムネイル・変換済み動画 | T-0068 |
+| `immich-postgres-data` | immich アセットメタデータ・CLIP埋め込み | T-0068 と同時（T-0029 側で拡張検討） |
+| `vaultwarden-data` | パスワードマネージャ本体（SQLite） | T-0069 |
+| `coder-postgres-data` | Coder 制御プレーン（ユーザー・workspace・監査ログ） | T-0070 |
+| `coder-<workspace-id>-home`（動的作成、`apps/coder/templates/personal/main.tf`） | workspace ごとの `/home/coder`（dotfiles・ghq clone 等） | **未起票**。T-0070 の対象外（別 PVC 群）のため、別途タスク化が必要 |
 
 ## わかっていること（repo から）
 
@@ -21,7 +60,10 @@
 - `Maintenance.md` / `CLAUDE.md` に、バックアップジョブのスケジュール・保持世代数・
   直近の成功/失敗・リストア検証の記録が無い
 
-## わからないこと（実機アクセスが要る）
+## わからないこと（実機アクセスが要る、PBS 時代の記録）
+
+方針転換前に挙げていた確認事項。**T-0034 は dropped** につき、以下はもう追わない
+（参考として残す）。
 
 1. PBS に node01 (`qemu/113`) を対象にしたバックアップジョブが実際に設定されているか
 2. 設定されている場合、スケジュールと保持世代数
@@ -30,16 +72,12 @@
 5. pbs 自身（PBS VM そのもの）はバックアップ対象外のままで問題ないか。pbs を失うと
    node01 のバックアップも一緒に失う片系構成になっていないか
 
-これらは `mcp__proxmox__*`（読み取り専用トークン）や PBS の Web UI が使える、Tailscale
-経由で homelab に到達できる環境でしか確認できない。autopilot のクラウドサンドボックスは
-Tailscale に接続できないため、物理的に手が届かない（`ops/CHARTER.md` §5.2）。
-確認は `ops/backlog.json` T-0034（needs-human）で人間にお願いしている。
+PBS の現況確認自体が要るなら T-0072（PBS 退役判断）の中で必要な分だけ見る。
 
 ## これに依存しているタスク
 
-- T-0029（immich postgres/vchord のメジャー更新、データを失いうる変更）は
+- T-0029（immich postgres/vchord のメジャー更新、データを失いうる変更）・T-0023（coder
+  v2.34.7 → v2.35.3、DB migration を伴う更新）・T-0027（immich メジャー更新）は
   CHARTER §4「データを失いうる変更」の手順どおり、バックアップの存在と復元手順が
-  確かめられるまで着手しない。T-0034 の確認が終わってから再検討する
-- T-0023（coder v2.34.7 → v2.35.3、DB migration を伴う更新）も同じ理由で blocked。
-  coder-postgres も local-path で node01 のディスク上に直接あり、coder は down-migration を
-  提供しないためロールバックにはバックアップ復元が要る（run #10 で判明）
+  確かめられるまで着手しない。blocked_by は T-0071（restic ベースの復元試験）を指しており、
+  それが通ってから再検討する

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 78,
-  "updated": "2026-08-05T05:50:00Z",
+  "next_id": 79,
+  "updated": "2026-08-05T06:05:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -1193,7 +1193,7 @@
       "title": "IaC 完全性の棚卸し — node01 が揮発しても Git/Doppler に無いものが残っていないか確認する",
       "kind": "investigate",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 35,
       "why": "issue #56 (2026-08-05 04:40:59) の人間の新方針: 『k8s より上は IaC で完全に記述できるようにして、揮発しても大丈夫な状態にしたい』。ArgoCD/dex/external-secrets/tailscale-operator 自体は状態を持たないはずだが、それを裏取りした記録が無い。『持っていないことを確認する』のがこのタスクの仕事（人間の言葉どおり）",
       "dod": "ArgoCD/dex/external-secrets/tailscale-operator の各 Deployment/StatefulSet が使う PVC を列挙し、実際に永続データを持つのはどれか（immich/vaultwarden/coder-postgres/immich-postgres 以外に無いか）を確認する。ArgoCD 自身の設定（RBAC、AppProject 等）が manifest（Git）だけで再現できるか、UI 経由でしか設定できない項目が無いかも確認する。結果を docs/backup.md に追記する。この調査自体では manifest を変更しない",
@@ -1202,7 +1202,8 @@
         "apps/"
       ],
       "created": "2026-08-05",
-      "pr": null
+      "pr": null,
+      "notes": "run #30: subagent に repo 横断調査を投げた。PVC を持つのは immich/vaultwarden/coder-postgres/immich-postgres の4アプリのみ（immich の valkey/machine-learning persistence はキャッシュ用途で再現可能なため対象外）。ArgoCD/dex/external-secrets/tailscale-operator は PVC/StatefulSet を一切持たず resync で完全復元可能と確認（『持っていないことの確認』完了）。ArgoCD 自身の RBAC/OIDC/アカウント宣言は values.yaml に git 管理され再現可能（admin ローカルアカウントの有効化制御のみ repo に無いが実害は薄い、Dex OIDC が主経路）。**新規発見**: `apps/coder/templates/personal/main.tf` が Coder の Terraform プロビジョナー経由で workspace ごとに `coder-<workspace-id>-home` PVC を動的作成しており（`apps/coder/*.yaml` の静的マニフェストには現れない）、これが Git/Doppler に無い5つ目の実データ対象と判明。docs/backup.md に追記し、backup CronJob 化を T-0078 として起票した"
     },
     {
       "id": "T-0066",
@@ -1401,6 +1402,24 @@
       "created": "2026-08-05",
       "pr": null,
       "notes": "run #30: issue #56 (05:12:43) の提案をそのまま起票。実装自体はブロックされていないが、T-0075（CronJob が実際に動いているかの確認）が先に通ってから着手するのが安全（土台が動いていない状態に機能を足しても検証できない）"
+    },
+    {
+      "id": "T-0078",
+      "domain": "homelab",
+      "title": "Coder workspace ごとの home PVC (`coder-<workspace-id>-home`) 用の backup CronJob を追加する",
+      "kind": "feature",
+      "risk": "medium",
+      "status": "blocked",
+      "priority": 40,
+      "why": "T-0065（run #30）の調査で発見。`apps/coder/templates/personal/main.tf` が Coder の Terraform プロビジョナー経由で workspace 作成のたびに `coder-<workspace-id>-home` という PVC を動的作成しており（`/home/coder` にマウント、dotfiles・`ghq` clone・code-server 設定等のユーザーデータが載る）、これは `apps/coder/*.yaml` の静的マニフェストには現れないため T-0070（coder-postgres の backup）ではカバーされない。node01 揮発時に失われる実データの5つ目の対象",
+      "dod": "workspace ごとに動的作成される `coder-<workspace-id>-home` PVC を列挙し（PVC 名は `coder-<workspace-id>-home` の命名規則で特定可能）、pg_dump 同様の考え方でファイルシステムスナップショット（tar もしくは直接 restic でファイルシステムを対象にする、DB とは異なりファイルなのでオンライン中でも整合性の問題は薄い）を restic で T-0067 の保存先へ push する CronJob を追加する。workspace は増減するため、対象 PVC の列挙は動的（`kubectl get pvc -l` 相当のラベルセレクタ、または命名パターンでのマッチ）にする",
+      "blocked_by": "T-0067（restic 保存先・credential）",
+      "refs": [
+        "apps/coder/templates/personal/main.tf",
+        "docs/backup.md"
+      ],
+      "created": "2026-08-05",
+      "pr": null
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1202,7 +1202,7 @@
         "apps/"
       ],
       "created": "2026-08-05",
-      "pr": null,
+      "pr": 157,
       "notes": "run #30: subagent に repo 横断調査を投げた。PVC を持つのは immich/vaultwarden/coder-postgres/immich-postgres の4アプリのみ（immich の valkey/machine-learning persistence はキャッシュ用途で再現可能なため対象外）。ArgoCD/dex/external-secrets/tailscale-operator は PVC/StatefulSet を一切持たず resync で完全復元可能と確認（『持っていないことの確認』完了）。ArgoCD 自身の RBAC/OIDC/アカウント宣言は values.yaml に git 管理され再現可能（admin ローカルアカウントの有効化制御のみ repo に無いが実害は薄い、Dex OIDC が主経路）。**新規発見**: `apps/coder/templates/personal/main.tf` が Coder の Terraform プロビジョナー経由で workspace ごとに `coder-<workspace-id>-home` PVC を動的作成しており（`apps/coder/*.yaml` の静的マニフェストには現れない）、これが Git/Doppler に無い5つ目の実データ対象と判明。docs/backup.md に追記し、backup CronJob 化を T-0078 として起票した"
     },
     {

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -929,3 +929,10 @@
      追加 RBAC は最小限）。土台（T-0075、CronJob が実際に動くかの確認）が先なので着手は後回し
 - T-0075（ops-health-reporter の動作確認）は #153 が merge されたばかりで CronJob がまだ 1〜2 回
   まわっていないため、この起動では確認しない（次回以降）
+- 続けて T-0065（IaC 完全性の棚卸し）に着手。subagent に `apps/` 全体の PVC/StatefulSet 横断調査を
+  投げた。PVC を持つのは immich/vaultwarden/coder-postgres/immich-postgres の4アプリのみ、
+  ArgoCD/dex/external-secrets/tailscale-operator は無状態で resync 復元可能と確認（『持っていない
+  ことの確認』完了）。**新規発見**: `apps/coder/templates/personal/main.tf` が workspace ごとに
+  動的作成する `coder-<workspace-id>-home` PVC（`/home/coder` の dotfiles/ghq clone 等）が、
+  静的マニフェストには現れないため T-0070 ではカバーされない5つ目の実データ対象と判明。
+  docs/backup.md に追記し、backup CronJob 化を T-0078（blocked_by T-0067）として起票した

--- a/ops/state.json
+++ b/ops/state.json
@@ -364,9 +364,10 @@
       "at": "2026-08-05T05:50:00Z",
       "kind": "scheduled",
       "by": "cloud routine",
-      "summary": "前回の中断: open PR 2件（#152 他セッション T-0073、#153 自分 T-0015 cooldown 中）を拾った。issue #56 に新しい異議が無いことを確認して #153 を merge（CI green）。#152 は main が先行しコンフリクトしていたため origin/main へ rebase・push し、別セッション側が先に merge した。issue #56 の未読フィードバック2件を反映: (1) クールダウンと直列化の規則衝突の指摘を受け、CHARTER §4 に『クールダウン中の PR には ops/ 記録を相乗りさせない』を追記。(2) #153 のレビュー（PVC 実使用量・コンテナ実メモリ/CPU が取れていない指摘）を T-0077 として起票（#156）。続けて T-0065（IaC 完全性の棚卸し）を subagent 調査で完遂: ArgoCD/dex/external-secrets/tailscale-operator は無状態と確認、Coder の workspace ごとの動的 PVC（`coder-<workspace-id>-home`）が backup 対象から抜けていたと判明し T-0078 として起票、docs/backup.md を更新",
+      "summary": "前回の中断: open PR 2件（#152 他セッション T-0073、#153 自分 T-0015 cooldown 中）を拾った。issue #56 に新しい異議が無いことを確認して #153 を merge（CI green）。#152 は main が先行しコンフリクトしていたため origin/main へ rebase・push し、別セッション側が先に merge した。issue #56 の未読フィードバック2件を反映: (1) クールダウンと直列化の規則衝突の指摘を受け、CHARTER §4 に『クールダウン中の PR には ops/ 記録を相乗りさせない』を追記。(2) #153 のレビュー（PVC 実使用量・コンテナ実メモリ/CPU が取れていない指摘）を T-0077 として起票（#156）。続けて T-0065（IaC 完全性の棚卸し）を subagent 調査で完遂: ArgoCD/dex/external-secrets/tailscale-operator は無状態と確認、Coder の workspace ごとの動的 PVC（`coder-<workspace-id>-home`）が backup 対象から抜けていたと判明し T-0078 として起票、docs/backup.md を更新（#157）",
       "prs": [
-        156
+        156,
+        157
       ]
     }
   ]

--- a/ops/state.json
+++ b/ops/state.json
@@ -364,7 +364,7 @@
       "at": "2026-08-05T05:50:00Z",
       "kind": "scheduled",
       "by": "cloud routine",
-      "summary": "前回の中断: open PR 2件（#152 他セッション T-0073、#153 自分 T-0015 cooldown 中）を拾った。issue #56 に新しい異議が無いことを確認して #153 を merge（CI green）。#152 は main が先行しコンフリクトしていたため origin/main へ rebase・push し、別セッション側が先に merge した。issue #56 の未読フィードバック2件を反映: (1) クールダウンと直列化の規則衝突の指摘を受け、CHARTER §4 に『クールダウン中の PR には ops/ 記録を相乗りさせない』を追記。(2) #153 のレビュー（PVC 実使用量・コンテナ実メモリ/CPU が取れていない指摘）を T-0077 として起票",
+      "summary": "前回の中断: open PR 2件（#152 他セッション T-0073、#153 自分 T-0015 cooldown 中）を拾った。issue #56 に新しい異議が無いことを確認して #153 を merge（CI green）。#152 は main が先行しコンフリクトしていたため origin/main へ rebase・push し、別セッション側が先に merge した。issue #56 の未読フィードバック2件を反映: (1) クールダウンと直列化の規則衝突の指摘を受け、CHARTER §4 に『クールダウン中の PR には ops/ 記録を相乗りさせない』を追記。(2) #153 のレビュー（PVC 実使用量・コンテナ実メモリ/CPU が取れていない指摘）を T-0077 として起票（#156）。続けて T-0065（IaC 完全性の棚卸し）を subagent 調査で完遂: ArgoCD/dex/external-secrets/tailscale-operator は無状態と確認、Coder の workspace ごとの動的 PVC（`coder-<workspace-id>-home`）が backup 対象から抜けていたと判明し T-0078 として起票、docs/backup.md を更新",
       "prs": [
         156
       ]


### PR DESCRIPTION
## 変更点

コードの挙動は変わりません（調査結果のドキュメント追加・backlog 起票のみ）。

- `docs/backup.md` を更新: issue #56 (2026-08-05 04:40:59) の新方針（PBS→restic 移行）に伴う
  棚卸し。ArgoCD/dex/external-secrets/tailscale-operator が PVC/StatefulSet を一切持たず
  resync で完全復元可能なことを確認し、バックアップ対象一覧を確定
- **新規発見**: `apps/coder/templates/personal/main.tf` が Coder の Terraform プロビジョナー
  経由で workspace 作成のたびに動的作成する `coder-<workspace-id>-home` PVC（`/home/coder` の
  dotfiles・`ghq` clone・code-server 設定等）が、既存のバックアップ対象一覧（immich/vaultwarden/
  coder-postgres/immich-postgres）から漏れていました。`apps/coder/*.yaml` の静的マニフェストには
  現れないため、これまでの調査では見つかっていませんでした
- 新規タスク起票: T-0078（coder workspace home PVC 用の backup CronJob、T-0067 待ちで blocked）

## 検証したこと

- subagent に `apps/` 全体を横断的に読ませ、PVC/StatefulSet/persistence 設定を grep・確認させた
- `python3 ops/validate.py` → 0 error

## ロールバック手順

`git revert`。ドキュメント追加と backlog 更新のみのため実インフラへの影響はありません。

## backlog task id

T-0065（完了）、派生タスク T-0078（blocked、T-0067 待ち）

---
_Generated by [Claude Code](https://claude.ai/code/session_016AvGkv2ai7UhHNZW1Kdecf)_