### PR TITLE
ops: run #47 の記録更新（PR番号反映・journal・state・PRキャッシュ）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1724,7 +1724,7 @@
         "apps/kustomization.yaml"
       ],
       "created": "2026-08-05",
-      "pr": null,
+      "pr": 187,
       "notes": "run #47: apps/kustomization.yaml と突き合わせて9子app+root=10件に更新。合わせて一覧の由来（kustomization.yaml参照）を一行添えた。docs のみで挙動影響なし"
     },
     {

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,20 @@
   "open": [],
   "merged": [
     {
+      "number": 187,
+      "title": "docs: apps/README.md の ArgoCD Application 出力例を実態に合わせる (T-0094)",
+      "url": "https://github.com/hikuohiku/homelab/pull/187",
+      "mergedAt": "2026-08-05T10:33:00Z",
+      "headRefName": "autopilot/T-0094-apps-readme-app-list"
+    },
+    {
+      "number": 186,
+      "title": "docs: CLAUDE.md の autopilot 定期実行間隔記述を実態に合わせる (T-0093)",
+      "url": "https://github.com/hikuohiku/homelab/pull/186",
+      "mergedAt": "2026-08-05T09:29:57Z",
+      "headRefName": "autopilot/T-0093-claude-md-schedule-interval"
+    },
+    {
       "number": 183,
       "title": "docs: README.md の insecure 手順を実態に合わせる (T-0092)",
       "url": "https://github.com/hikuohiku/homelab/pull/183",
@@ -9,17 +23,24 @@
       "headRefName": "autopilot/T-0092-readme-insecure-fix"
     },
     {
+      "number": 182,
+      "title": "ops: T-0091 の PR 番号反映、PR キャッシュ最新化 (run #43)",
+      "url": "https://github.com/hikuohiku/homelab/pull/182",
+      "mergedAt": "2026-08-05T09:04:43Z",
+      "headRefName": "autopilot/run43-pr-numbers"
+    },
+    {
       "number": 180,
       "title": "ci: terraform_version を 1.15.0 → 1.15.8 に更新 (T-0091)",
       "url": "https://github.com/hikuohiku/homelab/pull/180",
-      "mergedAt": "2026-08-05T09:02:00Z",
+      "mergedAt": "2026-08-05T09:01:37Z",
       "headRefName": "autopilot/T-0091-terraform-binary-version"
     },
     {
       "number": 178,
       "title": "ci: kustomize/helm バイナリ版を version_sync の監視対象に追加 (T-0090)",
       "url": "https://github.com/hikuohiku/homelab/pull/178",
-      "mergedAt": "2026-08-05T08:56:03Z",
+      "mergedAt": "2026-08-05T08:53:29Z",
       "headRefName": "autopilot/T-0090-ci-binary-version-tracking"
     },
     {
@@ -399,34 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/123",
       "mergedAt": "2026-08-05T01:22:18Z",
       "headRefName": "autopilot/run17-wrapup"
-    },
-    {
-      "number": 122,
-      "title": "ci: softprops/action-gh-release を v2 → v3 に上げる (T-0048)",
-      "url": "https://github.com/hikuohiku/homelab/pull/122",
-      "mergedAt": "2026-08-05T01:18:03Z",
-      "headRefName": "autopilot/T-0048-gh-release-v3"
-    },
-    {
-      "number": 121,
-      "title": "ci: cachix/cachix-action を v15 → v17 に上げる (T-0047)",
-      "url": "https://github.com/hikuohiku/homelab/pull/121",
-      "mergedAt": "2026-08-05T01:16:31Z",
-      "headRefName": "autopilot/T-0047-cachix-action-v17"
-    },
-    {
-      "number": 120,
-      "title": "ci: hashicorp/setup-terraform を v3 → v4 に上げる (T-0046)",
-      "url": "https://github.com/hikuohiku/homelab/pull/120",
-      "mergedAt": "2026-08-05T01:15:07Z",
-      "headRefName": "autopilot/T-0046-setup-terraform-v4"
-    },
-    {
-      "number": 119,
-      "title": "ci: azure/setup-helm を v4 → v5 に上げる (T-0045)",
-      "url": "https://github.com/hikuohiku/homelab/pull/119",
-      "mergedAt": "2026-08-05T01:13:46Z",
-      "headRefName": "autopilot/T-0045-setup-helm-v5"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1335,3 +1335,30 @@
   のため、次回の起動で main に相当する内容が入っていないか確認してから無視する判断を引き継ぐ
 - 次の起動へ: backlog の todo は 0 件。T-0079（node01 実ディスク容量、needs-human・priority 1）
   引き続き待ち。`autopilot/T-0088-tailscale-1.102.2` ブランチの確認も残っている
+
+## 2026-08-05 19:27 JST — run #47
+
+- 前回の中断: なし。オープン PR も無かった
+- 引き継ぎの確認: run #46 が残した孤児ブランチ `autopilot/T-0088-tailscale-1.102.2` を確認した。
+  main との diff はゼロ（`ops/backlog.json` に T-0088 という調査中タスクを1件足すだけのコミット
+  だったが、その ID は後の run #42 で別タスク「tf-provider-proxmox drift 修正」（#175, done）に
+  再利用され、このブランチの調査自体は run #41 の結論「k8s-nameserver/operator の配布物は
+  v1.98.9 より新しいタグが存在しない」で既に無効化されている）。回収すべき内容は無いと確認、
+  削除不能（403）なので孤児のまま無視してよい
+- 読んだフィードバック: issue #56 last_read (08:23:09Z) 以降、新規コメント0件（全64件を機械的に
+  確認）
+- ops-health-report (`generated_at: 2026-08-05T10:00:04Z`) で ArgoCD 全10アプリ Synced/Healthy、
+  pod_issues も既知の restart カウントのみ。pvc_usage は immich-library 348MB・
+  immich-postgres-data 317MB・vaultwarden-data 4.8MB・coder-postgres-data 76MB と実使用量は
+  いずれも小さく、T-0079（node01 実ディスク48.9GiB問題）は容量逼迫の実害はまだ出ていないが、
+  PVC の *requested* 合計（215Gi、immich-library単体50Gi）との差はそのまま。人間の報告待ち変わらず
+- backlog の todo が0件だったため subagent に新しい調査観点探しを投げ3件発見: T-0094
+  （apps/README.md の ArgoCD Application 出力例が実際の10件中4件しか無い）、T-0095（同ファイルの
+  「事前設定」節が sops-nix 導入前の旧ブートストラップ手順を案内しており、`K3S_TOKEN` 等も
+  `just inject-secrets` もリポジトリのどこからも参照されていないと repo 全体の grep で確認済み。
+  実行すると失敗するコマンドを案内している状態）、T-0096（ドキュメントの `just <recipe>` 参照を
+  CI で検証する仕組みが無いという提案、T-0095 と同型の drift を機械的に検出できるようにする案）
+- やったこと: T-0094 を完遂（#187）。apps/kustomization.yaml の実際の子 Application 一覧
+  （9件）+ root で計10件に出力例を更新。T-0095/T-0096 は backlog に起票のみで次回以降
+- 次の起動へ: backlog の todo は T-0095（priority 41）・T-0096（priority 45）の2件。
+  T-0079（node01 実ディスク容量、needs-human・priority 1）引き続き待ち

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T09:30:00Z",
+  "updated": "2026-08-05T10:30:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -525,6 +525,16 @@
       "summary": "前回の中断: #183 merge 直後、同時刻に走っていた別セッションが同じ T-0092 を独立に完遂した PR #184 が main の先行 merge で DIRTY になっていたため、内容重複と確認して close した（ブランチは削除できず孤児のまま残る）。issue #56 に未読フィードバックなし。ops-health-report (09:00:04Z) で ArgoCD 全10アプリ Synced/Healthy、新規異常なし。T-0093（CLAUDE.md の定期実行間隔記述）を完遂: 固定値を書かず ops/state.json の routines を単一の情報源として指す記述に書き換えた。backlog の todo は 0 件",
       "prs": [
         185
+      ]
+    },
+    {
+      "n": 47,
+      "at": "2026-08-05T10:27:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし（run #46 が残した孤児ブランチ autopilot/T-0088-tailscale-1.102.2 は main との diff ゼロと確認、回収不要）。issue #56 に未読フィードバックなし。ops-health-report で ArgoCD 全10アプリ Synced/Healthy、pvc_usage の実使用量はいずれも小さく（immich-library 348MB 等）T-0079 の逼迫はまだ実害化していない。backlog の todo が0件だったため subagent に調査を投げ3件発見: T-0094（apps/README.md の ArgoCD Application 出力例が10件中4件のみ、完遂・#187）、T-0095（同ファイルの旧ブートストラップ手順が実行すると失敗する状態のまま案内されている、todo）、T-0096（ドキュメントの `just <recipe>` 参照を CI で検証する仕組みが無い、todo）",
+      "prs": [
+        187
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

- `ops/backlog.json`: T-0094 の pr フィールドを 187（merged 済み）に反映
- `ops/journal/2026-08.md`: run #47 の記録を追記
- `ops/state.json`: `runs` に run #47 を追加
- `ops/dashboard/prs.json`: PR キャッシュを最新化（#187 を merged に反映）

運用記録のみ（CHARTER §4 の相乗り例外に該当する内容だが、対象の T-0094 PR (#187) が既に merge 済みのため別 PR で即マージする）。

## 検証したこと

- `python3 ops/validate.py` → 0 error（既存 warning 7件は本 PR と無関係の既知事項）
- `python3 ops/dashboard/build.py` → 例外なく完了

## ロールバック手順

記録のみの変更のため revert すれば元に戻る。インフラ状態への影響なし。

## backlog task id

なし（運用記録のみ）

---
_Generated by [Claude Code](https://claude.ai/code/session_018govyX4UhtzKereFhANSCE)_