### PR TITLE
ci: terraform_version を 1.15.0 → 1.15.8 に更新 (T-0091)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.15.0
+          terraform_version: 1.15.8
           terraform_wrapper: false
 
       - name: fmt

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 91,
-  "updated": "2026-08-05T08:42:00Z",
+  "next_id": 94,
+  "updated": "2026-08-05T08:55:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -1653,6 +1653,59 @@
       "created": "2026-08-05",
       "notes": "ops/inventory.json に gha-setup-helm-version (v3.16.4) / kustomize-binary (v5.8.1) を追加。ops/check_version_sync.py に extract_yaml_job_block（2-indent のジョブ境界でブロックを絞る）と、それを使う extract_helm_setup_version / extract_kustomize_download_version を追加し、GROUPS に manifests job / manifest-diff job の2箇所ずつを検証する2グループを追加。手元でこの2グループそれぞれ片方の値だけをずらして exit 1 になること、元に戻すと exit 0 に戻ることを確認済み（DoD 達成）。ci.yml 自体は変更していない",
       "pr": 178
+    },
+    {
+      "id": "T-0091",
+      "domain": "homelab",
+      "title": "CI の terraform_version (1.15.0) が required_version の範囲内で最新パッチ 1.15.8 より8パッチ遅れている",
+      "kind": "ci",
+      "risk": "low",
+      "status": "done",
+      "priority": 20,
+      "why": "run #43 の subagent 調査で発見。.github/workflows/ci.yml の hashicorp/setup-terraform ステップが terraform_version: 1.15.0 を固定指定しているが、terraform/proxmox/providers.tf の required_version は \"~> 1.15\" という範囲指定のため 1.15.0 のままでも CI 上は違反にならず、上流が 1.15.8 まで進んでいることに誰も気づけない状態だった。ops/inventory.json にも terraform バイナリ自体を追跡するエントリが無かった（T-0043〜T-0048/T-0090 は GitHub Actions と CI 内バイナリのカバレッジを広げてきたが terraform 本体は抜けていた）",
+      "dod": "1.15.0→1.15.8 の CHANGELOG を全文確認し breaking change の有無を判断する。ci.yml の terraform_version を 1.15.8 に更新。ops/inventory.json に terraform バイナリを追跡する新エントリを追加（policy: auto）",
+      "refs": [
+        ".github/workflows/ci.yml",
+        "terraform/proxmox/providers.tf",
+        "ops/inventory.json"
+      ],
+      "created": "2026-08-05",
+      "notes": "GitHub Releases (v1.15.8, 2026-07-08) と CHANGELOG.md の 1.15.1〜1.15.8 区間を WebFetch で原文確認。breaking change 無し。terraform validate に関する変更は『backend block の検証を追加→1.15.1 で一部撤回』のみで、このリポジトリの backend (Terraform Cloud, cloud{} ブロック) には影響しない。fmt/init への影響も出力整形のみ。ci.yml を 1.15.8 に更新し、ops/inventory.json に terraform-binary エントリを新設した",
+      "pr": null
+    },
+    {
+      "id": "T-0092",
+      "domain": "homelab",
+      "title": "README.md のトラブルシューティングが存在しない providers.tf の insecure フィールドを参照している",
+      "kind": "docs",
+      "risk": "low",
+      "status": "todo",
+      "priority": 40,
+      "why": "run #43 の subagent 調査で発見。README.md:268 に『自己署名証明書を許可する場合: providers.tf の insecure = false を insecure = true に変更』とあるが、実際の terraform/proxmox/providers.tf の provider \"proxmox\" ブロックには endpoint / api_token / ssh {} しかなく insecure 属性自体が存在しない（false との明記も無い）。bpg/proxmox provider が insecure という provider 引数を実際にサポートしているか一次ソース（provider ドキュメント）で確認した上で、サポートしているなら『追加する』という正しい手順に、廃止/非対応なら現状の正しい対処法に書き換える",
+      "dod": "bpg/proxmox provider のドキュメント（Terraform Registry または GitHub リポジトリ）で insecure 引数の現状を確認。README.md の該当箇所を実態に合わせて書き換える（値を変更ではなく追加する手順であること、または別の対処法であることを明記）",
+      "refs": [
+        "README.md",
+        "terraform/proxmox/providers.tf"
+      ],
+      "created": "2026-08-05",
+      "pr": null
+    },
+    {
+      "id": "T-0093",
+      "domain": "homelab",
+      "title": "CLAUDE.md が autopilot の定期実行間隔を『3時間ごと』と書いているが実際は毎時（ops/state.json 参照）",
+      "kind": "docs",
+      "risk": "low",
+      "status": "todo",
+      "priority": 40,
+      "why": "run #43 の subagent 調査で発見。CLAUDE.md:70『クラウドの定期実行（3 時間ごと）が独立セッションを起こし...』は、ops/state.json の routines[0] (cron: \"19 * * * * (UTC)\", cron_human: \"1 時間ごと（毎時 19 分）\") と食い違っている。state.json の note に『立ち上げ期は頻度を上げて安定性を見る。落ち着いたら間隔を空ける』とあり、この値は今後も変わりうるため、CLAUDE.md に具体的な間隔を固定で書くのではなく ops/state.json の routines を単一の情報源として指し示す書き方に直す",
+      "dod": "CLAUDE.md の該当箇所を、具体的な時間を決め打ちせず ops/state.json の routines を参照する記述に書き換える（もしくは現在の実値『毎時』に修正した上で、変更されたら state.json 側で追随する運用であることを明記する）",
+      "refs": [
+        "CLAUDE.md",
+        "ops/state.json"
+      ],
+      "created": "2026-08-05",
+      "pr": null
     }
   ]
 }

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -329,6 +329,18 @@
       "policy": "auto",
       "note": "manifests job と manifest-diff job が GitHub Releases から curl で直接ダウンロードしている kustomize バイナリのバージョン。GitHub Action ではないため gha-* エントリとは別扱い。2箇所に独立して書かれている（T-0090。ops/check_version_sync.py の GROUPS で内部一致を検証）",
       "observability_impact": "kustomize build job と manifest-diff job が使用。2箇所がずれると job ごとに異なる kustomize バージョンでレンダリングされ、T-0036 の削除検出（manifest-diff）がツールバージョン差分由来の偽陽性/偽陰性を出しうる"
+    },
+    {
+      "id": "terraform-binary",
+      "kind": "binary",
+      "name": "terraform (hashicorp/setup-terraform terraform_version input)",
+      "current": "1.15.8",
+      "file": ".github/workflows/ci.yml",
+      "match": "terraform_version:",
+      "upstream": "github:hashicorp/terraform",
+      "policy": "auto",
+      "note": "terraform job がインストールする terraform バイナリ本体のバージョン。terraform/proxmox/providers.tf の required_version (\"~> 1.15\") の範囲内で揃える。T-0091 (run #43) で発見時点 1.15.0 が最新 1.15.8 より8パッチ遅れていた（required_version の範囲は満たすため CI は気づけない）ことを機に新設。CHANGELOG 全文確認（1.15.1〜1.15.8）で breaking change 無し、fmt/validate/init への影響も軽微（backend block validation の追加→撤回、ログ整形のみ）と確認済み",
+      "observability_impact": "terraform validate job が使用。壊れると terraform validate の CI が動かなくなる"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1264,3 +1264,23 @@
   変更していない
 - 次の起動へ: backlog の todo が本 run 終了時点で 0 件になる見込み。次回は §3 の調査タスク
   起票から入る。T-0079（node01 実ディスク容量、needs-human・priority 1）引き続き待ち
+
+## 2026-08-05 18:10 JST — run #43（続き）
+
+- T-0090 (#178) の merge を見届けた後、backlog の todo が 0 件になったため subagent に新しい
+  調査観点探しを投げた。3件の候補（terraform CI バイナリ版の drift、README.md の insecure 記述
+  drift、CLAUDE.md の定期実行間隔 drift）を得て、それぞれ自分でも一次ソースを再確認したうえで
+  採用: T-0091（terraform_version drift、即完遂）、T-0092/T-0093（docs drift、todo で次回以降）
+- T-0091: ci.yml の hashicorp/setup-terraform ステップが terraform_version: 1.15.0 を固定していたが、
+  providers.tf の required_version ("~> 1.15") は範囲指定のため CI が気づけないまま最新 1.15.8
+  （2026-07-08 リリース、WebFetch で GitHub Releases から確認）より8パッチ遅れていた。CHANGELOG.md
+  の 1.15.1〜1.15.8 を全文確認し breaking change 無し（terraform validate への影響は backend block
+  検証の追加→1.15.1で一部撤回のみ、このリポジトリの cloud{} backend には無関係）と確認して更新。
+  ops/inventory.json に terraform-binary エントリを新設（T-0090 と同じ「CI 内バイナリのカバレッジ
+  漏れ」パターン）。ci.yml の変更は1箇所のみのため check_version_sync.py の GROUPS 追加は不要
+  （T-0090 のように2箇所以上に同じ値が書かれているケースではない）
+- T-0092/T-0093 は docs のみの低リスク修正で、次回以降の todo として起票済み（このタスクの
+  記録に相乗り）。まだ着手していない
+- 次の起動へ: backlog の todo は T-0092（priority 40, README.md の insecure 記述）と T-0093
+  （priority 40, CLAUDE.md の定期実行間隔記述）の2件。どちらも docs のみで低リスク。
+  T-0079（node01 実ディスク容量、needs-human・priority 1）引き続き待ち

--- a/ops/state.json
+++ b/ops/state.json
@@ -494,7 +494,7 @@
       "at": "2026-08-05T08:51:00Z",
       "kind": "scheduled",
       "by": "cloud routine",
-      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし（last_read 以降新規コメント0件、全64件を機械的に確認）。backlog の唯一の todo だった T-0090（ci.yml の manifests job / manifest-diff job に独立に書かれている azure/setup-helm の version 入力と kustomize バイナリ版が監視対象外）を完遂。ops/inventory.json に2エントリを追加し、ops/check_version_sync.py に extract_yaml_job_block（jobs: 配下の2-indent境界でブロックを絞る）とそれを使う2つの抽出関数、GROUPS に2グループを追加。DoD の『意図的に値をずらして CI が exit 1 になることを確認する』は手元で ci.yml を一時的に書き換えて両パターンとも検出できることを確認し、diff が空であることを確認して復元した（#178）",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし（last_read 以降新規コメント0件、全64件を機械的に確認）。backlog の唯一の todo だった T-0090（ci.yml の manifests job / manifest-diff job に独立に書かれている azure/setup-helm の version 入力と kustomize バイナリ版が監視対象外）を完遂。ops/inventory.json に2エントリを追加し、ops/check_version_sync.py に extract_yaml_job_block（jobs: 配下の2-indent境界でブロックを絞る）とそれを使う2つの抽出関数、GROUPS に2グループを追加。DoD の『意図的に値をずらして CI が exit 1 になることを確認する』は手元で ci.yml を一時的に書き換えて両パターンとも検出できることを確認し、diff が空であることを確認して復元した（#178）。続けて subagent に新しい調査観点探しを投げ3件発見: T-0091（ci.yml の terraform_version が 1.15.0 のまま最新 1.15.8 より8パッチ遅れ、CHANGELOG 全文確認のうえ即完遂）、T-0092（README.md が存在しない providers.tf の insecure フィールドを参照、todo）、T-0093（CLAUDE.md の定期実行間隔『3時間ごと』が ops/state.json の実際の毎時と食い違う、todo）",
       "prs": [
         178
       ]


### PR DESCRIPTION
## 変更点

`.github/workflows/ci.yml` の `terraform` job が `hashicorp/setup-terraform` の `terraform_version` を `1.15.0` に固定していましたが、`terraform/proxmox/providers.tf` の `required_version` は `"~> 1.15"` という範囲指定のため、CI 上は `1.15.0` のままでも違反にならず、上流が `1.15.8` まで進んでいることに誰も気づけない状態でした（T-0090 で見つけた kustomize/helm バイナリのカバレッジ漏れと同じパターンで、`ops/inventory.json` にも terraform バイナリ自体を追跡するエントリが無かった）。

- `ci.yml` の `terraform_version` を `1.15.8` に更新
- `ops/inventory.json` に `terraform-binary` エントリを新設（policy: auto）
- 副産物として見つかった docs drift 2件（README.md の存在しない `insecure` フィールド記述、CLAUDE.md の定期実行間隔の記述ずれ）を backlog に T-0092/T-0093 として起票（このタスクの記録に相乗り、着手は次回以降）

## 検証したこと

- GitHub Releases で `v1.15.8`（2026-07-08 リリース）が現時点の 1.15.x 系最新パッチであることを確認
- CHANGELOG.md の `1.15.1`〜`1.15.8` を全文確認: breaking change なし。`terraform validate` に関する変更は「backend block の検証を追加 → 1.15.1 で一部撤回」のみで、このリポジトリの backend（Terraform Cloud, `cloud {}` ブロック）には無関係。`fmt`/`init` への影響も出力整形のみ
- `python3 ops/validate.py` → 0 error
- `python3 ops/check_version_sync.py` → green（このバージョンは ci.yml 内で1箇所のみのため GROUPS への追加は不要）

## ロールバック手順

このコミットを revert すれば元に戻ります。CI ツールのバージョンのみの変更で、DB やスキーマは関与しないため revert 後のデータ不整合は考慮不要です。`terraform apply`/`destroy` は autopilot が実行しないため、この変更自体が実インフラに触れることはありません。

## backlog task id

T-0091（本体）、T-0092/T-0093（起票のみ、次回以降着手）


---
_Generated by [Claude Code](https://claude.ai/code/session_01AN2rH5jcQx9bjKqMcrgUs5)_