### PR TITLE
ops: T-0085 の PR番号(#169)を記録に反映

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 86,
-  "updated": "2026-08-05T08:05:00Z",
+  "updated": "2026-08-05T08:10:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -1559,7 +1559,7 @@
         "apps/coder/pvc-usage-cronjob.yaml"
       ],
       "created": "2026-08-05",
-      "pr": null,
+      "pr": 169,
       "notes": "run #38: CHARTER §2 に schedule (5/15/25 */6 * * *) から算出した実行予定時刻（00:05/06:05/12:05/18:05 UTC + namespace ごとの分オフセット）を明記し、それを過ぎてもなお 404 なら CronJob の異常を疑う基準を追加した"
     }
   ]

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T08:05:00Z",
+  "updated": "2026-08-05T08:10:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -446,7 +446,9 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "前回の中断: PR #168（T-0083, run #37 が open のまま終了）を拾い、CI 6件 green を確認して merge した。issue #56 の未読1件（07:41:02）を反映: pvc-usage-reporter デプロイ後の3 namespace 404 は初回実行前（12:05 UTC 頃）として想定内という報告と、その基準を記録すべきという指摘を受け、T-0085 として起票・完遂。各 CronJob の schedule（5/15/25 */6 * * *）から算出した初回実行予定時刻を CHARTER §2 に明記し、それを過ぎてもなお404が続く場合はCronJobの異常を疑う基準を追加した。あわせて T-0083/T-0084 の backlog エントリの pr フィールド（null のまま残っていた）を実際の #168 に反映",
-      "prs": []
+      "prs": [
+        169
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

PR #169（T-0085）の merge を確認したため、`ops/backlog.json` の `pr` フィールドと
`ops/state.json` の run #38 に実際の PR 番号を反映する記録更新のみ。コードの変更は無い。

## 検証したこと

- `python3 ops/validate.py` → 0 error

## ロールバック手順

記録のみのため実質的なロールバックは不要。必要なら revert する。

## backlog task id

T-0085（記録更新）

---
_Generated by [Claude Code](https://claude.ai/code/session_014uY8av92ATSKUW2LTnZMiY)_