### PR TITLE
docs: CLAUDE.md の Apps/ディレクトリ構造を実態に合わせる (T-0089)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Terraform で VM プロビジョニング、NixOS でOS構成、Kubernetes (Argo
 - **Networking**: Tailscale
 - **Secrets**: SOPS, External Secrets Operator
 - **Auth**: Dex (Google OAuth)
-- **Apps**: Nextcloud, ArgoCD, Tailscale Operator
+- **Apps**: ArgoCD, Dex, External Secrets Operator, Tailscale Operator, Immich, Vaultwarden, Coder, ops-health-reporter
 
 ## Directory Structure
 
@@ -23,10 +23,14 @@ nix/images/          — NixOS image definitions
 apps/                — Kubernetes manifests (ArgoCD applications)
   apps.yaml          — App of Apps root
   argocd/            — ArgoCD self-management
-  nextcloud/         — Nextcloud deployment
+  agent-rbac/        — エージェント用 read-only ServiceAccount/RBAC
   dex/               — Dex OIDC provider
   external-secrets/  — External Secrets Operator
   tailscale-operator/ — Tailscale networking
+  immich/            — Immich (写真管理)
+  vaultwarden/       — Vaultwarden (パスワード管理)
+  coder/             — Coder (開発環境)
+  ops-health-reporter/ — autopilot 向け ArgoCD/k8s 健全性レポーター（CronJob）
 .sops.yaml            — SOPS 設定（暗号鍵の対象範囲）
 nix/images/proxmox-cloud/secrets.yaml — SOPS 暗号化ファイル（単一ファイル、トップレベルの secrets/ ディレクトリは存在しない）
 ```

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1618,6 +1618,24 @@
       "notes": "run #42: subagent の調査で発見。providers.tf:17 の `version = \"= 0.111.1\"` と突き合わせて確認済み、値を修正するのみで挙動に影響しないため即完遂"
     },
     {
+      "id": "T-0089",
+      "domain": "homelab",
+      "title": "CLAUDE.md の Apps 一覧・ディレクトリ構造図が nextcloud/ 記載のまま実態（immich/coder/vaultwarden/ops-health-reporter/agent-rbac）に追随していない",
+      "kind": "docs",
+      "risk": "low",
+      "status": "done",
+      "priority": 30,
+      "why": "run #42 の subagent 調査で発見。Nextcloud は PR #46 で完全に撤去済み（Plans.md に記録あり）だが CLAUDE.md の Tech Stack『Apps』欄と Directory Structure のツリー図は nextcloud/ を挙げたまま、実際に存在する agent-rbac/immich/vaultwarden/coder/ops-health-reporter の5ディレクトリが未記載だった。T-0052（run #20）が同ファイルの secrets/ 記述だけを直し、apps 一覧は見落としていた。CLAUDE.md は毎セッション最初に読まれる項目のため、誤った一覧は存在しないディレクトリを探させたり実在のディレクトリを見落とさせたりする",
+      "dod": "CLAUDE.md の Apps 一覧・Directory Structure が apps/ の実際の中身（apps/README.md のディレクトリ構造図、T-0057 で更新済み）と一致する",
+      "refs": [
+        "CLAUDE.md",
+        "apps/README.md"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #42: `ls apps/` の実態と apps/README.md（T-0057 で既に正確な構造図がある）を突き合わせて Apps 一覧とディレクトリ構造図を書き換えた。挙動に影響しない docs のみの変更"
+    },
+    {
       "id": "T-0090",
       "domain": "homelab",
       "title": ".github/workflows/ci.yml の kustomize/azure-setup-helm バイナリ版が inventory.json / check_version_sync.py の監視対象に入っていない",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1238,3 +1238,12 @@
   manifest-diff job の2箇所がずれても CI が検出できない。GROUPS への追加が要るため次回以降
 - 次の起動へ: T-0089（CLAUDE.md docs drift）が本 run 内で直列に着手予定。T-0090 は todo。
   T-0079（node01 実ディスク容量、needs-human・priority 1）引き続き待ち
+
+## 2026-08-05 17:44 JST — run #42（続き）
+
+- 前回の中断: なし。PR #175（T-0087/T-0088 記録、T-0090 起票）の merge を見届けてから着手
+- やったこと: T-0089（CLAUDE.md の Apps 一覧・ディレクトリ構造図が nextcloud/ のまま実態と
+  ずれていた）を完遂。apps/README.md（T-0057 で正確化済み）と `ls apps/` の実態を突き合わせ、
+  CLAUDE.md の該当2箇所を書き換えた。docs のみの変更で挙動影響なし
+- 次の起動へ: T-0090（ci.yml の kustomize/azure-setup-helm バイナリ版のバージョン追跡漏れ）が
+  backlog の唯一の todo。T-0079（node01 実ディスク容量、needs-human・priority 1）引き続き待ち


### PR DESCRIPTION
## 変更点

CLAUDE.md の Tech Stack「Apps」欄と Directory Structure のツリー図が、撤去済みの `nextcloud/` を挙げたまま、実際に存在する `agent-rbac/` `immich/` `vaultwarden/` `coder/` `ops-health-reporter/` の5ディレクトリが未記載だった。`apps/README.md`（T-0057 で正確化済み）の構造図と `apps/` の実態に合わせて書き換えた。

## 検証したこと

- `ls apps/` の実際の中身と `apps/README.md` のディレクトリ構造図を突き合わせて確認
- docs のみの変更で manifest・挙動への影響なし
- `python3 ops/validate.py` → 0 error

## ロールバック手順

docs のみの変更のため revert すれば元に戻る。データ整合性の懸念なし。

## backlog task id

T-0089

---
_Generated by [Claude Code](https://claude.ai/code/session_015Mia1vXquFQF8g5ZjRZthw)_