### PR TITLE
ci: kustomize/helm バイナリ版を version_sync の監視対象に追加 (T-0090)

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1652,7 +1652,7 @@
       ],
       "created": "2026-08-05",
       "notes": "ops/inventory.json に gha-setup-helm-version (v3.16.4) / kustomize-binary (v5.8.1) を追加。ops/check_version_sync.py に extract_yaml_job_block（2-indent のジョブ境界でブロックを絞る）と、それを使う extract_helm_setup_version / extract_kustomize_download_version を追加し、GROUPS に manifests job / manifest-diff job の2箇所ずつを検証する2グループを追加。手元でこの2グループそれぞれ片方の値だけをずらして exit 1 になること、元に戻すと exit 0 に戻ることを確認済み（DoD 達成）。ci.yml 自体は変更していない",
-      "pr": null
+      "pr": 178
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1641,7 +1641,7 @@
       "title": ".github/workflows/ci.yml の kustomize/azure-setup-helm バイナリ版が inventory.json / check_version_sync.py の監視対象に入っていない",
       "kind": "ci",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 30,
       "why": "run #42 の subagent 調査で発見。ci.yml の manifests job と manifest-diff job の両方に azure/setup-helm (version: v3.16.4) と kustomize (v5.8.1、curl でダウンロード) が独立に2箇所ずつ書かれている。T-0042〜T-0048 は `uses: foo@vX` 形式の GitHub Actions のみを棚卸し対象にしており、これらはバイナリのバージョン文字列のため対象外だった。check_version_sync.py の GROUPS にも該当エントリが無く、2箇所の値がずれても CI は検出できない。ずれると manifests job と manifest-diff job で異なる kustomize/helm バージョンがレンダリングに使われ、T-0036 の削除検出（manifest-diff）がツールバージョン差分由来の偽陽性/偽陰性を出しうる",
       "dod": "ops/inventory.json に azure/setup-helm と kustomize の2エントリを追加（policy: auto）。ops/check_version_sync.py の GROUPS に、ci.yml 内の2箇所ずつの出現を検証する2グループを追加（既存の actions/checkout グループと同じパターン）。意図的に値をずらして CI (ops job) が exit 1 になることを確認する",
@@ -1651,6 +1651,7 @@
         "ops/check_version_sync.py"
       ],
       "created": "2026-08-05",
+      "notes": "ops/inventory.json に gha-setup-helm-version (v3.16.4) / kustomize-binary (v5.8.1) を追加。ops/check_version_sync.py に extract_yaml_job_block（2-indent のジョブ境界でブロックを絞る）と、それを使う extract_helm_setup_version / extract_kustomize_download_version を追加し、GROUPS に manifests job / manifest-diff job の2箇所ずつを検証する2グループを追加。手元でこの2グループそれぞれ片方の値だけをずらして exit 1 になること、元に戻すと exit 0 に戻ることを確認済み（DoD 達成）。ci.yml 自体は変更していない",
       "pr": null
     }
   ]

--- a/ops/check_version_sync.py
+++ b/ops/check_version_sync.py
@@ -55,6 +55,42 @@ def extract_tag_in_block(path: str, top_key: str) -> str:
     return v.group(1)
 
 
+def extract_yaml_job_block(path: str, job_name: str) -> str:
+    """`jobs:` 配下のトップレベルジョブ（2-indent の `<job_name>:`）から、次の同 indent の
+    ジョブ名または末尾までの範囲をブロックとして返す。`extract_yaml_top_level_block` と同じ
+    「構造で範囲を決める」考え方を、0-indent ではなく 2-indent のジョブ境界に適用したもの。
+    """
+    text = read(path)
+    job_re = re.compile(rf"^  {re.escape(job_name)}:\s*$", re.MULTILINE)
+    m = job_re.search(text)
+    if not m:
+        raise ValueError(f"{path}: ジョブ {job_name}: が見つからない")
+    next_job_re = re.compile(r"^  \S.*:\s*$", re.MULTILINE)
+    n = next_job_re.search(text, m.end())
+    end = n.start() if n else len(text)
+    return text[m.end() : end]
+
+
+def extract_helm_setup_version(path: str, job_name: str) -> str:
+    """指定したジョブ内の `azure/setup-helm@vX` ステップが `with: version:` で指定する
+    helm バイナリのバージョンを拾う（T-0090。Action 自体の pin とは別物）。"""
+    block = extract_yaml_job_block(path, job_name)
+    m = re.search(r"azure/setup-helm@\S+\s*\n\s*with:\s*\n\s*version:\s*(\S+)", block)
+    if not m:
+        raise ValueError(f"{path}: ジョブ {job_name} 内に azure/setup-helm の version: が見つからない")
+    return m.group(1)
+
+
+def extract_kustomize_download_version(path: str, job_name: str) -> str:
+    """指定したジョブ内で curl ダウンロードしている kustomize バイナリのバージョンを拾う
+    （T-0090。GitHub Action ではなく GitHub Releases から直接ダウンロードしている）。"""
+    block = extract_yaml_job_block(path, job_name)
+    m = re.search(r"kustomize%2Fv(\S+?)/kustomize_v\S+?_linux_amd64\.tar\.gz", block)
+    if not m:
+        raise ValueError(f"{path}: ジョブ {job_name} 内に kustomize ダウンロード URL の version が見つからない")
+    return m.group(1)
+
+
 def extract_all_action_tags(path: str, action_name: str) -> str:
     """`uses: <action_name>@<tag>` を全箇所拾い、ファイル内で全て一致することを確認して返す。
     1 ファイルに同じ Action が複数回 (`uses:`) 出てくる場合（例: ci.yml の複数 job）でも、
@@ -199,6 +235,28 @@ GROUPS = [
             )),
             ("apps/vaultwarden/pvc-usage-cronjob.yaml", lambda: extract_image_tag(
                 "apps/vaultwarden/pvc-usage-cronjob.yaml", "image: python:"
+            )),
+        ],
+    },
+    {
+        "name": "azure/setup-helm version input (T-0090, inventory: gha-setup-helm-version)",
+        "targets": [
+            (".github/workflows/ci.yml (manifests job)", lambda: extract_helm_setup_version(
+                ".github/workflows/ci.yml", "manifests"
+            )),
+            (".github/workflows/ci.yml (manifest-diff job)", lambda: extract_helm_setup_version(
+                ".github/workflows/ci.yml", "manifest-diff"
+            )),
+        ],
+    },
+    {
+        "name": "kustomize binary version (T-0090, inventory: kustomize-binary)",
+        "targets": [
+            (".github/workflows/ci.yml (manifests job)", lambda: extract_kustomize_download_version(
+                ".github/workflows/ci.yml", "manifests"
+            )),
+            (".github/workflows/ci.yml (manifest-diff job)", lambda: extract_kustomize_download_version(
+                ".github/workflows/ci.yml", "manifest-diff"
             )),
         ],
     },

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,28 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 178,
+      "title": "ci: kustomize/helm バイナリ版を version_sync の監視対象に追加 (T-0090)",
+      "url": "https://github.com/hikuohiku/homelab/pull/178",
+      "isDraft": false,
+      "createdAt": "2026-08-05T08:50:59Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "PENDING"
+        }
+      ],
+      "headRefName": "autopilot/T-0090-ci-binary-version-tracking",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 177,
+      "title": "ops: run #42 のラップアップ（PR #175/#176 反映）",
+      "url": "https://github.com/hikuohiku/homelab/pull/177",
+      "mergedAt": "2026-08-05T08:48:16Z",
+      "headRefName": "autopilot/run42-wrapup"
+    },
     {
       "number": 176,
       "title": "docs: CLAUDE.md の Apps/ディレクトリ構造を実態に合わせる (T-0089)",

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -305,6 +305,30 @@
       "policy": "auto",
       "note": "T-0080 (#163) で新設。3 namespace (immich/vaultwarden/coder) に同じタグを持つ同型 CronJob をコピーして配置しているため、ops-health-reporter-image と同様に 3 箇所とも揃えて更新すること（T-0082）",
       "observability_impact": "壊れるとその namespace の PVC 実使用量が pvc-usage-report ConfigMap に書き戻されなくなり、ops-health-reporter が集約する pvc_usage が古いまま止まる。読み取り専用 CronJob であり、壊れても homelab 本体の到達性・稼働には影響しない"
+    },
+    {
+      "id": "gha-setup-helm-version",
+      "kind": "binary",
+      "name": "helm (azure/setup-helm version input)",
+      "current": "v3.16.4",
+      "file": ".github/workflows/ci.yml",
+      "match": "version: v3.16.4",
+      "upstream": "github:helm/helm",
+      "policy": "auto",
+      "note": "azure/setup-helm@v5 の `with: version:` が指定する helm バイナリ本体のバージョン。gha-azure-setup-helm（Action 自体の pin, uses: azure/setup-helm@vX）とは別物。ci.yml の manifests job と manifest-diff job の2箇所に独立して書かれている（T-0090。ops/check_version_sync.py の GROUPS で内部一致を検証）",
+      "observability_impact": "kustomize build job (--enable-helm) と manifest-diff job が使用。2箇所がずれると job ごとに異なる helm バージョンでレンダリングされ、T-0036 の削除検出（manifest-diff）がツールバージョン差分由来の偽陽性/偽陰性を出しうる"
+    },
+    {
+      "id": "kustomize-binary",
+      "kind": "binary",
+      "name": "kustomize",
+      "current": "v5.8.1",
+      "file": ".github/workflows/ci.yml",
+      "match": "kustomize%2Fv5.8.1",
+      "upstream": "github:kubernetes-sigs/kustomize",
+      "policy": "auto",
+      "note": "manifests job と manifest-diff job が GitHub Releases から curl で直接ダウンロードしている kustomize バイナリのバージョン。GitHub Action ではないため gha-* エントリとは別扱い。2箇所に独立して書かれている（T-0090。ops/check_version_sync.py の GROUPS で内部一致を検証）",
+      "observability_impact": "kustomize build job と manifest-diff job が使用。2箇所がずれると job ごとに異なる kustomize バージョンでレンダリングされ、T-0036 の削除検出（manifest-diff）がツールバージョン差分由来の偽陽性/偽陰性を出しうる"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1247,3 +1247,20 @@
   CLAUDE.md の該当2箇所を書き換えた。docs のみの変更で挙動影響なし
 - 次の起動へ: T-0090（ci.yml の kustomize/azure-setup-helm バイナリ版のバージョン追跡漏れ）が
   backlog の唯一の todo。T-0079（node01 実ディスク容量、needs-human・priority 1）引き続き待ち
+
+## 2026-08-05 18:10 JST — run #43
+
+- 前回の中断: なし。オープン PR・autopilot ブランチとも無し
+- 読んだフィードバック: issue #56 last_read (08:23:09Z) 以降、新規コメント0件（全64件を機械的に
+  突き合わせて確認、last_read 自体が自分の直前の返信）
+- やったこと: T-0090 完遂。ops/inventory.json に gha-setup-helm-version (v3.16.4) /
+  kustomize-binary (v5.8.1) の2エントリを追加。ops/check_version_sync.py に
+  extract_yaml_job_block（`jobs:` 配下の2-indent ジョブ境界でブロックを絞る、
+  extract_yaml_top_level_block と同じ考え方を job 単位に適用）を追加し、それを使う
+  extract_helm_setup_version / extract_kustomize_download_version で GROUPS に2グループ
+  （manifests job と manifest-diff job の値を突き合わせ）を追加。DoD の「意図的に値をずらして
+  CI が exit 1 になることを確認する」は、ci.yml を一時的に書き換えて手元で実施（helm 側・
+  kustomize 側それぞれ検出を確認、その後 diff が空であることを確認して復元）。ci.yml 自体は
+  変更していない
+- 次の起動へ: backlog の todo が本 run 終了時点で 0 件になる見込み。次回は §3 の調査タスク
+  起票から入る。T-0079（node01 実ディスク容量、needs-human・priority 1）引き続き待ち

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T08:42:00Z",
+  "updated": "2026-08-05T08:51:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -487,6 +487,16 @@
       "prs": [
         175,
         176
+      ]
+    },
+    {
+      "n": 43,
+      "at": "2026-08-05T08:51:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし（last_read 以降新規コメント0件、全64件を機械的に確認）。backlog の唯一の todo だった T-0090（ci.yml の manifests job / manifest-diff job に独立に書かれている azure/setup-helm の version 入力と kustomize バイナリ版が監視対象外）を完遂。ops/inventory.json に2エントリを追加し、ops/check_version_sync.py に extract_yaml_job_block（jobs: 配下の2-indent境界でブロックを絞る）とそれを使う2つの抽出関数、GROUPS に2グループを追加。DoD の『意図的に値をずらして CI が exit 1 になることを確認する』は手元で ci.yml を一時的に書き換えて両パターンとも検出できることを確認し、diff が空であることを確認して復元した（#178）",
+      "prs": [
+        178
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

`.github/workflows/ci.yml` の `manifests` job と `manifest-diff` job には、それぞれ独立に

- `azure/setup-helm@v5` の `with: version:`（helm バイナリ本体のバージョン、Action 自体の pin とは別物）
- kustomize バイナリ（GitHub Releases から curl で直接ダウンロード）のバージョン

が2箇所ずつ書かれていましたが、これまで `ops/inventory.json` / `ops/check_version_sync.py` の監視対象外で、2箇所の値がずれても CI が検出できませんでした（既存の棚卸し (T-0042〜T-0048) は `uses: foo@vX` 形式の GitHub Actions のみが対象で、バージョン文字列であるこれらは対象外だった）。

- `ops/inventory.json` に `gha-setup-helm-version` (v3.16.4) / `kustomize-binary` (v5.8.1) の2エントリを追加
- `ops/check_version_sync.py` に `extract_yaml_job_block`（`jobs:` 配下の2-indentジョブ境界でテキストを絞る、既存の `extract_yaml_top_level_block` と同じ考え方）を追加し、それを使う `extract_helm_setup_version` / `extract_kustomize_download_version` で GROUPS に2グループ（`manifests` job と `manifest-diff` job の値の突き合わせ）を追加
- `.github/workflows/ci.yml` 自体は変更していません

## 検証したこと

- `python3 ops/check_version_sync.py` → 既存5グループ + 新規2グループとも green
- `python3 ops/validate.py` → 0 error
- DoD の「意図的に値をずらして CI (ops job) が exit 1 になることを確認する」を手元で実施: `ci.yml` の `manifest-diff` job 側だけ helm version / kustomize version をそれぞれ一時的にずらし、両ケースとも `check_version_sync.py` が exit 1 で不一致を検出することを確認。その後 `git diff` が空になる（= `ci.yml` に変更が残っていない）ことを確認して復元済み

## ロールバック手順

このコミットを revert すれば元に戻ります。DB やスキーマは関与しないため、revert 後のデータ不整合は考慮不要です。`ci.yml` 自体には触れていないため、CI の挙動（レンダリングに使う実際の helm/kustomize バージョン）に影響はありません。

## backlog task id

T-0090


---
_Generated by [Claude Code](https://claude.ai/code/session_01AN2rH5jcQx9bjKqMcrgUs5)_