### PR TITLE
ops: T-0091 の PR 番号反映、PR キャッシュ最新化 (run #43)

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1671,7 +1671,7 @@
       ],
       "created": "2026-08-05",
       "notes": "GitHub Releases (v1.15.8, 2026-07-08) と CHANGELOG.md の 1.15.1〜1.15.8 区間を WebFetch で原文確認。breaking change 無し。terraform validate に関する変更は『backend block の検証を追加→1.15.1 で一部撤回』のみで、このリポジトリの backend (Terraform Cloud, cloud{} ブロック) には影響しない。fmt/init への影響も出力整形のみ。ci.yml を 1.15.8 に更新し、ops/inventory.json に terraform-binary エントリを新設した",
-      "pr": null
+      "pr": 180
     },
     {
       "id": "T-0092",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,20 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
+    {
+      "number": 180,
+      "title": "ci: terraform_version を 1.15.0 → 1.15.8 に更新 (T-0091)",
+      "url": "https://github.com/hikuohiku/homelab/pull/180",
+      "mergedAt": "2026-08-05T09:02:00Z",
+      "headRefName": "autopilot/T-0091-terraform-binary-version"
+    },
     {
       "number": 178,
       "title": "ci: kustomize/helm バイナリ版を version_sync の監視対象に追加 (T-0090)",
       "url": "https://github.com/hikuohiku/homelab/pull/178",
-      "isDraft": false,
-      "createdAt": "2026-08-05T08:50:59Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "PENDING"
-        }
-      ],
-      "headRefName": "autopilot/T-0090-ci-binary-version-tracking",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-05T08:56:03Z",
+      "headRefName": "autopilot/T-0090-ci-binary-version-tracking"
+    },
     {
       "number": 177,
       "title": "ops: run #42 のラップアップ（PR #175/#176 反映）",
@@ -421,20 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/119",
       "mergedAt": "2026-08-05T01:13:46Z",
       "headRefName": "autopilot/T-0045-setup-helm-v5"
-    },
-    {
-      "number": 118,
-      "title": "ops: GitHub Actions を inventory.json の監視対象に追加する (T-0043)",
-      "url": "https://github.com/hikuohiku/homelab/pull/118",
-      "mergedAt": "2026-08-05T01:11:31Z",
-      "headRefName": "autopilot/T-0043-github-actions-inventory"
-    },
-    {
-      "number": 117,
-      "title": "ops: run #16 の PR キャッシュを最新化する",
-      "url": "https://github.com/hikuohiku/homelab/pull/117",
-      "mergedAt": "2026-08-05T00:52:49Z",
-      "headRefName": "autopilot/run16-wrapup"
     }
   ]
 }


### PR DESCRIPTION
## 変更点

- `ops/backlog.json`: T-0091 の `pr` フィールド（`null` のまま残っていた）を実際の PR 番号 `180` に反映
- `ops/dashboard/prs.json`: PR キャッシュを最新化（#178, #180 を merged に反映、open は 0 件）

コード・manifest の変更は無し。`ops/` 配下の記録のみ。

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 正常終了

## ロールバック手順

`ops/` 配下の記録のみの変更。revert すれば元に戻る。データ整合性の懸念なし。

## backlog task id

なし（T-0091 の記録更新のみ、新規タスクなし）


---
_Generated by [Claude Code](https://claude.ai/code/session_01AN2rH5jcQx9bjKqMcrgUs5)_