### PR TITLE
ci.yml の helm/kustomize バイナリバージョンを二重管理チェック対象に追加 (T-0090)

### DIFF
--- a/ops/check_version_sync.py
+++ b/ops/check_version_sync.py
@@ -55,6 +55,21 @@ def extract_tag_in_block(path: str, top_key: str) -> str:
     return v.group(1)
 
 
+def extract_all_regex_matches(path: str, pattern: str) -> str:
+    """pattern（capture group 1つ）の全マッチが完全一致することを確認して返す。
+    `extract_all_action_tags` の一般化版。`uses: name@tag` 以外の形（`with: version:` の
+    バイナリバージョン、curl URL に埋め込まれたバージョン等）で、1 ファイル内の複数箇所の
+    割れを検出する（T-0090）。"""
+    text = read(path)
+    matches = re.findall(pattern, text)
+    if not matches:
+        raise ValueError(f"{path}: パターンにマッチする箇所が見つからない: {pattern}")
+    uniq = sorted(set(matches))
+    if len(uniq) > 1:
+        raise ValueError(f"{path}: 値がファイル内で不一致 ({uniq})")
+    return uniq[0]
+
+
 def extract_all_action_tags(path: str, action_name: str) -> str:
     """`uses: <action_name>@<tag>` を全箇所拾い、ファイル内で全て一致することを確認して返す。
     1 ファイルに同じ Action が複数回 (`uses:`) 出てくる場合（例: ci.yml の複数 job）でも、
@@ -185,6 +200,24 @@ GROUPS = [
             )),
             (".github/workflows/release-image.yml", lambda: extract_all_action_tags(
                 ".github/workflows/release-image.yml", "actions/checkout"
+            )),
+        ],
+    },
+    {
+        "name": "helm CLI version via azure/setup-helm `with: version:` (T-0090, inventory: ci-helm-cli)",
+        "targets": [
+            (".github/workflows/ci.yml (manifests / manifest-diff job)", lambda: extract_all_regex_matches(
+                ".github/workflows/ci.yml",
+                r"azure/setup-helm@v5\s*\n\s*with:\s*\n\s*version:\s*(\S+)",
+            )),
+        ],
+    },
+    {
+        "name": "kustomize static binary version (T-0090, inventory: ci-kustomize-binary)",
+        "targets": [
+            (".github/workflows/ci.yml (manifests / manifest-diff job)", lambda: extract_all_regex_matches(
+                ".github/workflows/ci.yml",
+                r"kustomize_v(\S+?)_linux_amd64\.tar\.gz",
             )),
         ],
     },

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -222,6 +222,30 @@
       "observability_impact": "kustomize build job (--enable-helm) が使用。壊れると manifest-diff / kustomize build の CI が動かなくなる"
     },
     {
+      "id": "ci-helm-cli",
+      "kind": "cli-tool",
+      "name": "helm CLI（azure/setup-helm の `with: version:` input で指定するバイナリ本体のバージョン）",
+      "current": "v3.16.4",
+      "file": ".github/workflows/ci.yml",
+      "match": "version:",
+      "upstream": "github:helm/helm",
+      "policy": "auto",
+      "note": "T-0090: gha-azure-setup-helm（Action 自体のバージョン `azure/setup-helm@v5`）とは別物。manifests job / manifest-diff job の2箇所に独立して `version: v3.16.4` と書かれており、ops/check_version_sync.py の GROUPS でファイル内の一致を検証している",
+      "observability_impact": "kustomize build job (--enable-helm) が使用。壊れると manifest-diff / kustomize build の CI が動かなくなる"
+    },
+    {
+      "id": "ci-kustomize-binary",
+      "kind": "cli-tool",
+      "name": "kustomize（CI が curl でダウンロードする static binary）",
+      "current": "v5.8.1",
+      "file": ".github/workflows/ci.yml",
+      "match": "kustomize%2Fv",
+      "upstream": "github:kubernetes-sigs/kustomize",
+      "policy": "auto",
+      "note": "T-0090: manifests job / manifest-diff job の2箇所に独立して同じ curl コマンドが書かれており、ops/check_version_sync.py の GROUPS でファイル内の一致を検証している",
+      "observability_impact": "kustomize build job が使用。壊れると manifest-diff / kustomize build の CI が動かなくなる"
+    },
+    {
       "id": "gha-hashicorp-setup-terraform",
       "kind": "github-action",
       "name": "hashicorp/setup-terraform",


### PR DESCRIPTION
## 変更点

`.github/workflows/ci.yml` の `manifests` job と `manifest-diff` job には、それぞれ独立して次の2つのツールバージョンが書かれている。

- `azure/setup-helm@v5` の `with: version:` input（helm CLI 本体のバージョン、`v3.16.4`）
- kustomize の curl ダウンロード版（`v5.8.1`）

これまで `ops/inventory.json` の監視対象にも `ops/check_version_sync.py` の二重管理チェックにも入っておらず、2箇所の値がずれても CI が検出できなかった（`gha-azure-setup-helm` は `azure/setup-helm@v5` という Action 自体のバージョンを追跡しているだけで、それが実際にインストールする helm CLI 本体のバージョンとは別物）。

- `ops/inventory.json` に `ci-helm-cli` / `ci-kustomize-binary` の2エントリを追加（`policy: auto`）
- `ops/check_version_sync.py` に、ファイル内の複数箇所出現の一致を検証する汎用関数 `extract_all_regex_matches`（`extract_all_action_tags` の一般化）を追加し、上記2つを検証する GROUPS エントリを追加

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/check_version_sync.py` → 全 GROUPS が ok（新規2件含む）
- 意図的に片方の値だけをずらして exit 1 になることを確認（helm version / kustomize version の両方で確認済み。確認後に元の値へ戻し、diff がゼロであることも確認済み）
- `python3 ops/check_pvc_usage_script_sync.py` / `python3 ops/dashboard/build.py` も手元で実行しエラー無しを確認

## ロールバック手順

このブランチを revert すれば元に戻る。DB・スキーマを持つコンポーネントの変更ではなく、CI の検証スクリプトと `ops/inventory.json` のメタデータのみの変更のため、revert 後に不整合が残る余地はない。

## backlog

T-0090

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rv89pPmmmztP1vrFPqbWFW)_