### PR TITLE
ops: T-0087/T-0088 完遂の記録、T-0090 起票 (run #42)

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 88,
-  "updated": "2026-08-05T08:25:00Z",
+  "next_id": 91,
+  "updated": "2026-08-05T08:42:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -1586,7 +1586,7 @@
       "title": "T-0086 (immich v2.7.5) 反映後、machine-learning Pod が健全に起動しているか ops-health-report で確認する",
       "kind": "investigate",
       "risk": "low",
-      "status": "blocked",
+      "status": "done",
       "priority": 15,
       "why": "T-0086 の調査で、v2.7.0/v2.7.1 時点で一部 CPU（AVX2 非対応等）向けに ML コンテナが numpy 関連でクラッシュする一時的な不具合があったと判明（v2.7.2 で修正済みのため v2.7.5 には修正が含まれるが、node01 の CPU 世代でも問題ないかは未確認）",
       "dod": "T-0086 の PR が merge・ArgoCD に反映されてから1起動以上後、ops-health-report ブランチの pod_issues に immich-machine-learning の CrashLoopBackOff/Error が無いことを確認する。問題が無ければ done、あれば v2.6.3 への revert PR を出す",
@@ -1594,6 +1594,43 @@
       "refs": [
         "apps/immich/values.yaml",
         "ops/health/latest.json"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #42: #171 merge (08:16:43Z) 後の ops-health-report (generated_at 08:30:04Z) を確認。immich アプリは Synced/Healthy、pod_issues に immich-server/immich-machine-learning のいずれも出現せず（restarts の載っている pod は argocd/coredns/local-path-provisioner/metrics-server の常駐系のみで、いずれもノード再起動由来の既知の値。immich 側に新規のクラッシュ兆候なし）。v2.7.0/v2.7.1 の numpy クラッシュは node01 で再発していないと確認できたため done"
+    },
+    {
+      "id": "T-0088",
+      "domain": "homelab",
+      "title": "ops/inventory.json の tf-provider-proxmox current が 0.89.1 のまま古い（実際は 0.111.1）を修正する",
+      "kind": "docs",
+      "risk": "low",
+      "status": "done",
+      "priority": 30,
+      "why": "T-0030（人間が #145 で 0.89.1→0.111.1 に更新、run #27 で確認済み）の後、terraform/proxmox/providers.tf の pin は 0.111.1 に進んだが ops/inventory.json の current フィールドが更新されないまま残っていた。inventory.json は auto-policy の上流バージョン調査（run #39 等）が読む唯一の情報源のため、古いままだと将来の調査が実際の差分（0.111.1→最新）ではなく見せかけの大きな差分（0.89.1→最新）を報告し、調査の手間を無駄にする",
+      "dod": "ops/inventory.json の tf-provider-proxmox.current が terraform/proxmox/providers.tf の実際の pin (0.111.1) と一致する",
+      "refs": [
+        "ops/inventory.json",
+        "terraform/proxmox/providers.tf"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #42: subagent の調査で発見。providers.tf:17 の `version = \"= 0.111.1\"` と突き合わせて確認済み、値を修正するのみで挙動に影響しないため即完遂"
+    },
+    {
+      "id": "T-0090",
+      "domain": "homelab",
+      "title": ".github/workflows/ci.yml の kustomize/azure-setup-helm バイナリ版が inventory.json / check_version_sync.py の監視対象に入っていない",
+      "kind": "ci",
+      "risk": "low",
+      "status": "todo",
+      "priority": 30,
+      "why": "run #42 の subagent 調査で発見。ci.yml の manifests job と manifest-diff job の両方に azure/setup-helm (version: v3.16.4) と kustomize (v5.8.1、curl でダウンロード) が独立に2箇所ずつ書かれている。T-0042〜T-0048 は `uses: foo@vX` 形式の GitHub Actions のみを棚卸し対象にしており、これらはバイナリのバージョン文字列のため対象外だった。check_version_sync.py の GROUPS にも該当エントリが無く、2箇所の値がずれても CI は検出できない。ずれると manifests job と manifest-diff job で異なる kustomize/helm バージョンがレンダリングに使われ、T-0036 の削除検出（manifest-diff）がツールバージョン差分由来の偽陽性/偽陰性を出しうる",
+      "dod": "ops/inventory.json に azure/setup-helm と kustomize の2エントリを追加（policy: auto）。ops/check_version_sync.py の GROUPS に、ci.yml 内の2箇所ずつの出現を検証する2グループを追加（既存の actions/checkout グループと同じパターン）。意図的に値をずらして CI (ops job) が exit 1 になることを確認する",
+      "refs": [
+        ".github/workflows/ci.yml",
+        "ops/inventory.json",
+        "ops/check_version_sync.py"
       ],
       "created": "2026-08-05",
       "pr": null

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,10 +2,17 @@
   "open": [],
   "merged": [
     {
+      "number": 174,
+      "title": "ops: tailscale-operator/k8s-nameserver の v1.102.2 更新調査結果を記録 (run #41)",
+      "url": "https://github.com/hikuohiku/homelab/pull/174",
+      "mergedAt": "2026-08-05T08:37:19Z",
+      "headRefName": "autopilot/tailscale-v1102-investigation"
+    },
+    {
       "number": 173,
       "title": "ops: run #40 の記録漏れ(state.json/last_read)を埋め合わせ、PRキャッシュ更新",
       "url": "https://github.com/hikuohiku/homelab/pull/173",
-      "mergedAt": "2026-08-05T08:33:10Z",
+      "mergedAt": "2026-08-05T08:30:59Z",
       "headRefName": "autopilot/records-run40-catchup"
     },
     {
@@ -406,20 +413,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/115",
       "mergedAt": "2026-08-05T00:46:53Z",
       "headRefName": "autopilot/T-0042-pin-nix-installer-action"
-    },
-    {
-      "number": 114,
-      "title": "docs: Plans.md の kubectl ask 前提の記述を実態に合わせる (T-0041)",
-      "url": "https://github.com/hikuohiku/homelab/pull/114",
-      "mergedAt": "2026-08-05T00:24:50Z",
-      "headRefName": "autopilot/T-0041-plans-md-ask-drift"
-    },
-    {
-      "number": 113,
-      "title": "ops: run #14 の記録をまとめ、ダッシュボードを再生成する",
-      "url": "https://github.com/hikuohiku/homelab/pull/113",
-      "mergedAt": "2026-08-05T00:16:51Z",
-      "headRefName": "autopilot/run14-wrapup"
     }
   ]
 }

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -189,7 +189,7 @@
       "id": "tf-provider-proxmox",
       "kind": "terraform",
       "name": "bpg/proxmox",
-      "current": "0.89.1",
+      "current": "0.111.1",
       "file": "terraform/proxmox/providers.tf",
       "match": "bpg/proxmox",
       "upstream": "github:bpg/terraform-provider-proxmox",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1217,3 +1217,24 @@
 - 次の起動へ: tailscale-operator-chart/k8s-nameserver は当面 v1.98.9 のまま。backlog の
   todo は本 run 終了時点で 0 件。T-0079（node01 実ディスク容量）・T-0087（immich v2.7.5
   反映後の ML Pod 健全性、次回の ops-health-report で確認）待ち
+
+## 2026-08-05 17:42 JST — run #42
+
+- 前回の中断: なし。オープン PR・autopilot ブランチとも無し
+- ops-health-report ブランチ（generated_at 08:30:04Z、#171 merge 後の観測）を確認。immich
+  アプリ Synced/Healthy、pod_issues に immich-server/immich-machine-learning とも出現せず、
+  v2.7.0/v2.7.1 の ML numpy クラッシュが node01 で再発していないことを確認できた。T-0087 を
+  done にした
+- 読んだフィードバック: issue #56 の last_read (08:23:09) 以降、新規コメントなし（全64件を
+  機械的に突き合わせて確認）
+- やったこと: backlog の todo が0件だったため subagent に新しい調査観点探しを投げ、3件発見。
+  うち2件は即完遂: T-0088（ops/inventory.json の tf-provider-proxmox.current が 0.89.1 の
+  まま古く、実際の pin は T-0030/#145 で 0.111.1 に進んでいた。providers.tf と突き合わせて
+  修正）。T-0089（CLAUDE.md の Apps 一覧・ディレクトリ構造図が nextcloud/ を残したまま
+  immich/coder/vaultwarden/ops-health-reporter/agent-rbac の5ディレクトリが未記載だった。
+  次のブランチで着手）
+- 見つけたこと: T-0090 として起票（todo）: ci.yml の kustomize/azure-setup-helm バイナリ
+  バージョンが inventory.json / check_version_sync.py の監視対象外で、manifests job と
+  manifest-diff job の2箇所がずれても CI が検出できない。GROUPS への追加が要るため次回以降
+- 次の起動へ: T-0089（CLAUDE.md docs drift）が本 run 内で直列に着手予定。T-0090 は todo。
+  T-0079（node01 実ディスク容量、needs-human・priority 1）引き続き待ち

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T08:10:00Z",
+  "updated": "2026-08-05T08:42:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -476,6 +476,14 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "前回の中断: run #40 が journal のみ書いて state.json の runs 追記・last_read 更新をしないまま終了していたのを埋め合わせ（#173, auto-merged）。issue #56 に新規フィードバックなし。ops-health-report で ArgoCD 全10アプリ Synced/Healthy を確認（ただし T-0086 反映前の観測のため T-0087 は次回に持ち越し）。backlog の todo が0件のため、run #39/#40 が残した調査候補（tailscale-operator chart/k8s-nameserver を v1.98.9→v1.102.2 に揃える件）に着手。subagent が ghcr.io/Docker Hub の tags API を直接確認した結果、tailscale/tailscale 本体の git tag は v1.102.2 まであるが k8s-operator 系配布物（chart 元イメージ、k8s-nameserver イメージ）は v1.98.9 より新しい stable タグが存在せず、更新先自体が無いと判明。run #39/#40 の前提が誤りだったと訂正し、ops/inventory.json の該当2エントリに記録した（テンプレート/CRD差分は事前確認済みで、将来タグが出れば即着手できる）",
+      "prs": []
+    },
+    {
+      "n": 42,
+      "at": "2026-08-05T08:42:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし（last_read 以降新規コメント0件、全64件を機械的に確認）。ops-health-report (generated_at 08:30:04Z、#171 merge 後) で immich アプリ Synced/Healthy かつ pod_issues に immich-server/machine-learning が出現しないことを確認し T-0087 を done に。backlog の todo が0件だったため subagent に調査を投げ3件発見: T-0088（ops/inventory.json の tf-provider-proxmox.current が 0.89.1 のまま古く、実際の pin (providers.tf) は 0.111.1 と一致していなかった、即完遂）、T-0089（CLAUDE.md の Apps 一覧・ディレクトリ構造が nextcloud/ 記載のまま immich/coder/vaultwarden 等5ディレクトリ未記載、この起動内で直列に着手予定）、T-0090（ci.yml の kustomize/azure-setup-helm バイナリ版が監視対象外、次回以降の todo）",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

- T-0087（immich v2.7.5 反映後の machine-learning Pod 健全性確認）を done に。ops-health-report (generated_at 08:30:04Z、#171 merge 後) で immich アプリ Synced/Healthy、pod_issues に immich-server/immich-machine-learning とも出現しないことを確認した
- T-0088（`ops/inventory.json` の `tf-provider-proxmox.current` が `0.89.1` のまま古く、実際の pin (`terraform/proxmox/providers.tf`) は T-0030/#145 で `0.111.1` に進んでいた）を発見・即修正
- T-0090（`.github/workflows/ci.yml` の kustomize/azure-setup-helm バイナリ版が inventory.json / check_version_sync.py の監視対象外）を todo として起票（次回以降）
- run #42 の journal・state.json・ダッシュボード PR キャッシュを更新

## 検証したこと

- `python3 ops/validate.py` → 0 error（既存の warning 数件は今回変更と無関係の既知事項、新規2件は notes に理由記載済み）
- `python3 ops/dashboard/build.py` → 正常終了
- T-0088 の修正値は `terraform/proxmox/providers.tf:17` の実際の pin と突き合わせて確認済み

## ロールバック手順

`ops/` 配下の記録・追跡データのみの変更で、アプリケーションや manifest への影響は無い。revert すれば元の記録に戻る。データ整合性の懸念なし。

## backlog task id

T-0087, T-0088, T-0090

---
_Generated by [Claude Code](https://claude.ai/code/session_015Mia1vXquFQF8g5ZjRZthw)_