### PR TITLE
docs: apps/README.md の使われていない旧ブートストラップ手順を削除する (T-0095)

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -100,30 +100,6 @@ echo
 
 ## 事前設定 (初回のみ)
 
-### K3s シークレットの事前生成
-
-事前に K3s の CA と Token を生成し、Doppler に保存します:
-
-```bash
-# 一時ディレクトリで作業
-mkdir -p /tmp/k3s-scrt && cd /tmp/k3s-scrt
-
-# CA 生成
-openssl genrsa -out server-ca.key 2048
-openssl req -x509 -new -nodes -key server-ca.key -sha256 -days 3650 -out server-ca.crt -subj "/CN=k3s"
-
-# Token 生成
-K3S_TOKEN=$(openssl rand -hex 32)
-
-# Doppler に保存
-doppler secrets set K3S_TOKEN="$K3S_TOKEN" \
-  K3S_CA_CERT="$(cat server-ca.crt)" \
-  K3S_CA_KEY="$(cat server-ca.key)"
-
-# クリーンアップ
-cd - && rm -rf /tmp/k3s-scrt
-```
-
 ### Doppler プロジェクト設定
 
 1. [Doppler](https://doppler.com) でアカウント作成
@@ -132,12 +108,6 @@ cd - && rm -rf /tmp/k3s-scrt
    - `TAILSCALE_CLIENT_ID`
    - `TAILSCALE_CLIENT_SECRET`
 4. Service Token を生成 (Access → Generate Service Token)
-
-### VM 再構築後
-
-```bash
-just inject-secrets
-```
 
 ---
 

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1743,7 +1743,9 @@
         "nix/images/proxmox-cloud/configuration.nix"
       ],
       "created": "2026-08-05",
-      "pr": null
+      "status": "done",
+      "pr": null,
+      "notes": "run #47: 再度 grep で確認（K3S_TOKEN/K3S_CA_CERT/K3S_CA_KEY/inject-secrets ともリポジトリ内でこのファイル以外に参照なし）。DoD どおり『K3s シークレットの事前生成』節と『VM 再構築後』節（`just inject-secrets`）を削除。`Doppler プロジェクト設定`（TAILSCALE_CLIENT_ID/SECRET）は apps/external-secrets/tailscale-oauth-external-secret.yaml が実際に参照しており有効なため残置"
     },
     {
       "id": "T-0096",


### PR DESCRIPTION
## 変更点

`apps/README.md` の「事前設定 (初回のみ)」節にあった以下2つのサブセクションを削除した:

- 「K3s シークレットの事前生成」: openssl で CA/Token を作り `doppler secrets set K3S_TOKEN=... K3S_CA_CERT=... K3S_CA_KEY=...` を実行する手順
- 「VM 再構築後」: `just inject-secrets` を実行する手順

リポジトリ全体を grep しても `K3S_TOKEN`/`K3S_CA_CERT`/`K3S_CA_KEY` を参照する箇所はこのファイル以外に無く、`justfile` にも `inject-secrets` という recipe は存在しない。実際のクラスタブートストラップは同ファイル前半に書かれている sops-nix → `doppler-token` Secret → ArgoCD/ESO の経路のみで完結しており、この2節は sops-nix 導入前の古い手順の残骸と見られる。VM 再構築時にこれを真に受けると、何も消費されない Doppler 変数を設定する無駄な作業と、実行すると `unknown recipe` で失敗するコマンドに時間を溶かす。

同じ節にあった「Doppler プロジェクト設定」(`TAILSCALE_CLIENT_ID`/`TAILSCALE_CLIENT_SECRET`) は `apps/external-secrets/tailscale-oauth-external-secret.yaml` が実際に参照しており有効なため残置した。

## 検証したこと

- `grep -rln "K3S_TOKEN\|K3S_CA_CERT\|K3S_CA_KEY\|inject-secrets"` をリポジトリ全体（`.nix`/`.tf`/`justfile`/`.yaml`/`.yml`/`.md`）に実行し、`apps/README.md` 以外に参照が無いことを確認（journal の過去記録のみヒット、これは削除対象外）
- `justfile` の recipe 一覧に `inject-secrets` が存在しないことを確認
- `python3 ops/validate.py` → 0 error（既存 warning 7件は本 PR と無関係の既知事項）

## ロールバック手順

このコミットを revert すれば削除前の記述に戻る。ドキュメントのみの変更で、DB・スキーマ・インフラの状態は一切変わらないため、revert に伴う不整合は無い。

## backlog task id

T-0095（`ops/backlog.json` に同梱、pr 番号はこの PR 作成後に追記）

---
_Generated by [Claude Code](https://claude.ai/code/session_018govyX4UhtzKereFhANSCE)_