### PR TITLE
ops: run #42 のラップアップ（PR #175/#176 反映）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1614,7 +1614,7 @@
         "terraform/proxmox/providers.tf"
       ],
       "created": "2026-08-05",
-      "pr": null,
+      "pr": 175,
       "notes": "run #42: subagent の調査で発見。providers.tf:17 の `version = \"= 0.111.1\"` と突き合わせて確認済み、値を修正するのみで挙動に影響しないため即完遂"
     },
     {
@@ -1632,7 +1632,7 @@
         "apps/README.md"
       ],
       "created": "2026-08-05",
-      "pr": null,
+      "pr": 176,
       "notes": "run #42: `ls apps/` の実態と apps/README.md（T-0057 で既に正確な構造図がある）を突き合わせて Apps 一覧とディレクトリ構造図を書き換えた。挙動に影響しない docs のみの変更"
     },
     {

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,20 @@
   "open": [],
   "merged": [
     {
+      "number": 176,
+      "title": "docs: CLAUDE.md の Apps/ディレクトリ構造を実態に合わせる (T-0089)",
+      "url": "https://github.com/hikuohiku/homelab/pull/176",
+      "mergedAt": "2026-08-05T08:46:20Z",
+      "headRefName": "autopilot/T-0089-claude-md-apps"
+    },
+    {
+      "number": 175,
+      "title": "ops: T-0087/T-0088 完遂の記録、T-0090 起票 (run #42)",
+      "url": "https://github.com/hikuohiku/homelab/pull/175",
+      "mergedAt": "2026-08-05T08:44:20Z",
+      "headRefName": "autopilot/T-0087-record"
+    },
+    {
       "number": 174,
       "title": "ops: tailscale-operator/k8s-nameserver の v1.102.2 更新調査結果を記録 (run #41)",
       "url": "https://github.com/hikuohiku/homelab/pull/174",
@@ -399,20 +413,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/117",
       "mergedAt": "2026-08-05T00:52:49Z",
       "headRefName": "autopilot/run16-wrapup"
-    },
-    {
-      "number": 116,
-      "title": "ci: actions/checkout を v4 → v7 に上げる (T-0044)",
-      "url": "https://github.com/hikuohiku/homelab/pull/116",
-      "mergedAt": "2026-08-05T00:51:08Z",
-      "headRefName": "autopilot/T-0044-checkout-v7"
-    },
-    {
-      "number": 115,
-      "title": "ci: nix-installer-action の floating ref を固定する (T-0042)",
-      "url": "https://github.com/hikuohiku/homelab/pull/115",
-      "mergedAt": "2026-08-05T00:46:53Z",
-      "headRefName": "autopilot/T-0042-pin-nix-installer-action"
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -483,8 +483,11 @@
       "at": "2026-08-05T08:42:00Z",
       "kind": "scheduled",
       "by": "cloud routine",
-      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし（last_read 以降新規コメント0件、全64件を機械的に確認）。ops-health-report (generated_at 08:30:04Z、#171 merge 後) で immich アプリ Synced/Healthy かつ pod_issues に immich-server/machine-learning が出現しないことを確認し T-0087 を done に。backlog の todo が0件だったため subagent に調査を投げ3件発見: T-0088（ops/inventory.json の tf-provider-proxmox.current が 0.89.1 のまま古く、実際の pin (providers.tf) は 0.111.1 と一致していなかった、即完遂）、T-0089（CLAUDE.md の Apps 一覧・ディレクトリ構造が nextcloud/ 記載のまま immich/coder/vaultwarden 等5ディレクトリ未記載、この起動内で直列に着手予定）、T-0090（ci.yml の kustomize/azure-setup-helm バイナリ版が監視対象外、次回以降の todo）",
-      "prs": []
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし（last_read 以降新規コメント0件、全64件を機械的に確認）。ops-health-report (generated_at 08:30:04Z、#171 merge 後) で immich アプリ Synced/Healthy かつ pod_issues に immich-server/machine-learning が出現しないことを確認し T-0087 を done に。backlog の todo が0件だったため subagent に調査を投げ3件発見: T-0088（ops/inventory.json の tf-provider-proxmox.current が 0.89.1 のまま古く、実際の pin (providers.tf) は 0.111.1 と一致していなかった、即完遂・#175）、T-0089（CLAUDE.md の Apps 一覧・ディレクトリ構造が nextcloud/ 記載のまま immich/coder/vaultwarden 等5ディレクトリ未記載、直列に着手・完遂・#176）、T-0090（ci.yml の kustomize/azure-setup-helm バイナリ版が監視対象外、次回以降の todo）",
+      "prs": [
+        175,
+        176
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

- `ops/state.json` の run #42 エントリに実際の PR 番号（#175, #176）を反映
- T-0088/T-0089 の backlog エントリの `pr` フィールドを実際の PR 番号に反映
- `ops/dashboard/prs.json` キャッシュを最新化（#175/#176 を含む）

## 検証したこと

- `python3 ops/validate.py` → 0 error（5 warning、いずれも既知・対応不要）

## ロールバック手順

`ops/` 配下の記録のみの変更。revert すれば元に戻る。データ整合性の懸念なし。

## backlog task id

（run #42 の記録更新、新規タスクなし）

---
_Generated by [Claude Code](https://claude.ai/code/session_015Mia1vXquFQF8g5ZjRZthw)_