### PR TITLE
docs: README.md の insecure 手順を実態に合わせる (T-0092)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ ProxmoxがデフォルトでHTTPSを使用しています。自己署名証明�
 - Proxmoxに有効なSSL証明書をインストール（Let's Encryptなど）
 
 **自己署名証明書を許可する場合**:
-- `providers.tf`の`insecure = false`を`insecure = true`に変更
+- `providers.tf`の`provider "proxmox"`ブロックに`insecure = true`を追加（デフォルトは`false`で、現状の`providers.tf`には明記されていない。値を変更するのではなく新規に追加する）
 
 ### 認証エラー
 

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1679,7 +1679,7 @@
       "title": "README.md のトラブルシューティングが存在しない providers.tf の insecure フィールドを参照している",
       "kind": "docs",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 40,
       "why": "run #43 の subagent 調査で発見。README.md:268 に『自己署名証明書を許可する場合: providers.tf の insecure = false を insecure = true に変更』とあるが、実際の terraform/proxmox/providers.tf の provider \"proxmox\" ブロックには endpoint / api_token / ssh {} しかなく insecure 属性自体が存在しない（false との明記も無い）。bpg/proxmox provider が insecure という provider 引数を実際にサポートしているか一次ソース（provider ドキュメント）で確認した上で、サポートしているなら『追加する』という正しい手順に、廃止/非対応なら現状の正しい対処法に書き換える",
       "dod": "bpg/proxmox provider のドキュメント（Terraform Registry または GitHub リポジトリ）で insecure 引数の現状を確認。README.md の該当箇所を実態に合わせて書き換える（値を変更ではなく追加する手順であること、または別の対処法であることを明記）",
@@ -1688,7 +1688,8 @@
         "terraform/proxmox/providers.tf"
       ],
       "created": "2026-08-05",
-      "pr": null
+      "pr": 183,
+      "notes": "run #45: bpg/proxmox provider の実ドキュメント（GitHub raw, docs/index.md）で insecure 引数がサポートされている（デフォルト false、TLS検証スキップ）ことを確認。現状の providers.tf には insecure が明記されていないため、README の手順を『値を変更』ではなく『provider \"proxmox\" ブロックに insecure = true を新規追加』に書き換えた"
     },
     {
       "id": "T-0093",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1284,3 +1284,32 @@
 - 次の起動へ: backlog の todo は T-0092（priority 40, README.md の insecure 記述）と T-0093
   （priority 40, CLAUDE.md の定期実行間隔記述）の2件。どちらも docs のみで低リスク。
   T-0079（node01 実ディスク容量、needs-human・priority 1）引き続き待ち
+
+## 2026-08-05 18:50 JST — run #44
+
+- backlog の todo（T-0090、唯一）に着手し実装・検証まで終えて PR #179 を作成したところ、
+  別セッションが同時刻に同じ T-0090 を先に完遂・merge 済み（#178）と判明した（run #13 の
+  #105/#106、run #33 の T-0080 と同型の並行実行衝突）。#178 の実装で DoD 達成済みと確認し、
+  #179 は issue 上で理由を説明した上で close した（重複）
+- 読んだフィードバック: issue #56 last_read (08:23:09Z) 以降、新規コメントなし
+- ブランチ `autopilot/T-0090-ci-tool-version-sync`（旧 #179）は `git push origin --delete` が
+  403 で失敗する既知の制約（CHARTER §5.1）により削除できず孤児のまま残る。次回このブランチ名を
+  見つけたら main に T-0090 相当の内容が既に入っている（#178 由来）ことを確認した上で無視してよい
+- 次の起動へ: backlog の todo は 0 件。この run の記録用 PR (#181) は main が #180/#182 の merge
+  で先行したため DIRTY になり、run #45 が close して本記録を復元した（下記参照）
+
+## 2026-08-05 19:01 JST — run #45
+
+- 前回の中断: PR #181（run #44 が記録更新のみで開いていた PR）を発見。`mergeable_state: dirty`
+  （main が #180/#182 の merge で base より先行していたため）。実質的な変更（`prs.json` の PR178
+  反映等）は main に既に #182 経由で反映済みと確認できたが、journal の run #44 エントリ（上記の
+  T-0090 重複 PR 衝突の記録）だけは main 側に無かったため、#181 を close し本 PR で該当エントリを
+  復元した。ブランチ `autopilot/run43-record` は削除できず孤児のまま残る（CHARTER §5.1）
+- 読んだフィードバック: issue #56 last_read (08:23:09Z) 以降、新規コメント0件（64件全件を機械的に
+  確認）
+- やったこと: T-0092（README.md の insecure 記述 drift）を完遂。bpg/proxmox provider の実ドキュメント
+  （GitHub raw, docs/index.md）で `insecure` 引数がサポートされている（デフォルト `false`、TLS検証
+  スキップ）ことを確認。現状の `providers.tf` には `insecure` が明記されていないため、README の
+  手順を『既存の値を変更』ではなく『provider ブロックに `insecure = true` を新規追加』に書き換えた
+- 次の起動へ: backlog の todo は T-0093（priority 40, CLAUDE.md の定期実行間隔記述）の1件。
+  T-0079（node01 実ディスク容量、needs-human・priority 1）引き続き待ち

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T08:51:00Z",
+  "updated": "2026-08-05T09:10:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -497,6 +497,24 @@
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし（last_read 以降新規コメント0件、全64件を機械的に確認）。backlog の唯一の todo だった T-0090（ci.yml の manifests job / manifest-diff job に独立に書かれている azure/setup-helm の version 入力と kustomize バイナリ版が監視対象外）を完遂。ops/inventory.json に2エントリを追加し、ops/check_version_sync.py に extract_yaml_job_block（jobs: 配下の2-indent境界でブロックを絞る）とそれを使う2つの抽出関数、GROUPS に2グループを追加。DoD の『意図的に値をずらして CI が exit 1 になることを確認する』は手元で ci.yml を一時的に書き換えて両パターンとも検出できることを確認し、diff が空であることを確認して復元した（#178）。続けて subagent に新しい調査観点探しを投げ3件発見: T-0091（ci.yml の terraform_version が 1.15.0 のまま最新 1.15.8 より8パッチ遅れ、CHANGELOG 全文確認のうえ即完遂）、T-0092（README.md が存在しない providers.tf の insecure フィールドを参照、todo）、T-0093（CLAUDE.md の定期実行間隔『3時間ごと』が ops/state.json の実際の毎時と食い違う、todo）",
       "prs": [
         178
+      ]
+    },
+    {
+      "n": 44,
+      "at": "2026-08-05T08:50:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なしで開始。backlog の唯一の todo だった T-0090 に着手し実装・検証まで終えて PR #179 を作成したところ、別セッションが同時刻に同じ T-0090 を先に完遂・merge 済み（#178）と判明。#178 の実装で DoD 達成済みと確認し、#179 は理由を説明した上で close（重複、run #13 の #105/#106 と同型）。ブランチは git push --delete が 403 のため孤児のまま残る。issue #56 に新規フィードバックなし。この run の記録用 PR (#181) は main が #180/#182 の merge で先行したため DIRTY になり merge できず、run #45 が close して記録を復元した",
+      "prs": []
+    },
+    {
+      "n": 45,
+      "at": "2026-08-05T09:01:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "前回の中断: PR #181（run #44 の記録用 PR）が main の #180/#182 先行merge により DIRTY だったため close し、失われていなかった実質的な変更（prs.json の PR178 反映）は main に既に反映済みと確認、journal の run #44 エントリのみ本 run で復元した。issue #56 に未読フィードバックなし。T-0092（README.md の insecure 記述 drift）を完遂: bpg/proxmox provider の実ドキュメント（GitHub raw, docs/index.md）で insecure 引数がサポートされている（デフォルト false）ことを確認し、README の手順を『既存の値を変更』ではなく『provider ブロックに insecure = true を新規追加』に書き換えた",
+      "prs": [
+        183
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

- `README.md`: 「自己署名証明書を許可する場合」の手順が、実際には存在しない `providers.tf` の `insecure = false` を変更する体裁になっていた。`terraform/proxmox/providers.tf` の `provider "proxmox"` ブロックには `insecure` が明記されておらず、bpg/proxmox provider のドキュメント（デフォルト `false`）を確認した上で「既存の値を変更」ではなく「`insecure = true` を新規追加」する手順に書き換えた
- `ops/backlog.json`: T-0092 を `done` に
- `ops/journal/2026-08.md`, `ops/state.json`: run #44（T-0090 の重複 PR #179/#178 の衝突記録）・run #45（本PR）を記録。run #44 の記録用 PR #181 は main の #180/#182 先行 merge で DIRTY になり close したため、失われていた journal 記録のみ本 PR で復元した

## 検証したこと

- bpg/proxmox provider の実ドキュメント（`raw.githubusercontent.com/bpg/terraform-provider-proxmox/main/docs/index.md`）で `insecure` 引数のサポート・デフォルト値を確認
- `python3 ops/validate.py` → 0 error（既存の warning 6件は本PRと無関係）
- `python3 ops/dashboard/build.py` → 正常終了

## ロールバック手順

ドキュメントのみの変更。revert すれば元に戻る。データ・スキーマへの影響なし。

## backlog task id

T-0092

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1phhAWxPuRzShTY55R9wb)_