### PR TITLE
run #34: T-0080 の並行セッション調整反映、記録更新

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 81,
-  "updated": "2026-08-05T06:41:00Z",
+  "updated": "2026-08-05T06:50:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -1448,7 +1448,7 @@
       "title": "ops-health-reporter に PVC 実使用量（du -sb 相当）の収集を追加する",
       "kind": "feature",
       "risk": "low",
-      "status": "todo",
+      "status": "blocked",
       "priority": 5,
       "why": "T-0077 (run #32) の分割で起票。PVC (immich-library, immich-postgres-data, vaultwarden-data, coder-postgres-data) はそれぞれ別 namespace (immich/vaultwarden/coder) にあり、Pod は自 namespace の PVC しかマウントできないため、既存の cluster-wide な ops-health-reporter CronJob 1 個には収まらない。namespace ごとに小さな CronJob を置き、結果をどう ops-health-reporter 側に集約するか（ConfigMap 経由 read 等）を設計してから実装する必要がある。T-0079（node01 実ディスク容量の食い違い）の裏付けとして も緊急度が高い",
       "dod": "対象 4 PVC の実使用量が ops/health/latest.json（または別ファイル）から読める。namespace ごとの CronJob は読み取り専用マウント (readOnly: true) のみで PVC への書き込み権限を持たない。追加する RBAC は最小限（ConfigMap 経由にするなら該当 namespace 内の configmaps get/list/create/update のみに絞り、cluster-wide にしない）",
@@ -1461,8 +1461,8 @@
         "apps/coder/postgres.yaml"
       ],
       "created": "2026-08-05",
-      "pr": null,
-      "notes": "run #33: 実装前に2つ blocked にした。(1) このタスク自体が既に認識している namespace 分散の課題に加え、既存 Pod（immich-server 等）が `securityContext.fsGroup` を設定している場合、新しい CronJob Pod が同じ PVC を readOnly でマウントしても kubelet がマウント時にボリューム全体へ再帰的な chown を試みることがある（fsGroup が Pod ごとの設定のため、chart のデフォルト値をこのサンドボックスから確認できていない）。immich-library だけで 50Gi あり、ディスクが逼迫している疑いのある状況（T-0079）でこの走査を追加するとディスク I/O 負荷が増え悪化させるリスクがある。(2) 実装しても実機で動作確認する手段が無く（kubectl 不可）、fsGroup の挙動を机上でしか検証できないため、着手前に T-0079 で実際の空き容量の余裕を確認しておきたい。T-0079 の df -h/lsblk 報告が来たら、fsGroup の値を values.yaml 等で明示指定してから実装するか検討する"
+      "pr": 163,
+      "notes": "run #33: 実装前に2つ blocked にした。(1) このタスク自体が既に認識している namespace 分散の課題に加え、既存 Pod（immich-server 等）が `securityContext.fsGroup` を設定している場合、新しい CronJob Pod が同じ PVC を readOnly でマウントしても kubelet がマウント時にボリューム全体へ再帰的な chown を試みることがある（fsGroup が Pod ごとの設定のため、chart のデフォルト値をこのサンドボックスから確認できていない）。immich-library だけで 50Gi あり、ディスクが逼迫している疑いのある状況（T-0079）でこの走査を追加するとディスク I/O 負荷が増え悪化させるリスクがある。(2) 実装しても実機で動作確認する手段が無く（kubectl 不可）、fsGroup の挙動を机上でしか検証できないため、着手前に T-0079 で実際の空き容量の余裕を確認しておきたい。T-0079 の df -h/lsblk 報告が来たら、fsGroup の値を values.yaml 等で明示指定してから実装するか検討する | run #34: 実装を完了し #163 として PR 化した。3 namespace (immich/vaultwarden/coder) それぞれに pvc-usage-reporter CronJob を追加し、対象 PVC を readOnly マウントして 標準ライブラリのみでディレクトリサイズを合計、自 namespace の ConfigMap へ書き戻す設計。#162（run #33、並行セッション）が指摘した fsGroup 再帰 chown リスクは、この実装が pod レベルの securityContext.fsGroup を一切設定しない（所有者違いのファイルは runAsUser: 0 の DAC_OVERRIDE で読む）ことで構造的に回避しており該当しないと #163 に コメントで説明した。ただし #162 のもう一つの懸念（T-0079 未解決のままディスクへ新しい I/O 負荷をかけるべきではない）は独立した妥当な慎重さのため踏襲し、blocked_by は T-0079 のまま維持。実装は完了済みなので T-0079 解決後は即 merge 可能"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,28 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 163,
+      "title": "PVC の実使用量を計測する namespace 別 CronJob を追加 (T-0080)",
+      "url": "https://github.com/hikuohiku/homelab/pull/163",
+      "isDraft": false,
+      "createdAt": "2026-08-05T06:33:10Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "PENDING"
+        }
+      ],
+      "headRefName": "autopilot/T-0080-pvc-usage",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 162,
+      "title": "ops: T-0080 に fsGroup 再帰 chown リスクを追記 (run #33)",
+      "url": "https://github.com/hikuohiku/homelab/pull/162",
+      "mergedAt": "2026-08-05T06:33:03Z",
+      "headRefName": "autopilot/T-0080-fsgroup-risk-note"
+    },
     {
       "number": 161,
       "title": "ops-health-reporter に metrics-server 経由のコンテナ実メモリ/CPU 収集を追加",
@@ -399,20 +421,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/103",
       "mergedAt": "2026-08-04T23:09:47Z",
       "headRefName": "autopilot/run12-wrapup"
-    },
-    {
-      "number": 102,
-      "title": "external-secrets chart を 1.1.1 → 1.3.2 に上げる (T-0026)",
-      "url": "https://github.com/hikuohiku/homelab/pull/102",
-      "mergedAt": "2026-08-04T23:08:09Z",
-      "headRefName": "autopilot/run12-feedback-t0026"
-    },
-    {
-      "number": 101,
-      "title": "ops: run #11 の記録をまとめ、ダッシュボードを再生成する",
-      "url": "https://github.com/hikuohiku/homelab/pull/101",
-      "mergedAt": "2026-08-04T22:42:03Z",
-      "headRefName": "autopilot/run-11-wrapup"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1020,3 +1020,22 @@
 - 次の起動へ: backlog の todo は 0 件（T-0080 は T-0079 待ちで blocked）。T-0079（node01 実ディスク
   容量、needs-human・priority 1）が引き続き最優先のブロッカー。df -h/lsblk の報告が来たら T-0080
   の blocked_by を解除して再検討する
+
+## 2026-08-05 15:35 JST — run #34
+
+- 続き: PR #161（T-0077, metrics-server 経由のコンテナ実メモリ/CPU 収集）の merge を見届けた後、
+  T-0080（PVC 実使用量収集）に着手。immich/vaultwarden/coder の3 namespace それぞれに
+  pvc-usage-reporter CronJob を実装（対象 PVC を readOnly マウントし標準ライブラリのみで
+  ディレクトリサイズを合計、自 namespace の ConfigMap へ書き戻す。ops-health-reporter 側は
+  configmaps の get を resourceNames で1オブジェクト名に絞って追加し3 namespace 分を集約）
+- ラップアップ中に、同じ cron から並行して起動していた別セッション（run #33）が先に T-0080 の
+  backlog に fsGroup 再帰 chown リスクの notes と `blocked_by: T-0079` を追記済み（#162, merge済み）
+  と判明。origin/main を rebase して追従した上で、この実装は pod レベルの `securityContext.fsGroup`
+  を一切設定しない設計（所有者違いのファイルは `runAsUser: 0` の DAC_OVERRIDE で読む）のため
+  fsGroup 再帰 chown リスクは構造的に該当しないと PR #163 にコメントで説明した。ただし #162 の
+  もう一つの懸念（T-0079 未解決のままディスクへ新しい I/O 負荷をかけるべきではない）は独立した
+  妥当な慎重さのため踏襲し、blocked_by は T-0079 のまま維持。#163 は実装完了・auto-merge 未有効化
+  の状態で open のまま起動を終える
+- 次の起動へ: PR #163（T-0080, 実装完了・T-0079 待ちで open）を拾うこと。T-0079（node01 実ディスク
+  容量、needs-human・priority 1）が引き続き最優先のブロッカー。df -h/lsblk の報告が来たら #163 を
+  merge してよい

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T06:41:00Z",
+  "updated": "2026-08-05T06:50:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -397,6 +397,16 @@
       "by": "cloud routine",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。着手直後に、同じ cron から同時刻に起動した別セッション（run #32 を先に使用）が T-0077 を分割実装済み（metrics-server 経由のコンテナ実メモリ/CPU 収集、#161 merge 済み）・T-0080（PVC実使用量）を起票済みと判明。自分が用意していたローカル変更（T-0077 を丸ごと blocked にする案）は stale だったため破棄し、origin/main へ reset して再出発（journal 側は run #33 に採番し直した）。T-0080 に、自分が独自に見つけていた懸念（fsGroup が既存 Pod と食い違うと readOnly マウントでも kubelet が再帰的 chown を試みうるリスク、ディスク逼迫が疑われる状況での追加走査の危険性）を notes として追記し、T-0079 待ちの blocked_by を付けた。同一 cron から複数セッションが同時起動し run 番号が衝突する事例を初めて確認",
       "prs": []
+    },
+    {
+      "n": 34,
+      "at": "2026-08-05T06:35:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "PR #161（T-0077, metrics-server 経由のコンテナ実メモリ/CPU 収集）の merge を見届けた後、T-0080（PVC実使用量収集）に着手。immich/vaultwarden/coder の3 namespace それぞれに pvc-usage-reporter CronJob を実装（対象 PVC を readOnly マウントし標準ライブラリのみでディレクトリサイズを合計、自 namespace の ConfigMap へ書き戻す）。ラップアップ中に並行セッション（run #33, #162）が先に T-0080 へ fsGroup 再帰 chown リスクと blocked_by: T-0079 を記録済みと判明。この実装は pod レベルの fsGroup を設定しない設計のためそのリスクは該当しないと #163 にコメントで説明したが、もう一つの懸念（T-0079 未解決のまま新しい I/O 負荷をかけない）は踏襲し、#163 は実装完了・merge保留のまま open で起動を終えた",
+      "prs": [
+        163
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

- `ops/backlog.json`: T-0080 を `blocked`（`blocked_by: T-0079`）のまま `pr: 163` を記録。並行セッション（#162, run #33）が指摘した fsGroup 再帰 chown リスクは、#163 の実装が pod レベルの `securityContext.fsGroup` を設定しない設計のため該当しないと PR コメントで説明済み。もう一つの懸念（T-0079 未解決のまま新しい I/O 負荷をかけない）は妥当なため踏襲し、blocked のまま維持
- `ops/journal/2026-08.md`: run #34 の記録を追記
- `ops/state.json`: run #34 のエントリを追加
- `ops/dashboard/prs.json`: PR キャッシュを最新化（#161/#162 の merge を反映）

この起動（run #32〜#34 相当）は複数の並行セッションと同時に動いており、CHARTER §2 の直列化原則に従って前段（#161, #162）の merge を待ってから本 PR を作成しています。実装本体（PVC 実使用量収集）は #163 で完結しており、この PR は記録のみです。

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 正常終了、ダッシュボードを既存の Artifact URL へ再公開済み

## ロールバック手順

`ops/` 配下の記録更新のみ（repo 内で閉じる変更）。問題があれば revert すれば良く、実インフラへの影響はありません。

## backlog

T-0080（記録更新のみ。実装は #163）

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnuvypW45QVrTDoAtFzaZN)_