### PR TITLE
T-0082: pvc-usage-reporter の python イメージを inventory 監視対象に追加

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1502,7 +1502,7 @@
         "apps/vaultwarden/pvc-usage-cronjob.yaml"
       ],
       "created": "2026-08-05",
-      "pr": null,
+      "pr": 167,
       "notes": "run #36: inventory.json に pvc-usage-reporter-image（current: 3.12-alpine, mirrors: coder/vaultwarden の2ファイル）を追加し、check_version_sync.py の GROUPS に対応する3ファイルの mirror group を追加した。手元で apps/coder/pvc-usage-cronjob.yaml だけタグを 3.13-alpine に変えて非0終了することを確認済み（変更後は元に戻した）。バージョン更新自体はスコープ外（現行 3.12-alpine のまま、監視の仕組みのみ追加）"
     }
   ]

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 82,
-  "updated": "2026-08-05T07:25:00Z",
+  "next_id": 83,
+  "updated": "2026-08-05T07:35:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -1483,6 +1483,27 @@
       "created": "2026-08-05",
       "pr": 166,
       "notes": "run #35: ops/check_version_sync.py と同じ標準ライブラリのみの方針で ops/check_pvc_usage_script_sync.py を作成。ブロックスカラー（`pvc_usage.py: |`）をインデント境界で抽出し3ファイル間で完全一致を検証する。既存の ops job（ruleset の必須チェックの1つ）にステップとして追加したため、新しい required check の登録依頼は不要（既存job内の追加ステップのため）。手元で1ファイルだけ書き換えて非0終了することを確認済み。フル共有化（Kustomize component 化等のアーキテクチャ変更）は見送り、drift の機械検出のみに留めた（CHARTER『器を太らせる前に使い切る』、既存パターンの横展開で足りるため）"
+    },
+    {
+      "id": "T-0082",
+      "domain": "homelab",
+      "title": "pvc-usage-reporter CronJob の python イメージを ops/inventory.json の監視対象に追加する",
+      "kind": "ci",
+      "risk": "low",
+      "status": "done",
+      "priority": 6,
+      "why": "run #36 の調査で発見。T-0080 (#163) が追加した apps/{immich,vaultwarden,coder}/pvc-usage-cronjob.yaml の3ファイルは同じ python:3.12-alpine タグを使っているが、ops-health-reporter-image と違って ops/inventory.json に対応するエントリが無く、上流の新しいリリースを誰も監視していなかった。加えて check_version_sync.py の GROUPS にも入っておらず、3ファイルのうち1つだけタグを上げても CI が検出できない状態だった（T-0051/T-0081 と同型の抜け）",
+      "dod": "ops/inventory.json に pvc-usage-reporter-image エントリ（mirrors で他2ファイルを指定）を追加する。ops/check_version_sync.py の GROUPS に3ファイル分の mirror group を追加し、1ファイルだけタグを変えると非0終了することを手元で確認する",
+      "refs": [
+        "ops/inventory.json",
+        "ops/check_version_sync.py",
+        "apps/immich/pvc-usage-cronjob.yaml",
+        "apps/coder/pvc-usage-cronjob.yaml",
+        "apps/vaultwarden/pvc-usage-cronjob.yaml"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #36: inventory.json に pvc-usage-reporter-image（current: 3.12-alpine, mirrors: coder/vaultwarden の2ファイル）を追加し、check_version_sync.py の GROUPS に対応する3ファイルの mirror group を追加した。手元で apps/coder/pvc-usage-cronjob.yaml だけタグを 3.13-alpine に変えて非0終了することを確認済み（変更後は元に戻した）。バージョン更新自体はスコープ外（現行 3.12-alpine のまま、監視の仕組みのみ追加）"
     }
   ]
 }

--- a/ops/check_version_sync.py
+++ b/ops/check_version_sync.py
@@ -188,6 +188,20 @@ GROUPS = [
             )),
         ],
     },
+    {
+        "name": "pvc-usage-reporter python image tag (T-0082, inventory: pvc-usage-reporter-image)",
+        "targets": [
+            ("apps/immich/pvc-usage-cronjob.yaml", lambda: extract_image_tag(
+                "apps/immich/pvc-usage-cronjob.yaml", "image: python:"
+            )),
+            ("apps/coder/pvc-usage-cronjob.yaml", lambda: extract_image_tag(
+                "apps/coder/pvc-usage-cronjob.yaml", "image: python:"
+            )),
+            ("apps/vaultwarden/pvc-usage-cronjob.yaml", lambda: extract_image_tag(
+                "apps/vaultwarden/pvc-usage-cronjob.yaml", "image: python:"
+            )),
+        ],
+    },
 ]
 
 

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,35 @@
 {
   "open": [
     {
-      "number": 166,
-      "title": "ci: pvc-usage-reporter の埋め込みスクリプト3ファイルの一致を検証する (T-0081)",
-      "url": "https://github.com/hikuohiku/homelab/pull/166",
+      "number": 167,
+      "title": "T-0082: pvc-usage-reporter の python イメージを inventory 監視対象に追加",
+      "url": "https://github.com/hikuohiku/homelab/pull/167",
       "isDraft": false,
-      "createdAt": "2026-08-05T07:07:00Z",
+      "createdAt": "2026-08-05T07:24:22Z",
       "statusCheckRollup": [
         {
           "conclusion": "PENDING"
         }
       ],
-      "headRefName": "autopilot/T-0081-pvc-usage-script-sync",
-      "autoMergeRequest": true
+      "headRefName": "autopilot/T-0082-pvc-usage-reporter-image-inventory",
+      "autoMergeRequest": null
     }
   ],
   "merged": [
+    {
+      "number": 166,
+      "title": "ci: pvc-usage-reporter の埋め込みスクリプト3ファイルの一致を検証する (T-0081)",
+      "url": "https://github.com/hikuohiku/homelab/pull/166",
+      "mergedAt": "2026-08-05T07:09:53Z",
+      "headRefName": "autopilot/T-0081-pvc-usage-script-sync"
+    },
+    {
+      "number": 165,
+      "title": "run #35: T-0080 完遂の記録更新",
+      "url": "https://github.com/hikuohiku/homelab/pull/165",
+      "mergedAt": "2026-08-05T07:03:37Z",
+      "headRefName": "autopilot/T-0080-records-2"
+    },
     {
       "number": 163,
       "title": "PVC の実使用量を計測する namespace 別 CronJob を追加 (T-0080)",
@@ -414,6 +428,13 @@
       "url": "https://github.com/hikuohiku/homelab/pull/107",
       "mergedAt": "2026-08-04T23:38:46Z",
       "headRefName": "autopilot/t0032-vaultwarden-ip-header"
+    },
+    {
+      "number": 106,
+      "title": "external-secrets chart を 1.3.2 → 2.8.0 に上げる (T-0037)",
+      "url": "https://github.com/hikuohiku/homelab/pull/106",
+      "mergedAt": "2026-08-04T23:35:52Z",
+      "headRefName": "autopilot/t0037-external-secrets-2.8.0"
     }
   ]
 }

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -292,6 +292,19 @@
       "policy": "auto",
       "note": "T-0015 (run #29) で新設。標準ライブラリのみで動くスクリプトのため minor/patch 更新はほぼ無害",
       "observability_impact": "壊れると ops-health-report ブランチへの書き戻しが止まり、autopilot が直前の auto-merge 後の ArgoCD/Pod/PVC 状態を確認できなくなる。ただし読み取り専用 CronJob であり、壊れても homelab 本体の到達性・稼働には影響しない"
+    },
+    {
+      "id": "pvc-usage-reporter-image",
+      "kind": "image",
+      "name": "python (pvc-usage-reporter CronJob)",
+      "current": "3.12-alpine",
+      "file": "apps/immich/pvc-usage-cronjob.yaml",
+      "match": "image: python:",
+      "mirrors": ["apps/coder/pvc-usage-cronjob.yaml", "apps/vaultwarden/pvc-usage-cronjob.yaml"],
+      "upstream": "dockerhub:library/python",
+      "policy": "auto",
+      "note": "T-0080 (#163) で新設。3 namespace (immich/vaultwarden/coder) に同じタグを持つ同型 CronJob をコピーして配置しているため、ops-health-reporter-image と同様に 3 箇所とも揃えて更新すること（T-0082）",
+      "observability_impact": "壊れるとその namespace の PVC 実使用量が pvc-usage-report ConfigMap に書き戻されなくなり、ops-health-reporter が集約する pvc_usage が古いまま止まる。読み取り専用 CronJob であり、壊れても homelab 本体の到達性・稼働には影響しない"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1063,3 +1063,24 @@
 - 見つけたこと: なし（T-0081 はフィードバック起因ではなく自発的な調査による発見）
 - 次の起動へ: なし。T-0079（node01 実ディスク容量、needs-human・priority 1）が引き続き最優先。
   backlog の todo は 0 件
+
+## 2026-08-05 16:35 JST — run #36
+
+- 前回の中断: なし。open PR・autopilot/* ブランチとも無し
+- 読んだフィードバック: issue #56 の last_read (05:56:49) 以降で 4 件表示されたが、全て run #31/#35
+  自身がその場で返信・処理済みのやり取り（last_read を更新し忘れていたブックキーピング漏れ）。
+  新しい人間フィードバックは無かった。last_read を最後のコメント時刻 (06:58:34) に更新した
+- ops-health-report ブランチ（generated_at 07:00:04Z、直近）を確認。ArgoCD 全10アプリ Synced/Healthy。
+  node の ephemeral-storage は引き続き約48.9GiBのまま（capacity 51250152Ki）。T-0079（node01 実
+  ディスク容量の食い違い、needs-human・priority 1）は人間の df -h/lsblk 報告待ちで進展なし。
+  T-0080 の PVC 実使用量は CronJob が6時間毎のためこの回では未反映（次回以降の health report で見える）
+- やったこと: backlog の todo が0件だったため CHARTER §3 に従い調査。T-0080 (#163, 直前の run #35
+  で merge) が追加した apps/{immich,coder,vaultwarden}/pvc-usage-cronjob.yaml の3ファイルは
+  python:3.12-alpine を使うが、同型の ops-health-reporter-image と違い ops/inventory.json の
+  監視対象にも check_version_sync.py の GROUPS にも入っておらず、上流の新バージョンを誰も見ておらず
+  3ファイルの drift も CI で検出できない状態だった。T-0082 として起票・即完遂: inventory.json に
+  pvc-usage-reporter-image エントリ（mirrors で他2ファイル指定）を追加し、check_version_sync.py に
+  対応する mirror group を追加。1ファイルだけタグを変えて非0終了することを手元で確認済み
+- 見つけたこと: なし（T-0082 はフィードバック起因ではなく自発的な調査による発見）
+- 次の起動へ: なし。T-0079（node01 実ディスク容量、needs-human・priority 1）が引き続き最優先。
+  backlog の todo は本 run 終了時点で 0 件

--- a/ops/state.json
+++ b/ops/state.json
@@ -426,7 +426,9 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読の人間フィードバックなし（4件表示されたが全て run #31/#35 が既に返信済みのやり取りで、last_read (05:56:49) が更新されていなかっただけのブックキーピング漏れ。06:58:34 に更新）。ops-health-report ブランチ（generated_at 07:00:04Z）で ArgoCD 全10アプリ Synced/Healthy、node ephemeral-storage は引き続き約48.9GiBのままで T-0079 は人間の df -h/lsblk 報告待ち。backlog の todo が0件だったため CHARTER §3 に従い調査し、T-0080 (#163) が追加した3つの pvc-usage-reporter CronJob (python:3.12-alpine) が ops-health-reporter-image と違い ops/inventory.json の監視対象・check_version_sync.py の GROUPS のどちらにも入っていない抜けを発見。T-0082 として起票・即完遂した",
-      "prs": []
+      "prs": [
+        167
+      ]
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-05T07:15:00Z",
+  "updated": "2026-08-05T07:35:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-05T05:56:49Z"
+    "last_read": "2026-08-05T06:58:34Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -419,6 +419,14 @@
         165,
         166
       ]
+    },
+    {
+      "n": 36,
+      "at": "2026-08-05T07:35:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読の人間フィードバックなし（4件表示されたが全て run #31/#35 が既に返信済みのやり取りで、last_read (05:56:49) が更新されていなかっただけのブックキーピング漏れ。06:58:34 に更新）。ops-health-report ブランチ（generated_at 07:00:04Z）で ArgoCD 全10アプリ Synced/Healthy、node ephemeral-storage は引き続き約48.9GiBのままで T-0079 は人間の df -h/lsblk 報告待ち。backlog の todo が0件だったため CHARTER §3 に従い調査し、T-0080 (#163) が追加した3つの pvc-usage-reporter CronJob (python:3.12-alpine) が ops-health-reporter-image と違い ops/inventory.json の監視対象・check_version_sync.py の GROUPS のどちらにも入っていない抜けを発見。T-0082 として起票・即完遂した",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

T-0080 (#163) が追加した `apps/{immich,coder,vaultwarden}/pvc-usage-cronjob.yaml` の3ファイルは
`python:3.12-alpine` を使っているが、同型の `ops-health-reporter-image` と違い
`ops/inventory.json` の監視対象にも `ops/check_version_sync.py` の GROUPS にも入っておらず、
上流の新バージョン監視も3ファイル間の drift 検出も出来ない状態だった（T-0051/T-0081 と同型の抜け、
run #36 の自発調査で発見）。

- `ops/inventory.json` に `pvc-usage-reporter-image` エントリを追加（mirrors で他2ファイルを指定）
- `ops/check_version_sync.py` の GROUPS に対応する3ファイルの mirror group を追加
- あわせて `ops/journal/2026-08.md`・`ops/backlog.json`（T-0082 起票・done）・`ops/state.json`
  （run #36 記録、issue #56 の `feedback.last_read` の更新漏れ修正）を更新

バージョン更新自体は範囲外（現行 `3.12-alpine` のまま、監視の仕組みのみ追加）。

## 検証したこと

- `python3 ops/check_version_sync.py` が新しい mirror group を含めて green（0 exit）
- `apps/coder/pvc-usage-cronjob.yaml` だけ意図的に `python:3.13-alpine` に変えて非0終了することを
  手元で確認（確認後は元に戻し済み）
- `python3 ops/validate.py` が 0 error（既存の警告のみ）

## ロールバック手順

このコミットを revert するだけ。挙動を変える変更は無く（監視・CI 検証を追加しただけ）、
manifest 自体・実行中の CronJob には影響しない。

## backlog

T-0082（このタスク自体）

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUTNXvQE5asjc66EaRZowM)_