### PR TITLE
ops-health-reporter に metrics-server 経由のコンテナ実メモリ/CPU 収集を追加

### DIFF
--- a/apps/ops-health-reporter/rbac.yaml
+++ b/apps/ops-health-reporter/rbac.yaml
@@ -17,6 +17,9 @@ rules:
   - apiGroups: ["argoproj.io"]
     resources: ["applications"]
     verbs: ["get", "list"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/apps/ops-health-reporter/report.py
+++ b/apps/ops-health-reporter/report.py
@@ -101,6 +101,44 @@ def collect_pvcs():
     return out
 
 
+def collect_pod_metrics():
+    data = k8s_get("/apis/metrics.k8s.io/v1beta1/pods")
+    out = []
+    for item in data.get("items", []):
+        meta = item.get("metadata", {})
+        out.append(
+            {
+                "namespace": meta.get("namespace"),
+                "name": meta.get("name"),
+                "containers": [
+                    {
+                        "name": c.get("name"),
+                        "cpu": c.get("usage", {}).get("cpu"),
+                        "memory": c.get("usage", {}).get("memory"),
+                    }
+                    for c in item.get("containers", [])
+                ],
+            }
+        )
+    return out
+
+
+def collect_node_metrics():
+    data = k8s_get("/apis/metrics.k8s.io/v1beta1/nodes")
+    out = []
+    for item in data.get("items", []):
+        meta = item.get("metadata", {})
+        usage = item.get("usage", {})
+        out.append(
+            {
+                "name": meta.get("name"),
+                "cpu": usage.get("cpu"),
+                "memory": usage.get("memory"),
+            }
+        )
+    return out
+
+
 def collect_nodes():
     data = k8s_get("/api/v1/nodes")
     out = []
@@ -196,9 +234,12 @@ def main():
         "pod_issues": collect(collect_pod_issues),
         "pvcs": collect(collect_pvcs),
         "nodes": collect(collect_nodes),
+        "pod_metrics": collect(collect_pod_metrics),
+        "node_metrics": collect(collect_node_metrics),
         "notes": (
-            "実使用量（ディスク/メモリの実消費）は metrics-server / kubelet stats 依存のため未収集。"
-            "RBAC は get/list のみ、write 系の verb は含まない。"
+            "コンテナ/ノードの実メモリ・CPU 使用量は metrics-server (metrics.k8s.io) から取得 "
+            "(pod_metrics/node_metrics)。PVC の実ディスク使用量（du 相当）は別 CronJob 化が必要なため "
+            "未収集（T-0080）。RBAC は get/list のみ、write 系の verb は含まない。"
         ),
     }
 

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 80,
-  "updated": "2026-08-05T05:58:50Z",
+  "next_id": 81,
+  "updated": "2026-08-05T06:35:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -1389,20 +1389,20 @@
     {
       "id": "T-0077",
       "domain": "homelab",
-      "title": "ops-health-reporter に PVC 実使用量（du -sb）とコンテナ実メモリ/CPU（metrics-server）の取得を追加する",
+      "title": "ops-health-reporter に metrics-server 経由のコンテナ実メモリ/CPU 収集を追加する",
       "kind": "feature",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 5,
       "why": "issue #56 (2026-08-05 05:12:43) の指摘。T-0015 (#153) の ops-health-reporter は ArgoCD sync/health・Pod 異常・Node 状態は取れるが、PVC の `capacity`（宣言値）しか読んでおらず実使用量は取れない。コンテナの実メモリ/CPU 使用量も取れていない。この2つが無いと T-0066（immich ライブラリの実サイズ測定、restic 保存先の選定に必要）と、#132 で差し戻された resource limits の実測が永久に手に入らない",
-      "dod": "(1) 対象 PVC を `readOnly: true` でマウントし `du -sb` を実行する専用 CronJob（追加 RBAC 不要、既存の ops-health-reporter ClusterRole とは分離してよい）を追加し、結果を `ops/health/` 配下に書き戻す。(2) `metrics.k8s.io`（k3s 同梱の metrics-server）への read 権限を ops-health-reporter の ClusterRole に追加し、コンテナ単位の実メモリ/CPU 使用量を収集する。(2) は `nodes/proxy` のような広い権限を避け、`metrics.k8s.io` の `pods`/`nodes` read のみに絞る。T-0066 が求める実サイズがこれで得られることを確認する",
+      "dod": "ops-health-reporter の ClusterRole に metrics.k8s.io の pods/nodes read (get/list) を追加し、report.py が pod_metrics/node_metrics としてコンテナ単位の実メモリ/CPU 使用量を収集する。PVC の実ディスク使用量（du 相当）は T-0080 に分離した",
       "refs": [
         "apps/ops-health-reporter/",
         "ops/backlog.json"
       ],
       "created": "2026-08-05",
-      "pr": null,
-      "notes": "run #30: issue #56 (05:12:43) の提案をそのまま起票。実装自体はブロックされていないが、T-0075（CronJob が実際に動いているかの確認）が先に通ってから着手するのが安全（土台が動いていない状態に機能を足しても検証できない） | run #31: T-0075 は既に完了済み（着手可能）。T-0079 で node01 の実ディスクが 48.9GiB しか無いと判明し、PVC 実使用量が緊急の情報になったため priority を 36→5 に引き上げた（issue #56, 2026-08-05 05:35:04）"
+      "pr": 161,
+      "notes": "run #30: issue #56 (05:12:43) の提案をそのまま起票。実装自体はブロックされていないが、T-0075（CronJob が実際に動いているかの確認）が先に通ってから着手するのが安全（土台が動いていない状態に機能を足しても検証できない） | run #31: T-0075 は既に完了済み（着手可能）。T-0079 で node01 の実ディスクが 48.9GiB しか無いと判明し、PVC 実使用量が緊急の情報になったため priority を 36→5 に引き上げた（issue #56, 2026-08-05 05:35:04） | run #32: スコープを分割した。PVC ごとに namespace が異なる（immich/vaultwarden/coder）ため du -sb を実行する専用 CronJob は単一 Pod からの読み取りマウントで完結せず、namespace ごとの 設計が別途必要と判明。CHARTER『大きく感じたら分割する』に従い、metrics-server 経由のコンテナ 実メモリ/CPU 収集のみをこのタスクで完了し、PVC 実使用量の収集は T-0080 として新規起票した"
     },
     {
       "id": "T-0078",
@@ -1441,6 +1441,26 @@
       "created": "2026-08-05",
       "pr": null,
       "notes": "run #31: issue #56 (05:35:04) の指摘をそのまま起票。判断材料は ops-health-report ブランチの ops/health/latest.json（generated_at: 2026-08-05T05:30:09Z）。T-0066 の上限確定（B2 確定、Hetzner比較不要）にも直結。T-0077（PVC実使用量の取得）と合わせて実施すると、ディスク逼迫の全体像（容量×使用量）が揃う"
+    },
+    {
+      "id": "T-0080",
+      "domain": "homelab",
+      "title": "ops-health-reporter に PVC 実使用量（du -sb 相当）の収集を追加する",
+      "kind": "feature",
+      "risk": "low",
+      "status": "todo",
+      "priority": 5,
+      "why": "T-0077 (run #32) の分割で起票。PVC (immich-library, immich-postgres-data, vaultwarden-data, coder-postgres-data) はそれぞれ別 namespace (immich/vaultwarden/coder) にあり、Pod は自 namespace の PVC しかマウントできないため、既存の cluster-wide な ops-health-reporter CronJob 1 個には収まらない。namespace ごとに小さな CronJob を置き、結果をどう ops-health-reporter 側に集約するか（ConfigMap 経由 read 等）を設計してから実装する必要がある。T-0079（node01 実ディスク容量の食い違い）の裏付けとして も緊急度が高い",
+      "dod": "対象 4 PVC の実使用量が ops/health/latest.json（または別ファイル）から読める。namespace ごとの CronJob は読み取り専用マウント (readOnly: true) のみで PVC への書き込み権限を持たない。追加する RBAC は最小限（ConfigMap 経由にするなら該当 namespace 内の configmaps get/list/create/update のみに絞り、cluster-wide にしない）",
+      "refs": [
+        "apps/ops-health-reporter/",
+        "apps/immich/library-pvc.yaml",
+        "apps/immich/postgres.yaml",
+        "apps/vaultwarden/pvc.yaml",
+        "apps/coder/postgres.yaml"
+      ],
+      "created": "2026-08-05",
+      "pr": null
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,28 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 161,
+      "title": "ops-health-reporter に metrics-server 経由のコンテナ実メモリ/CPU 収集を追加",
+      "url": "https://github.com/hikuohiku/homelab/pull/161",
+      "isDraft": false,
+      "createdAt": "2026-08-05T06:25:18Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "PENDING"
+        }
+      ],
+      "headRefName": "autopilot/T-0077-metrics-collect",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 160,
+      "title": "ops: node01 実ディスク容量の食い違いを起票、PR作り直し時の規則を追記 (T-0079)",
+      "url": "https://github.com/hikuohiku/homelab/pull/160",
+      "mergedAt": "2026-08-05T06:05:50Z",
+      "headRefName": "autopilot/T-0079-node01-disk-discrepancy"
+    },
     {
       "number": 159,
       "title": "ops: 取り残された cooldown/直列化の衝突対策を CHARTER に戻す",
@@ -399,13 +421,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/101",
       "mergedAt": "2026-08-04T22:42:03Z",
       "headRefName": "autopilot/run-11-wrapup"
-    },
-    {
-      "number": 100,
-      "title": "upgrade(tailscale): operator chart 1.90.9→1.98.9、k8s-nameserver を v1.98.9 に揃える (T-0024, T-0025)",
-      "url": "https://github.com/hikuohiku/homelab/pull/100",
-      "mergedAt": "2026-08-04T22:40:28Z",
-      "headRefName": "autopilot/T-0024-T-0025-tailscale-upgrade"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -984,3 +984,19 @@
   しか無い場合は disk 拡張のやり直し or PVC 要求量の削減を検討する新タスクを起票、(b) kubelet
   側の古い値と判明した場合は health-reporter か CronJob 再起動を疑う、のいずれかに分岐する。
   backlog の他の todo（T-0077 等）はこの調査と並行して進めてよい
+
+## 2026-08-05 15:25 JST — run #32
+
+- 前回の中断: なし（open PR、autopilot/* ブランチとも無し。クリーンな状態から開始）
+- 読んだフィードバック: issue #56 に未読は無かった（05:56:49 以降の新着1件は自分自身の直前の
+  返信コメントで、新しい人間フィードバックではないと確認）
+- `ops-health-report` ブランチを確認（generated_at 06:00:04Z、直近）。ArgoCD 10 アプリ全て
+  Synced/Healthy。T-0079（node01 実ディスク容量の食い違い）は人間からの df -h/lsblk 報告が
+  まだ来ておらず、依然 needs-human・priority 1 のまま
+- やったこと: backlog の todo が T-0077 のみだったため着手。当初のスコープ（PVC実使用量 + 
+  metrics-server 経由のコンテナ実メモリ/CPU）のうち、PVC 実使用量は対象 PVC が immich/vaultwarden/
+  coder の3 namespace に分散しており単一 CronJob では収まらない（Pod は自 namespace の PVC しか
+  マウントできない）と判明したため分割。metrics-server 経由のコンテナ/ノード実メモリ・CPU 収集
+  のみを実装し T-0077 を done、PVC 実使用量は T-0080 として新規起票（#161）
+- 次の起動へ: #161 の CI green を確認して merge すること。T-0080（PVC実使用量、priority 5）が
+  次の候補。T-0079 は引き続き人間の df -h/lsblk 報告待ち

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T05:58:50Z",
+  "updated": "2026-08-05T06:25:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -378,6 +378,16 @@
       "summary": "オープン PR・autopilot ブランチとも無く中断なし（#159 は構築セッションが既に自力で作成・merge 済みで main に反映確認済み）。issue #56 の未読フィードバック2件を反映: (1) 05:35:04（重要）ops-health-report の実測で node01 の ephemeral-storage capacity が 48.9GiB しか無いと判明、terraform/docs/CLAUDE.md が前提とする 256GiB と食い違う。PVC requested 合計 215Gi（immich-library 単体 50Gi）が既に実ディスクを超えており local-path 特性上ディスク逼迫で全データ同時破損のリスクがあるため、T-0079（needs-human, priority 1）として起票し人間に df -h/lsblk での実機確認を依頼。ドキュメントは実態未確定のため書き換えず。T-0066 は上限確定（immich ライブラリは物理的に49GiB上限、保存先はBackblaze B2で確定）を notes に反映。T-0077（PVC実使用量取得）の priority を 36→5 に引き上げ。(2) 05:56:49: #155→#158 の作り直しで CHARTER の8行(cooldown/直列化対処)が一時的に main から漏れていた件（構築セッションが #159 で復旧済み）を受け、CHARTER §4 に『PR を作り直すときは git diff で旧ブランチとの差分ゼロを確認する』『新しい規則を足すときは既存規則との前提衝突を1行考える』の2点を追記",
       "prs": [
         160
+      ]
+    },
+    {
+      "n": 32,
+      "at": "2026-08-05T06:25:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 の未読1件は自分自身の直前の返信で、新しい人間フィードバックなし。T-0079（node01 実ディスク容量の食い違い）は引き続き人間の df -h/lsblk 報告待ち。backlog の todo が T-0077 のみだったため着手。当初スコープ（PVC実使用量 + metrics-server 経由のコンテナ実メモリ/CPU）のうち、PVC 実使用量は対象4 PVC が immich/vaultwarden/coder の3 namespace に分散しており単一 CronJob には収まらない（Pod は自 namespace の PVC しかマウントできない）と判明したため分割。metrics-server 経由のコンテナ/ノード実メモリ・CPU 収集のみを実装し T-0077 を done、PVC 実使用量は T-0080 として新規起票（#161）",
+      "prs": [
+        161
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

`ops-health-reporter`（クラスタ内から状態を集めて `ops-health-report` ブランチへ書き戻す CronJob）に、metrics-server 経由でコンテナ/ノードの実メモリ・CPU 使用量を収集する機能を追加しました。

- `apps/ops-health-reporter/rbac.yaml`: ClusterRole に `metrics.k8s.io` の `pods`/`nodes` に対する `get`/`list` を追加（write 系 verb は含まない）
- `apps/ops-health-reporter/report.py`: `pod_metrics`（namespace/pod/container 単位の cpu・memory）と `node_metrics`（node 単位）を `ops/health/latest.json` に追加

## 検証したこと

- 既存の各 `collect_*()` と同様に `try/except` でラップしており（`collect()` ヘルパー）、metrics-server 側にアクセスできない場合でも他の項目（ArgoCD sync/health 等）の収集は継続し、ジョブ全体は失敗しません
- `python3 ops/validate.py` は 0 error（既存の warning 5 件のみ、本 PR の変更とは無関係）
- クラスタへの到達手段がこの実行環境に無いため、`kustomize build --enable-helm` による manifest 検証と実際の CronJob 動作確認は CI (`manifest-diff` job) と次回以降の起動での `ops-health-report` ブランチ確認に委ねています

## 観測経路への影響について

この変更は自分（autopilot）がクラスタの健全性を観測する経路（`ops-health-reporter`）自身に対するものです。反映中に一時的にジョブが失敗しても、既存の `collect()` によるエラーラップにより他の収集項目は継続され、`ops/health/latest.json` の `generated_at` が更新されなくなる（30分以上古いまま）ことで異常に気づけます。次回起動時の CHARTER §2 の確認手順でこれを検知します。

## ロールバック手順

`git revert` でこのコミットを打ち消す PR を作成し merge すれば、ArgoCD が自動的に旧 RBAC/CronJob 定義へ収束します。データを持たない読み取り専用の変更のため、ロールバックによる副作用はありません。

## backlog

T-0077（元タスクをスコープ分割。PVC の実使用量収集は namespace ごとの設計が別途必要なため T-0080 として分離）

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnuvypW45QVrTDoAtFzaZN)_