### PR TITLE
README.md の insecure 手順を修正、run #44 の journal 記録を復元 (T-0092)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ ProxmoxがデフォルトでHTTPSを使用しています。自己署名証明�
 - Proxmoxに有効なSSL証明書をインストール（Let's Encryptなど）
 
 **自己署名証明書を許可する場合**:
-- `providers.tf`の`insecure = false`を`insecure = true`に変更
+- `providers.tf`の`provider "proxmox"`ブロックに`insecure = true`を追加（`insecure`は省略時`false`扱いのオプション引数で、既定では存在しない。`PROXMOX_VE_INSECURE`環境変数でも指定可能）
 
 ### 認証エラー
 

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 94,
-  "updated": "2026-08-05T08:55:00Z",
+  "updated": "2026-08-05T09:24:25Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -1679,7 +1679,7 @@
       "title": "README.md のトラブルシューティングが存在しない providers.tf の insecure フィールドを参照している",
       "kind": "docs",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 40,
       "why": "run #43 の subagent 調査で発見。README.md:268 に『自己署名証明書を許可する場合: providers.tf の insecure = false を insecure = true に変更』とあるが、実際の terraform/proxmox/providers.tf の provider \"proxmox\" ブロックには endpoint / api_token / ssh {} しかなく insecure 属性自体が存在しない（false との明記も無い）。bpg/proxmox provider が insecure という provider 引数を実際にサポートしているか一次ソース（provider ドキュメント）で確認した上で、サポートしているなら『追加する』という正しい手順に、廃止/非対応なら現状の正しい対処法に書き換える",
       "dod": "bpg/proxmox provider のドキュメント（Terraform Registry または GitHub リポジトリ）で insecure 引数の現状を確認。README.md の該当箇所を実態に合わせて書き換える（値を変更ではなく追加する手順であること、または別の対処法であることを明記）",
@@ -1688,7 +1688,8 @@
         "terraform/proxmox/providers.tf"
       ],
       "created": "2026-08-05",
-      "pr": null
+      "pr": null,
+      "notes": "run #44: bpg/proxmox provider の一次ソース（docs/index.md）で insecure が省略可能な bool 引数（省略時 false）と確認。README.md の該当手順を「insecure=false→true に変更」ではなく「provider ブロックに insecure=true を追加」に書き換えた（PROXMOX_VE_INSECURE 環境変数でも指定可能な旨も追記）"
     },
     {
       "id": "T-0093",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1284,3 +1284,28 @@
 - 次の起動へ: backlog の todo は T-0092（priority 40, README.md の insecure 記述）と T-0093
   （priority 40, CLAUDE.md の定期実行間隔記述）の2件。どちらも docs のみで低リスク。
   T-0079（node01 実ディスク容量、needs-human・priority 1）引き続き待ち
+
+## 2026-08-05 17:59 JST — run #44
+
+- 前回の中断: なし（開始時点でオープン PR・`autopilot/*` ブランチともに無かった）
+- backlog の todo が T-0090（唯一）だったため着手し、実装・検証まで完了させて PR #179 を
+  作成したところ、**別セッションが同時刻に同じ T-0090 に着手し #178 として先に merge 済み**
+  だったと判明（run #13 の #105/#106、run #33〜#35 の T-0080 と同型の衝突）。origin/main を確認し
+  #178 の実装で DoD が満たされていることを確認したため、#179 は issue 上で理由を説明した上で
+  close した。記録用の PR #181 を作ったが、着手中に別セッションが T-0091（terraform_version
+  drift）を完遂・merge していて base 乖離（DIRTY）が発生し、その別セッションが #181 を
+  close・埋め合わせを引き受けてくれた（コメント参照）が、journal の run #44 本文自体は
+  main に反映されないまま残っていたため、この起動でここに復元する
+- ブランチ `autopilot/T-0090-ci-tool-version-sync` / `autopilot/run43-record` は
+  `git push origin --delete` が 403 で失敗する既知の制約（CHARTER §5.1）により削除できず
+  孤児のまま残る
+- 読んだフィードバック: issue #56 の last_read (08:23:09Z) 以降、新規コメントなし
+- 続けて backlog の todo（T-0092, T-0093）から T-0092 に着手・完遂。README.md
+  トラブルシューティングの「`providers.tf`の`insecure = false`を`insecure = true`に変更」という
+  手順が誤り（`terraform/proxmox/providers.tf` の `provider "proxmox"` ブロックに `insecure`
+  引数自体が存在せず、`insecure = false` という記述はどこにも無い）と確認。bpg/proxmox provider
+  の一次ソース（GitHub raw の docs/index.md）で `insecure` が省略可能な bool 引数で省略時
+  `false` 相当と確認し、README を「追加する」手順に書き換えた（`PROXMOX_VE_INSECURE` 環境変数
+  でも指定可能な旨も追記）
+- 次の起動へ: backlog の todo は T-0093（CLAUDE.md の定期実行間隔記述が実態とずれている件）。
+  T-0079（node01 実ディスク容量、needs-human・priority 1）引き続き待ち


### PR DESCRIPTION
## 変更点

`README.md` のトラブルシューティング「自己署名証明書を許可する場合」の手順が、実際には存在しない記述を前提にしていた。

- `terraform/proxmox/providers.tf` の `provider "proxmox"` ブロックには `endpoint` / `api_token` / `ssh {}` しかなく、`insecure` 引数自体が書かれていない（`insecure = false` という記述はどこにも無い）
- bpg/proxmox provider の一次ソース（GitHub raw の `docs/index.md`）を確認したところ、`insecure` は省略可能な bool 引数で、省略時は `false` 相当（TLS 検証を行う）
- そのため「`insecure = false` を `insecure = true` に変更」ではなく「`insecure = true` を追加する」が正しい手順。`PROXMOX_VE_INSECURE` 環境変数でも指定可能な旨も追記した

あわせて、直前に出した記録専用 PR (#181) が、着手中に別セッションが T-0091 を merge したことによる base 乖離（DIRTY）で close されてしまい、そこに書いていた journal の run #44 本文（T-0090 の重複 PR #179/#178 の衝突記録）が main に反映されないまま失われていた。この PR でその内容を journal に復元する（#181 のクローズ経緯は同 PR のコメント参照）。

- `README.md`: 上記の手順修正
- `ops/backlog.json`: T-0092 を完遂として記録
- `ops/journal/2026-08.md`: run #44（#179/#178 の衝突記録の復元 + T-0092 完遂）を追記

## 検証したこと

- bpg/proxmox provider の `docs/index.md`（raw.githubusercontent.com 経由）で `insecure` 引数の存在・型・デフォルト値を一次ソースで確認
- `terraform/proxmox/providers.tf` の実際の `provider "proxmox"` ブロックと突き合わせ、`insecure` が存在しないことを確認
- `python3 ops/validate.py` → 0 error
- docs のみの変更で manifest・CI 設定への影響なし

## ロールバック手順

このコミットを revert すれば元の記述に戻る。docs のみの変更で、DB・スキーマ・実インフラへの影響は無い。

## backlog task id

T-0092

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rv89pPmmmztP1vrFPqbWFW)_