### PR TITLE
CHARTER: blocked/needs-humanをタスク全体でなく部分で見る (T-0095)

### DIFF
--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -84,6 +84,19 @@ PVC 実使用量・コンテナ/ノードの実メモリ・CPU 使用量は `pvc
 
 `ops/backlog.json` から `status: "todo"` を `priority` 昇順で取る。同順位ならリスクが低い方から。
 
+**`blocked`/`needs-human` は「タスク全体」ではなく「タスクのどの部分か」で見る**（issue #56,
+2026-08-05 10:29:40 の指摘）。credential 待ちで丸ごと止めたタスクでも、詰まっているのは大抵
+「最後の一歩」（実行・認証・実機確認）だけで、manifest の設計・記述は credential が届く前から
+進められる。「credential が無いから何もできない」と丸ごと止めない。
+
+- manifest（CronJob・ExternalSecret 等）は先に書く。ExternalSecret が参照する Doppler のキー名は
+  実装時にこちらで決め、`needs_human_reason` に「このキー名でこの値を登録してほしい」と具体的に書く
+  （T-0030/T-0049 で「調査は自分、実行は人間」の分割が機能した実例と同型）
+- CI（`kustomize build` / `manifest-diff`）で manifest の妥当性は検証できる。値が届く前でも
+  構造が壊れていないことは確認できる
+- 実行・確認だけを `needs-human`/`blocked` の対象として残し、設計・記述が終わった分は `done`/`todo`
+  に進めて引き継ぎを明確にする
+
 backlog が空、または全部 `blocked` のときは**調査タスクを自分で起票する**。空回りするのではなく、次にやるべきことを探すのが仕事。探し方の例:
 
 - `ops/inventory.json` の監視対象に上流の新しいリリースが出ていないか

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1247,11 +1247,11 @@
       "title": "immich 用 backup CronJob（日次内蔵DBダンプ + restic でライブラリごと）を追加する",
       "kind": "feature",
       "risk": "medium",
-      "status": "blocked",
+      "status": "todo",
       "priority": 40,
       "why": "issue #56 (2026-08-05 04:40:59) の人間の新方針・構築セッションの調査。immich は内蔵の日次 DB ダンプが UPLOAD_LOCATION/backups に 14 世代落ちる仕様のため、これが有効なら library PVC を restic で 1 本取るだけでライブラリと DB dump が同時に取れる（要確認）。稼働中に取る場合は DB dump が先、ファイルが後の順（DB に無い余分なファイルが残るだけで済む）",
-      "dod": "immich の内蔵日次 DB ダンプが有効か確認したうえで、CronJob が restic でライブラリ PVC（DB dump を含む）を snapshot し、T-0067 の保存先へ push する。retention（`restic forget --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --prune` 相当）を週次で走らせる仕組みも同じ PR に含める。credential は Doppler → External Secrets 経由",
-      "blocked_by": "T-0067（restic 保存先・credential）",
+      "dod": "immich の内蔵日次 DB ダンプが有効か確認したうえで、CronJob が restic でライブラリ PVC（DB dump を含む）を snapshot し、T-0067 の保存先へ push する。retention（`restic forget --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --prune` 相当）を週次で走らせる仕組みも同じ PR に含める。credential は Doppler → External Secrets 経由（キー名は T-0069 で決めた命名規則に揃える）",
+      "notes": "run #48: issue #56 (10:29:40) の指摘を受け blocked → todo に変更。manifest（CronJob・ExternalSecret）の設計・記述は T-0067（credential 発行）を待たずに進められる。実際に暗号化 push が成功するかの確認だけが T-0067 待ち",
       "refs": [
         "apps/immich/",
         "docs/backup.md"
@@ -1265,11 +1265,11 @@
       "title": "vaultwarden 用 backup CronJob（sqlite .backup + restic）を追加する",
       "kind": "feature",
       "risk": "medium",
-      "status": "blocked",
+      "status": "in_progress",
       "priority": 40,
       "why": "issue #56 (2026-08-05 04:40:59) の人間の新方針・構築セッションの調査。`/data` を丸ごと restic するのは NG（`-wal`/`-shm` と本体の不整合）。`sqlite3 .backup` か vaultwarden 内蔵の `/vaultwarden backup`（1.32.1+、このリポジトリは 1.37.1 で対象）を使い、その出力を restic で保存する",
-      "dod": "CronJob が vaultwarden 内蔵の backup 機能（またはsqlite3 .backup）でリストア可能な単一ファイルを作り、restic で T-0067 の保存先へ push する。復元時は既存の db.sqlite3-wal を先に消す必要がある旨を手順として docs/backup.md に残す。retention は T-0068 と同じ方針",
-      "blocked_by": "T-0067（restic 保存先・credential）",
+      "dod": "CronJob が vaultwarden 内蔵の backup 機能（またはsqlite3 .backup）でリストア可能な単一ファイルを作り、restic で T-0067 の保存先へ push する。復元時は既存の db.sqlite3-wal を先に消す必要がある旨を手順として docs/backup.md に残す。retention は T-0068 と同じ方針。credential (RESTIC_PASSWORD/RESTIC_REPOSITORY/B2 キー) は Doppler のキー名をこのタスクで決め、T-0067 の登録依頼に反映する",
+      "notes": "run #48: issue #56 (10:29:40) の指摘を受け blocked → in_progress に変更し着手。restic の暗号化 push 自体は T-0067（credential）待ちだが、CronJob/ExternalSecret の manifest は先に書く",
       "refs": [
         "apps/vaultwarden/",
         "docs/backup.md"
@@ -1283,11 +1283,11 @@
       "title": "coder-postgres 用 backup CronJob（pg_dump + restic）を追加する",
       "kind": "feature",
       "risk": "medium",
-      "status": "blocked",
+      "status": "todo",
       "priority": 40,
       "why": "issue #56 (2026-08-05 04:40:59) の人間の新方針・構築セッションの調査。PostgreSQL は restic で PGDATA を直接舐めてはいけない（サーバを止めない限り一貫したスナップショットにならないと PostgreSQL 公式が明記）。`pg_dump` を使う。immich-postgres（cloudnative-vectorchord）は対象外（拡張本体を含めた扱いが別途要るため T-0029 側で検討）、まず coder-postgres（素の postgres）から着手する",
-      "dod": "CronJob が `pg_dump` の出力を restic で T-0067 の保存先へ push する。retention は T-0068 と同じ方針。credential は既存の coder-postgres Secret を流用する",
-      "blocked_by": "T-0067（restic 保存先・credential）",
+      "dod": "CronJob が `pg_dump` の出力を restic で T-0067 の保存先へ push する。retention は T-0068 と同じ方針。credential は既存の coder-postgres Secret を流用し、restic 側のキー名は T-0069 に揃える",
+      "notes": "run #48: issue #56 (10:29:40) の指摘を受け blocked → todo に変更。manifest の設計・記述は T-0067（credential 発行）を待たずに進められる",
       "refs": [
         "apps/coder/postgres.yaml",
         "docs/backup.md"


### PR DESCRIPTION
## 変更点

- `ops/CHARTER.md` §3: issue #56 (2026-08-05 10:29:40) の指摘を反映。credential 待ちで
  `blocked`/`needs-human` にしたタスクでも、詰まっているのは大抵「最後の一歩」（実行・認証・実機確認）
  だけで、manifest の設計・記述は credential が届く前から進められるという原則を明文化した。
- `ops/backlog.json`: T-0068（immich backup CronJob）・T-0070（coder-postgres backup CronJob）を
  `blocked` → `todo` に変更（manifest 設計は今から進められるため）。T-0069（vaultwarden backup
  CronJob）を `in_progress` に変更し、この起動で着手する。

## 検証したこと

- `python3 ops/validate.py` → 0 error（既存 warning 7件は本 PR と無関係の既知事項）

## ロールバック手順

記録・方針文書のみの変更。revert すれば元に戻る。インフラ状態への影響なし。

## backlog task id

T-0095（本 PR で完遂、記録用のため新規タスクとしては起票せず）

---
_Generated by [Claude Code](https://claude.ai/code/session_01922FLpCxKNWyQ7SoL5yGm2)_