### PR TITLE
ci: pvc-usage-reporter の埋め込みスクリプト3ファイルの一致を検証する (T-0081)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,8 @@ jobs:
         run: python3 ops/validate.py
       - name: check duplicated version pins are in sync
         run: python3 ops/check_version_sync.py
+      - name: check pvc-usage-reporter script is in sync across namespaces
+        run: python3 ops/check_pvc_usage_script_sync.py
       - name: dashboard build.py runs without error
         # index.html は生成物なので git 管理していない（T-0035）。壊れていないことだけここで担保する
         run: python3 ops/dashboard/build.py

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1481,7 +1481,7 @@
         "apps/coder/pvc-usage-cronjob.yaml"
       ],
       "created": "2026-08-05",
-      "pr": null,
+      "pr": 166,
       "notes": "run #35: ops/check_version_sync.py と同じ標準ライブラリのみの方針で ops/check_pvc_usage_script_sync.py を作成。ブロックスカラー（`pvc_usage.py: |`）をインデント境界で抽出し3ファイル間で完全一致を検証する。既存の ops job（ruleset の必須チェックの1つ）にステップとして追加したため、新しい required check の登録依頼は不要（既存job内の追加ステップのため）。手元で1ファイルだけ書き換えて非0終了することを確認済み。フル共有化（Kustomize component 化等のアーキテクチャ変更）は見送り、drift の機械検出のみに留めた（CHARTER『器を太らせる前に使い切る』、既存パターンの横展開で足りるため）"
     }
   ]

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 81,
-  "updated": "2026-08-05T07:15:00Z",
+  "next_id": 82,
+  "updated": "2026-08-05T07:25:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -1462,6 +1462,27 @@
       "created": "2026-08-05",
       "pr": 163,
       "notes": "run #33: 実装前に2つ blocked にした。(1) このタスク自体が既に認識している namespace 分散の課題に加え、既存 Pod（immich-server 等）が `securityContext.fsGroup` を設定している場合、新しい CronJob Pod が同じ PVC を readOnly でマウントしても kubelet がマウント時にボリューム全体へ再帰的な chown を試みることがある（fsGroup が Pod ごとの設定のため、chart のデフォルト値をこのサンドボックスから確認できていない）。immich-library だけで 50Gi あり、ディスクが逼迫している疑いのある状況（T-0079）でこの走査を追加するとディスク I/O 負荷が増え悪化させるリスクがある。(2) 実装しても実機で動作確認する手段が無く（kubectl 不可）、fsGroup の挙動を机上でしか検証できないため、着手前に T-0079 で実際の空き容量の余裕を確認しておきたい。T-0079 の df -h/lsblk 報告が来たら、fsGroup の値を values.yaml 等で明示指定してから実装するか検討する | run #34: 実装を完了し #163 として PR 化した。3 namespace (immich/vaultwarden/coder) それぞれに pvc-usage-reporter CronJob を追加し、対象 PVC を readOnly マウントして 標準ライブラリのみでディレクトリサイズを合計、自 namespace の ConfigMap へ書き戻す設計。#162（run #33、並行セッション）が指摘した fsGroup 再帰 chown リスクは、この実装が pod レベルの securityContext.fsGroup を一切設定しない（所有者違いのファイルは runAsUser: 0 の DAC_OVERRIDE で読む）ことで構造的に回避しており該当しないと #163 に コメントで説明した。ただし #162 のもう一つの懸念（T-0079 未解決のままディスクへ新しい I/O 負荷をかけるべきではない）は独立した妥当な慎重さのため踏襲し、blocked_by は T-0079 のまま維持。実装は完了済みなので T-0079 解決後は即 merge 可能 | run #35: 構築セッションのレビュー（issue #56, 06:38:17）を受け2点反映。(1) `capabilities: {drop: [ALL], add: [DAC_READ_SEARCH]}` を3つの CronJob 全てに追加し、`runAsUser: 0` を読み取り専用のパーミッションチェック回避のみに絞った。(2) `blocked_by: T-0079` を解除した。根拠: この走査は `os.lstat` によるサイズ合計のみでファイル内容を読まず書き込みも行わず、ディスク容量も消費しない。T-0079 が懸念する『書き込み系 I/O がディスク逼迫を悪化させる』とは負荷の性質が異なるため、解決を待つ理由が無いと判断した。CI green と issue #56 に新しい異議が無いことを確認し #163 を merge。done とする"
+    },
+    {
+      "id": "T-0081",
+      "domain": "homelab",
+      "title": "pvc-usage-reporter の埋め込みスクリプトが3ファイルで揃っているか CI で検証する",
+      "kind": "ci",
+      "risk": "low",
+      "status": "done",
+      "priority": 6,
+      "why": "run #35 の subagent 調査で発見。T-0080 (#163) で apps/{immich,vaultwarden,coder}/pvc-usage-cronjob.yaml の3ファイルに同一の pvc_usage.py スクリプト（約90行、ConfigMap の data ブロック内）をコピーして持ち込んだ。namespace ごとにマウントできる PVC が異なるため単一ファイルへの統合はできない構成上、将来どれか1つだけを直して他を直し忘れる drift が起きうる（ops/CHARTER.md が警戒する『同じ事実が2箇所に書かれている』の3箇所版）",
+      "dod": "3ファイルの埋め込みスクリプトが一致することを検証する CI チェックがあり、既存の必須チェック（ops job）に含まれる。わざと1ファイルだけ変えて CI が落ちることを確認する",
+      "refs": [
+        "ops/check_pvc_usage_script_sync.py",
+        ".github/workflows/ci.yml",
+        "apps/immich/pvc-usage-cronjob.yaml",
+        "apps/vaultwarden/pvc-usage-cronjob.yaml",
+        "apps/coder/pvc-usage-cronjob.yaml"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #35: ops/check_version_sync.py と同じ標準ライブラリのみの方針で ops/check_pvc_usage_script_sync.py を作成。ブロックスカラー（`pvc_usage.py: |`）をインデント境界で抽出し3ファイル間で完全一致を検証する。既存の ops job（ruleset の必須チェックの1つ）にステップとして追加したため、新しい required check の登録依頼は不要（既存job内の追加ステップのため）。手元で1ファイルだけ書き換えて非0終了することを確認済み。フル共有化（Kustomize component 化等のアーキテクチャ変更）は見送り、drift の機械検出のみに留めた（CHARTER『器を太らせる前に使い切る』、既存パターンの横展開で足りるため）"
     }
   ]
 }

--- a/ops/check_pvc_usage_script_sync.py
+++ b/ops/check_pvc_usage_script_sync.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+apps/{immich,vaultwarden,coder}/pvc-usage-cronjob.yaml に埋め込まれた pvc_usage.py
+スクリプトが3ファイルとも一致しているか検証する。CI (ops job) から実行する。
+
+T-0080 でこの3ファイルに同一のスクリプトをコピーして持ち込んだ（1ファイルにまとめる
+共有元が無い構成のため）。今後どれか1つだけを直して他を直し忘れる drift を機械的に
+検出する（ops/check_version_sync.py と同じ考え方。標準ライブラリのみで動くこと）。
+"""
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+PATHS = [
+    "apps/immich/pvc-usage-cronjob.yaml",
+    "apps/vaultwarden/pvc-usage-cronjob.yaml",
+    "apps/coder/pvc-usage-cronjob.yaml",
+]
+
+
+def extract_block_scalar(path: str, key: str) -> str:
+    """`<key>: |` の行から、その行より深いインデントが続く範囲（ブロックスカラーの中身）を
+    そのまま返す。インデントが戻る最初の行（次の兄弟キーや `---` 区切り）で打ち切る。
+    """
+    text = (ROOT / path).read_text()
+    m = re.search(rf"^([ \t]*){re.escape(key)}:\s*\|\s*$", text, re.MULTILINE)
+    if not m:
+        raise ValueError(f"{path}: `{key}: |` が見つからない")
+    key_indent = len(m.group(1))
+    lines = text[m.end() :].splitlines(keepends=True)
+    body = []
+    for line in lines:
+        stripped = line.strip("\n")
+        if stripped == "":
+            body.append(line)
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        if indent <= key_indent:
+            break
+        body.append(line)
+    if not body:
+        raise ValueError(f"{path}: `{key}: |` の中身が空")
+    return "".join(body)
+
+
+def main() -> int:
+    scripts = []
+    for path in PATHS:
+        try:
+            scripts.append((path, extract_block_scalar(path, "pvc_usage.py")))
+        except Exception as e:
+            print(f"::error::{path}: 抽出に失敗しました: {e}")
+            return 1
+
+    canonical_path, canonical = scripts[0]
+    mismatches = [path for path, body in scripts if body != canonical]
+    if mismatches:
+        print(
+            f"::error::pvc_usage.py が {canonical_path} と一致しません: {mismatches}"
+            " (apps/{immich,vaultwarden,coder}/pvc-usage-cronjob.yaml の埋め込みスクリプトは"
+            " 全て同一である必要があります)"
+        )
+        return 1
+
+    print(f"ok: pvc_usage.py は {len(scripts)} ファイルで一致 ({canonical_path} が正)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,5 +1,20 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 166,
+      "title": "ci: pvc-usage-reporter の埋め込みスクリプト3ファイルの一致を検証する (T-0081)",
+      "url": "https://github.com/hikuohiku/homelab/pull/166",
+      "isDraft": false,
+      "createdAt": "2026-08-05T07:07:00Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "PENDING"
+        }
+      ],
+      "headRefName": "autopilot/T-0081-pvc-usage-script-sync",
+      "autoMergeRequest": true
+    }
+  ],
   "merged": [
     {
       "number": 163,

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1052,7 +1052,14 @@
   T-0079 の懸念（書き込み系 I/O の悪化）に該当しないため解除してよい
 - やったこと: 上記2点を #163 に追加コミットで反映し、CI green と issue #56 に新しい異議が無い
   ことを確認したうえで同一起動内で merge した（cooldown は run #34 の open からこの起動までの
-  間隔で満たされている）。backlog の T-0080 を done に更新
-- 見つけたこと: なし
+  間隔で満たされている）。backlog の T-0080 を done に更新（#165）。続けて backlog の todo が
+  0 件になったため CHARTER §3 に従い subagent に新しい調査観点探しを投げ、T-0080 (#163) が
+  apps/{immich,vaultwarden,coder}/pvc-usage-cronjob.yaml の3ファイルに同一の pvc_usage.py
+  スクリプト（約90行）をコピーして持ち込んでいたと判明。namespace ごとに PVC が異なり単一
+  ファイルへの統合はできない構成のため、将来どれか1つだけ直して他を直し忘れる drift の
+  リスクがある。T-0081 として起票・即完遂し、ops/check_version_sync.py と同じ標準ライブラリ
+  のみの方針で ops/check_pvc_usage_script_sync.py を作成、既存の ops job（ruleset の必須
+  チェック）にステップとして追加した。1ファイルだけ書き換えて非0終了することを手元で確認済み
+- 見つけたこと: なし（T-0081 はフィードバック起因ではなく自発的な調査による発見）
 - 次の起動へ: なし。T-0079（node01 実ディスク容量、needs-human・priority 1）が引き続き最優先。
   backlog の todo は 0 件

--- a/ops/state.json
+++ b/ops/state.json
@@ -413,10 +413,11 @@
       "at": "2026-08-05T07:00:00Z",
       "kind": "scheduled",
       "by": "cloud routine",
-      "summary": "PR #163（T-0080, run #34 が blocked_by: T-0079 のまま open で終了）を拾った。issue #56 の未読2件を反映: fsGroup リスクの再確認（該当せず）と run 番号衝突の説明は対応不要。#163 のレビューを受け、capabilities を drop: [ALL] + add: [DAC_READ_SEARCH] に絞り runAsUser: 0 のフル root 権限を回避、blocked_by: T-0079 は走査が os.lstat のみでディスク容量を消費せず T-0079 の懸念（書き込み系 I/O の悪化）に該当しないため解除。CI green と新しい異議が無いことを確認し #163 を merge、T-0080 を done にした（#165）",
+      "summary": "PR #163（T-0080, run #34 が blocked_by: T-0079 のまま open で終了）を拾った。issue #56 の未読2件を反映: fsGroup リスクの再確認（該当せず）と run 番号衝突の説明は対応不要。#163 のレビューを受け、capabilities を drop: [ALL] + add: [DAC_READ_SEARCH] に絞り runAsUser: 0 のフル root 権限を回避、blocked_by: T-0079 は走査が os.lstat のみでディスク容量を消費せず T-0079 の懸念（書き込み系 I/O の悪化）に該当しないため解除。CI green と新しい異議が無いことを確認し #163 を merge、T-0080 を done にした（#165）。続けて backlog の todo が0件になったため subagent に新しい調査観点探しを投げ、T-0080 (#163) が apps/{immich,vaultwarden,coder} の3ファイルに同一の pvc_usage.py スクリプトをコピーして持ち込んでいたと判明。ops/check_pvc_usage_script_sync.py を新設し既存の ops job に組み込んで3ファイルの一致を CI で検証するようにした（T-0081, #166）",
       "prs": [
         163,
-        165
+        165,
+        166
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

T-0080（#163）で `apps/{immich,vaultwarden,coder}/pvc-usage-cronjob.yaml` の3ファイルに、PVC の実使用量を計測する同一の `pvc_usage.py` スクリプト（約90行、ConfigMap の `data` ブロック内）をコピーして持ち込みました。namespace ごとにマウントできる PVC が異なるため単一ファイルへの統合はできない構成上、将来どれか1つだけ直して他を直し忘れる drift が起きえます（`ops/check_version_sync.py` が既に検出している「同じ事実が複数箇所に書かれている」の3箇所版）。

- `ops/check_pvc_usage_script_sync.py` を新設。3ファイルの `pvc_usage.py: |` ブロックスカラーをインデント境界で抽出し、完全一致することを検証する（標準ライブラリのみ、`ops/check_version_sync.py` と同じ方針）
- 既存の `ops` job（`main` の ruleset が必須チェックにしている3つのうちの1つ）にステップとして追加。新しい required check の登録依頼は不要（既存 job 内の追加ステップのため）

フル共有化（Kustomize component 化などのアーキテクチャ変更）は見送り、drift の機械検出のみに留めています。

## 検証したこと

- `python3 ops/check_pvc_usage_script_sync.py`: 3ファイル一致で 0 終了を確認
- 1ファイルだけ書き換えて非0終了・差分の報告を確認（手元で revert 済み）
- `python3 ops/validate.py`: 0 error

## ロールバック手順

`git revert` で打ち消せる。検証ステップの追加のみでクラスタへの影響は無い。

## backlog

T-0081（この PR で done）

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABeVmaH2GSPgNKmWXwpt4W)_