### PR TITLE
ops: T-0090 の重複 PR (#179) を close した記録 (run #44)

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,13 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 178,
       "title": "ci: kustomize/helm バイナリ版を version_sync の監視対象に追加 (T-0090)",
       "url": "https://github.com/hikuohiku/homelab/pull/178",
-      "isDraft": false,
-      "createdAt": "2026-08-05T08:50:59Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "PENDING"
-        }
-      ],
-      "headRefName": "autopilot/T-0090-ci-binary-version-tracking",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-05T08:53:29Z",
+      "headRefName": "autopilot/T-0090-ci-binary-version-tracking"
+    },
     {
       "number": 177,
       "title": "ops: run #42 のラップアップ（PR #175/#176 反映）",
@@ -428,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/118",
       "mergedAt": "2026-08-05T01:11:31Z",
       "headRefName": "autopilot/T-0043-github-actions-inventory"
-    },
-    {
-      "number": 117,
-      "title": "ops: run #16 の PR キャッシュを最新化する",
-      "url": "https://github.com/hikuohiku/homelab/pull/117",
-      "mergedAt": "2026-08-05T00:52:49Z",
-      "headRefName": "autopilot/run16-wrapup"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1264,3 +1264,20 @@
   変更していない
 - 次の起動へ: backlog の todo が本 run 終了時点で 0 件になる見込み。次回は §3 の調査タスク
   起票から入る。T-0079（node01 実ディスク容量、needs-human・priority 1）引き続き待ち
+
+## 2026-08-05 17:59 JST — run #44
+
+- 前回の中断: なし（開始時点でオープン PR・`autopilot/*` ブランチともに無かった）
+- backlog の todo が T-0090（唯一）だったため着手し、実装・検証まで完了させて PR #179 を
+  作成したところ、**別セッションが同時刻に同じ T-0090 に着手し #178 として先に merge 済み**
+  だったと判明（run #13 の #105/#106、run #33 の T-0080 と同型の衝突）。origin/main を確認し
+  #178 の実装（`ops/inventory.json` に `gha-setup-helm-version`/`kustomize-binary`、
+  `ops/check_version_sync.py` に `extract_yaml_job_block` + `extract_helm_setup_version`/
+  `extract_kustomize_download_version`）で DoD が満たされていることを確認したため、
+  #179 は issue 上で理由を説明した上で close した。ブランチ
+  `autopilot/T-0090-ci-tool-version-sync` は `git push origin --delete` が 403 で失敗する既知の
+  制約（CHARTER §5.1）により削除できず孤児のまま残る。次回この名前のブランチを見つけたら、
+  main に T-0090 相当の内容が既に入っている（#178 由来）ことを確認した上で無視してよい
+- 読んだフィードバック: issue #56 の last_read (08:23:09Z) 以降、新規コメントなし
+- 次の起動へ: backlog の todo は 0 件。この PR の merge を見届けたら CHARTER §3 に従い新しい
+  調査観点を探すこと。T-0079（node01 実ディスク容量、needs-human・priority 1）引き続き待ち

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T08:51:00Z",
+  "updated": "2026-08-05T08:59:43Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -498,6 +498,14 @@
       "prs": [
         178
       ]
+    },
+    {
+      "n": 44,
+      "at": "2026-08-05T08:50:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なしで開始。backlog の唯一の todo だった T-0090 に着手し実装・検証まで終えて PR #179 を作成したところ、別セッションが同時刻に同じ T-0090 を先に完遂・merge 済み（#178）と判明。#178 の実装で DoD 達成済みと確認し、#179 は理由を説明した上で close（重複、run #13 の #105/#106 と同型）。ブランチは git push --delete が 403 のため孤児のまま残る。issue #56 に新規フィードバックなし。ダッシュボード PR キャッシュを最新化",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

backlog の唯一の todo だった T-0090 に着手し、実装・検証まで終えて PR #179 を作成したところ、別セッションが同時刻に同じ T-0090 に着手して #178 として先に merge していたと判明した（run #13 の #105/#106、run #33〜#35 の T-0080 と同型の並行実行衝突）。#178 の実装内容で DoD（`ops/inventory.json` への2エントリ追加、`ops/check_version_sync.py` の GROUPS 拡張、意図的な desync での CI 失敗確認）が既に満たされていることを確認したため、#179 は issue 上で理由を説明した上で close した。

- `ops/journal/2026-08.md`: run #44 として今回の経緯を記録
- `ops/state.json`: `runs` に追記
- `ops/dashboard/prs.json`: PR キャッシュを最新化（#178 を merged、#179 は載せない、open は 0 件）

コード・manifest の変更は無い（`.github/workflows/ci.yml` / `ops/inventory.json` / `ops/check_version_sync.py` は既に #178 の内容のまま）。

なお、close した PR #179 のブランチ `autopilot/T-0090-ci-tool-version-sync` は `git push origin --delete` がこのサンドボックスから 403 で失敗するため削除できず、孤児のまま remote に残る（CHARTER §5.1 の既知の制約）。

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 正常終了

## ロールバック手順

`ops/` 配下の記録のみの変更。revert すれば元に戻る。データ整合性の懸念なし。

## backlog task id

なし（T-0090 は既に #178 で done。今回は記録更新のみ）

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rv89pPmmmztP1vrFPqbWFW)_