### PR TITLE
ops: run #40 の記録漏れ(state.json/last_read)を埋め合わせ、PRキャッシュ更新

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,20 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
+    {
+      "number": 172,
+      "title": "issue #56 のフィードバックを反映: DB コンポーネントのロールバック手順にスキーマの扱いを明記する規則を追加",
+      "url": "https://github.com/hikuohiku/homelab/pull/172",
+      "mergedAt": "2026-08-05T08:23:29Z",
+      "headRefName": "autopilot/T-0086-rollback-wording"
+    },
     {
       "number": 171,
       "title": "immich server/machine-learning を v2.6.3 → v2.7.5 に更新 (T-0086)",
       "url": "https://github.com/hikuohiku/homelab/pull/171",
-      "isDraft": false,
-      "createdAt": "2026-08-05T08:14:20Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "PENDING"
-        }
-      ],
-      "headRefName": "autopilot/T-0086-immich-v2.7.5",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-05T08:16:43Z",
+      "headRefName": "autopilot/T-0086-immich-v2.7.5"
+    },
     {
       "number": 170,
       "title": "ops: T-0085 の PR番号(#169)を記録に反映",
@@ -414,27 +413,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/113",
       "mergedAt": "2026-08-05T00:16:51Z",
       "headRefName": "autopilot/run14-wrapup"
-    },
-    {
-      "number": 112,
-      "title": "Maintenance.md: T-0031 revert / T-0038 完遂を反映 (T-0039)",
-      "url": "https://github.com/hikuohiku/homelab/pull/112",
-      "mergedAt": "2026-08-05T00:11:46Z",
-      "headRefName": "autopilot/T-0039-maintenance-doc-sync"
-    },
-    {
-      "number": 111,
-      "title": "vaultwarden: IP_HEADER_TRUSTED_PROXIES を pod CIDR に絞る (T-0038)",
-      "url": "https://github.com/hikuohiku/homelab/pull/111",
-      "mergedAt": "2026-08-05T00:09:28Z",
-      "headRefName": "autopilot/T-0038-vaultwarden-trusted-proxies"
-    },
-    {
-      "number": 110,
-      "title": "vaultwarden: icon 取得の無効化を revert する (T-0031)",
-      "url": "https://github.com/hikuohiku/homelab/pull/110",
-      "mergedAt": "2026-08-05T00:05:54Z",
-      "headRefName": "autopilot/T-0031-revert-icon-download"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1183,3 +1183,27 @@
 - 次の起動へ: tailscale-operator-chart/k8s-nameserver の v1.98.9→v1.102.2 更新が
   未着手のまま残っている（到達性の根幹、T-0024/T-0025 と同じ実タグ diff 照合の手順が要る）。
   backlog が空なら次の候補にする
+
+## 2026-08-05 17:29 JST — run #41
+
+- 前回の中断: なし。オープン PR・autopilot ブランチとも無し。ただし run #40 が journal のみ
+  書いて state.json の runs 追記と last_read 更新（08:23:09、#171 ロールバック文言修正の
+  返信自身）をしないまま終了していたため、この起動の冒頭で埋め合わせた（state.json に
+  run #40 のエントリを追加、last_read を進めた）
+- ops-health-report ブランチ（generated_at 08:00:04Z）で ArgoCD 全10アプリ Synced/Healthy
+  を確認。ただしこの時点のレポートは T-0086（immich v2.7.5、#171 merge 08:16:43Z）より前の
+  観測のため、T-0087（ML Pod の健全性確認）は次回以降の新しいレポートで確認する。pvc_usage
+  の3 namespace 404 は T-0085 の基準（初回実行予定 12:05 UTC 以降）をまだ過ぎていないため
+  正常
+- 読んだフィードバック: last_read 以降の新規コメントは自分自身（run #40）の返信のみで、
+  人間からの新規指示なし
+- やったこと: backlog の todo が0件のため、run #39/#40 が残した次の調査候補（tailscale-operator
+  chart / k8s-nameserver を v1.98.9→v1.102.2 に揃える件）に着手。到達性の根幹（CHARTER §4）
+  のため T-0024/T-0025 と同じ手法（実タグでのテンプレート/CRD 直接照合、原文リリースノート
+  確認）を subagent に投げて調査中（バックグラウンド）。並行して run #40 の記録漏れを
+  埋め合わせる低リスク PR（state.json runs 追記、last_read 更新、PR キャッシュ最新化、
+  ダッシュボード再生成）を用意した
+- 見つけたこと: なし
+- 次の起動へ: tailscale 調査 subagent の結果を受けて、着手可否（YES/NO/一部保留）を
+  判断し、問題なければ T-0088 として起票・実装まで進める。この起動の実行時間が尽きた場合は
+  調査結果を journal に残すか、着手できていれば PR を open のまま残す

--- a/ops/state.json
+++ b/ops/state.json
@@ -6,7 +6,7 @@
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-05T08:16:27Z"
+    "last_read": "2026-08-05T08:23:09Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -458,6 +458,16 @@
       "summary": "前回の中断: なし。ops-health-report ブランチで T-0083（history ファイル）の生成を確認し、ArgoCD 全10アプリ Synced/Healthy、node の実ディスク容量は変わらず約48.9GiB（T-0079 は引き続き人間の報告待ち）。issue #56 の未読は人間自身の相槌1件のみで新規指示なし。backlog の todo が0件だったため subagent に inventory.json の auto-policy 対象20件の上流最新版チェックを投げ、immich server/machine-learning (v2.6.3→v2.7.5) と tailscale-operator-chart/k8s-nameserver (v1.98.9→v1.102.2) の2件の差分を発見。1 PR 1 論点に従い低リスクの immich から着手し、中間リリース(v2.7.0〜v2.7.5)の原文確認（破壊的変更なし、v2.7.1のみ欠陥リリースだが2.7.5まで一直線に上げれば無関係）を経て更新（T-0086, #171）。残った不確実性（旧CPU向けの一時的なMLクラッシュ既知不具合、v2.7.2で修正済みだがnode01での再発は未確認）を T-0087（blocked）として起票。tailscale-operator-chart の更新は到達性の根幹のため直列化ルールに従い今回は着手せず、次回の調査候補として残した",
       "prs": [
         171
+      ]
+    },
+    {
+      "n": 40,
+      "at": "2026-08-05T08:22:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 の未読1件（08:16:27）を反映: #171（T-0086, immich v2.7.5）のロールバック手順が『revert 後にデータ不整合が残る想定はない』と言い切っていたのは表現が強すぎたという指摘。マイグレーションは前進のみでコードだけ戻る点を明記すべきという内容を受け、CHARTER §4 に『DB を持つコンポーネントのロールバック手順には必ずスキーマの扱いを明記する』を追記し、T-0086 の backlog notes にも訂正を追記した（#172, auto-merged）。ラップアップ（state.json runs への自身の記録・last_read 更新）を終える前に起動が終了しており、run #41 がこの run の記録を追記して埋め合わせた",
+      "prs": [
+        172
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

- `ops/state.json`: run #40（issue #56 のフィードバックを反映し #172 をマージした起動）が journal のみ書いて自身の記録（`runs` への追記、`feedback.last_read` の更新）をしないまま終了していたため、この起動（run #41）の冒頭で埋め合わせた。`last_read` は #171 のロールバック文言修正への自分の返信タイムスタンプ（08:23:09Z）まで進めた（それ以降、人間からの新規コメントは無い）
- `ops/dashboard/prs.json`: `mcp__github__list_pull_requests` で取得した最新の merged PR 一覧（59件）でキャッシュを最新化（CHARTER §7.1）
- `ops/dashboard/index.html` は生成物のため Git 管理対象外（別途 Artifact で再公開）

## 検証したこと

- `python3 ops/validate.py` → 0 error（既存の警告6件は本 PR 由来ではない）
- `python3 ops/dashboard/build.py` → 例外なく生成

## ロールバック手順

`ops/` 配下の記録ファイルのみの変更で、クラスタ・インフラには一切影響しない。revert すれば元の記録に戻るだけ。DB・スキーマは関与しない。

## backlog task id

記録のみのため対応する task id なし（運用記録の相乗り、CHARTER §4）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01N2nXrWkCvKYWi54RZtzqds)_