### PR TITLE
ops: tailscale-operator/k8s-nameserver の v1.102.2 更新調査結果を記録 (run #41)

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 173,
+      "title": "ops: run #40 の記録漏れ(state.json/last_read)を埋め合わせ、PRキャッシュ更新",
+      "url": "https://github.com/hikuohiku/homelab/pull/173",
+      "mergedAt": "2026-08-05T08:33:10Z",
+      "headRefName": "autopilot/records-run40-catchup"
+    },
+    {
       "number": 172,
       "title": "issue #56 のフィードバックを反映: DB コンポーネントのロールバック手順にスキーマの扱いを明記する規則を追加",
       "url": "https://github.com/hikuohiku/homelab/pull/172",

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -58,7 +58,7 @@
       "match": "version:",
       "upstream": "github:tailscale/tailscale",
       "policy": "auto",
-      "note": "到達性の根幹。壊すとクラスタに届かなくなる。T-0024 で 1.90.9→1.98.9 に更新（#100）。k8s-nameserver（同ファイル群内の別エントリ）と同じ tailscale/tailscale@vX.Y.Z タグから揃えて更新すること。実機確認済み（2026-08-05、人間が Tailscale 経由の名前解決を確認。issue #56 04:18:44）",
+      "note": "到達性の根幹。壊すとクラスタに届かなくなる。T-0024 で 1.90.9→1.98.9 に更新（#100）。k8s-nameserver（同ファイル群内の別エントリ）と同じ tailscale/tailscale@vX.Y.Z タグから揃えて更新すること。実機確認済み（2026-08-05、人間が Tailscale 経由の名前解決を確認。issue #56 04:18:44）。訂正（2026-08-05 run #41）: 上流調査 subagent が v1.98.9→v1.102.2 への更新余地ありと報告したが、実際には ghcr.io/Docker Hub の tags API を直接確認したところ k8s-operator 系の配布物（chart 相当のコンテナイメージ）は v1.98.9 より新しい stable タグが存在しない（tailscale/tailscale 本体の git tag は v1.102.2 まであるが k8s-operator 一式のリリースはまだ切られていない）。次回はイメージタグの実在確認を先に行うこと（chart index 自体は pkgs.tailscale.com/artifacthub.io ともにこのサンドボックスから到達不可のため、ghcr.io/Docker Hub の該当イメージタグの存在で代替確認する）",
       "observability_impact": "壊れると Tailscale 経由の到達性（人間・autopilot 自身がこの homelab に触れる唯一の経路）そのものが失われる。復旧に homelab への到達自体が要るため、壊れている間は自分で直せない可能性がある"
     },
     {
@@ -160,7 +160,7 @@
       "match": "k8s-nameserver",
       "upstream": "github:tailscale/tailscale",
       "policy": "auto",
-      "note": "T-0025 で unstable-v1.91.150 → v1.98.9 に更新（#100）。訂正: T-0001/T-0005 時点（chart 1.90.9）では stable 相当のタグは無く unstable-vX.Y.Z のスナップショットのみだったが、chart 1.92 系以降は tailscale/tailscale の release tag と同じ非 floating な vX.Y.Z タグが ghcr.io / Docker Hub 両方に存在する。今後の更新は unstable-* に戻さず、tailscale-operator-chart と同じ vX.Y.Z で揃える。実機確認済み（2026-08-05、人間が Tailscale 経由の DNS 解決を確認。issue #56 04:18:44。#100 の PR 本文に残っていた「残った不確実性」2点のうちこちらは解消、admissionregistration.k8s.io/v1 対応の点は未使用機能のため実害なしのまま）",
+      "note": "T-0025 で unstable-v1.91.150 → v1.98.9 に更新（#100）。訂正: T-0001/T-0005 時点（chart 1.90.9）では stable 相当のタグは無く unstable-vX.Y.Z のスナップショットのみだったが、chart 1.92 系以降は tailscale/tailscale の release tag と同じ非 floating な vX.Y.Z タグが ghcr.io / Docker Hub 両方に存在する。今後の更新は unstable-* に戻さず、tailscale-operator-chart と同じ vX.Y.Z で揃える。実機確認済み（2026-08-05、人間が Tailscale 経由の DNS 解決を確認。issue #56 04:18:44。#100 の PR 本文に残っていた「残った不確実性」2点のうちこちらは解消、admissionregistration.k8s.io/v1 対応の点は未使用機能のため実害なしのまま）。2026-08-05 run #41: v1.102.2 相当への更新を調査したが ghcr.io/Docker Hub いずれにも v1.98.9 より新しい tailscale/k8s-nameserver タグが無く、現時点では更新できない（tailscale-operator-chart の note を参照）",
       "observability_impact": "tailscale-operator-chart と同じ到達性の一部（tailnet 内の MagicDNS 名前解決）。壊れると名前解決経由のアクセスが失われる（IP 直指定は影響を受けない可能性がある）"
     },
     {

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1200,10 +1200,20 @@
 - やったこと: backlog の todo が0件のため、run #39/#40 が残した次の調査候補（tailscale-operator
   chart / k8s-nameserver を v1.98.9→v1.102.2 に揃える件）に着手。到達性の根幹（CHARTER §4）
   のため T-0024/T-0025 と同じ手法（実タグでのテンプレート/CRD 直接照合、原文リリースノート
-  確認）を subagent に投げて調査中（バックグラウンド）。並行して run #40 の記録漏れを
-  埋め合わせる低リスク PR（state.json runs 追記、last_read 更新、PR キャッシュ最新化、
-  ダッシュボード再生成）を用意した
-- 見つけたこと: なし
-- 次の起動へ: tailscale 調査 subagent の結果を受けて、着手可否（YES/NO/一部保留）を
-  判断し、問題なければ T-0088 として起票・実装まで進める。この起動の実行時間が尽きた場合は
-  調査結果を journal に残すか、着手できていれば PR を open のまま残す
+  確認）を subagent に投げた。並行して run #40 の記録漏れを埋め合わせる低リスク PR（state.json
+  runs 追記、last_read 更新、PR キャッシュ最新化、ダッシュボード再生成）を作成し auto-merge
+  で完遂（#173）
+- 見つけたこと（本命）: subagent の調査結果、run #39/#40 の前提だった「v1.102.2 相当に更新
+  余地あり」は誤りと判明。`tailscale/tailscale` 本体の git tag は v1.102.2 まで存在するが、
+  k8s-operator 系の配布物（Helm chart の元になる `tailscale/k8s-operator` イメージ、
+  `tailscale/k8s-nameserver` イメージ）は ghcr.io / Docker Hub の tags API を直接確認した
+  ところ v1.98.9 より新しい stable タグが一切無い（本体のタグは進んだが k8s-operator 一式の
+  リリースがまだ切られていない状態）。更新先自体が存在しないため今回は着手不可（一部保留・
+  実質 NO）。念のため v1.98.9→v1.102.2 間のテンプレート/CRD 差分（Peer Relays 機能の追加分、
+  RBAC 追加のみで破壊的変更なし）も事前確認済みなので、将来 stable タグが出た時点ですぐ着手
+  できる。ops/inventory.json の該当2エントリ（tailscale-operator-chart, k8s-nameserver）に
+  この訂正を記録した（新規 backlog タスクは起票せず、次回の auto-policy 調査で ghcr.io/Docker
+  Hub のタグ存在確認を先に行うよう note に明記）
+- 次の起動へ: tailscale-operator-chart/k8s-nameserver は当面 v1.98.9 のまま。backlog の
+  todo は本 run 終了時点で 0 件。T-0079（node01 実ディスク容量）・T-0087（immich v2.7.5
+  反映後の ML Pod 健全性、次回の ops-health-report で確認）待ち

--- a/ops/state.json
+++ b/ops/state.json
@@ -469,6 +469,14 @@
       "prs": [
         172
       ]
+    },
+    {
+      "n": 41,
+      "at": "2026-08-05T08:29:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "前回の中断: run #40 が journal のみ書いて state.json の runs 追記・last_read 更新をしないまま終了していたのを埋め合わせ（#173, auto-merged）。issue #56 に新規フィードバックなし。ops-health-report で ArgoCD 全10アプリ Synced/Healthy を確認（ただし T-0086 反映前の観測のため T-0087 は次回に持ち越し）。backlog の todo が0件のため、run #39/#40 が残した調査候補（tailscale-operator chart/k8s-nameserver を v1.98.9→v1.102.2 に揃える件）に着手。subagent が ghcr.io/Docker Hub の tags API を直接確認した結果、tailscale/tailscale 本体の git tag は v1.102.2 まであるが k8s-operator 系配布物（chart 元イメージ、k8s-nameserver イメージ）は v1.98.9 より新しい stable タグが存在せず、更新先自体が無いと判明。run #39/#40 の前提が誤りだったと訂正し、ops/inventory.json の該当2エントリに記録した（テンプレート/CRD差分は事前確認済みで、将来タグが出れば即着手できる）",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

- `ops/inventory.json`: `tailscale-operator-chart` / `k8s-nameserver` の note に調査結果を追記。run #39/#40 が「v1.98.9 → v1.102.2 への更新余地あり」としていたのは誤りで、`tailscale/tailscale` 本体の git tag は v1.102.2 まで存在するが、k8s-operator 系の配布物（Helm chart の元になる `tailscale/k8s-operator` イメージ、`tailscale/k8s-nameserver` イメージ）は ghcr.io / Docker Hub の tags API を直接確認したところ v1.98.9 より新しい stable タグが一切存在しない（本体のタグは進んだが k8s-operator 一式のリリースはまだ切られていない）。**apps/ 配下のマニフェストは無変更**（更新先が存在しないため）
- `ops/journal/2026-08.md`, `ops/state.json`: run #41 の記録
- `ops/dashboard/prs.json`: PR キャッシュに #173 を反映

## 検証したこと

- ghcr.io / Docker Hub の `tailscale/k8s-operator`, `tailscale/k8s-nameserver` の tags API を直接確認し、v1.98.9 より新しい stable タグが存在しないことを確認（subagent 実施）
- 念のため v1.98.9→v1.102.2 間で実際に存在するテンプレート/CRD差分（Peer Relays 機能の RBAC 追加のみ、DNSConfig CRD は差分ゼロ）も事前確認済み。将来 stable タグが出た際は riskless に着手できる
- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 例外なく生成

## ロールバック手順

`ops/` 配下の記録・inventory のコメント追記のみで、クラスタ・インフラには一切影響しない。revert すれば元の記録に戻るだけ。DB・スキーマは関与しない。

## backlog task id

対応する backlog タスクなし（T-0024/T-0025 は既に done。今回は formal task 化せず inventory.json の note のみで再調査防止を図った）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01N2nXrWkCvKYWi54RZtzqds)_