### PR TITLE
feat: vaultwarden用restic backup CronJobを追加 (T-0069)

### DIFF
--- a/apps/vaultwarden/kustomization.yaml
+++ b/apps/vaultwarden/kustomization.yaml
@@ -9,3 +9,5 @@ resources:
   - service.yaml
   - ingress.yaml
   - pvc-usage-cronjob.yaml
+  - restic-external-secret.yaml
+  - restic-backup-cronjob.yaml

--- a/apps/vaultwarden/restic-backup-cronjob.yaml
+++ b/apps/vaultwarden/restic-backup-cronjob.yaml
@@ -1,0 +1,190 @@
+# vaultwarden データ (SQLite DB + attachments + rsa鍵 + config.json) を restic で
+# Backblaze B2 へバックアップする (T-0069)。
+#
+# DB は稼働中の Pod に write されうるため、`/data` の PVC をそのまま restic に渡すと
+# db.sqlite3-wal/-shm と本体の不整合を持ち込む (vaultwarden 公式 wiki が明記)。
+# そのため initContainer で SQLite の Online Backup API (`sqlite3 .backup`, VACUUM INTO と
+# 同じ仕組みで稼働中でも一貫性のあるコピーが取れる) を使い、db.sqlite3 だけ emptyDir へ
+# 一貫コピーしてから、本体の restic-backup コンテナが「PVC (db.sqlite3系とicon_cacheを除く) +
+# 一貫コピー済みdb.sqlite3」の2パスをまとめて1スナップショットにする。
+# 参考: https://github.com/dani-garcia/vaultwarden/wiki/Backing-up-your-vault
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: vaultwarden-restic-backup
+  namespace: vaultwarden
+spec:
+  schedule: "40 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 1800
+      template:
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          initContainers:
+            - name: sqlite-snapshot
+              image: alpine:3.22.5
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  apk add --no-cache sqlite >/dev/null
+                  sqlite3 -readonly "$SRC_DB" ".backup '$DST_DB'"
+              env:
+                - name: SRC_DB
+                  value: /mnt/vaultwarden-data/db.sqlite3
+                - name: DST_DB
+                  value: /staging/db.sqlite3
+              # PVC は vaultwarden コンテナの fsGroup/runAsUser (1000) で書かれており、
+              # このジョブは所有権に関わらず正しく読む必要があるため pvc-usage-cronjob.yaml
+              # (T-0080) と同じ最小権限パターンを使う: 読み取り専用の権限チェック回避のみ許可し
+              # フルの root 権限は持たせない。書き込みは readOnly: true でも構造的に禁止している
+              securityContext:
+                runAsUser: 0
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+                  add: ["DAC_READ_SEARCH"]
+              # apk add でパッケージ一覧を取得する程度のためメモリ上限は不要な負荷をかけない値に
+              # 留める。CPU limit は超過しても throttle で回復するため縛る変更には該当しない
+              # (memory limit は実測なしで新設しない、CHARTER §4)
+              resources:
+                requests:
+                  cpu: 20m
+                  memory: 64Mi
+                limits:
+                  cpu: 500m
+              volumeMounts:
+                - name: vaultwarden-data
+                  mountPath: /mnt/vaultwarden-data
+                  readOnly: true
+                - name: staging
+                  mountPath: /staging
+          containers:
+            - name: restic-backup
+              image: restic/restic:0.19.1
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  restic snapshots >/dev/null 2>&1 || restic init
+                  restic backup /mnt/vaultwarden-data /staging/db.sqlite3 \
+                    --exclude db.sqlite3 --exclude db.sqlite3-wal --exclude db.sqlite3-shm \
+                    --exclude icon_cache
+              env:
+                - name: RESTIC_B2_BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      name: vaultwarden-restic-credentials
+                      key: RESTIC_B2_BUCKET
+                # bucket 名の後ろの "vaultwarden" がリポジトリパスの区切り。immich/coder-postgres
+                # は同じ bucket ・同じ credential で末尾だけ変えて使う想定 (T-0068/T-0070)
+                - name: RESTIC_REPOSITORY
+                  value: "b2:$(RESTIC_B2_BUCKET):vaultwarden"
+                - name: RESTIC_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: vaultwarden-restic-credentials
+                      key: RESTIC_PASSWORD
+                - name: B2_ACCOUNT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: vaultwarden-restic-credentials
+                      key: B2_ACCOUNT_ID
+                - name: B2_ACCOUNT_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: vaultwarden-restic-credentials
+                      key: B2_ACCOUNT_KEY
+              securityContext:
+                runAsUser: 0
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+                  add: ["DAC_READ_SEARCH"]
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+              volumeMounts:
+                - name: vaultwarden-data
+                  mountPath: /mnt/vaultwarden-data
+                  readOnly: true
+                - name: staging
+                  mountPath: /staging
+                  readOnly: true
+          volumes:
+            - name: vaultwarden-data
+              persistentVolumeClaim:
+                claimName: vaultwarden-data
+                readOnly: true
+            - name: staging
+              emptyDir: {}
+---
+# 週次で古い世代を刈る (restic forget --prune)。PVC には触れないため readOnly マウント不要。
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: vaultwarden-restic-retention
+  namespace: vaultwarden
+spec:
+  schedule: "0 4 * * 0"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 1800
+      template:
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          containers:
+            - name: restic-forget
+              image: restic/restic:0.19.1
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  restic snapshots >/dev/null 2>&1 || { echo "repository not initialized yet, skipping"; exit 0; }
+                  restic forget --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --prune
+              env:
+                - name: RESTIC_B2_BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      name: vaultwarden-restic-credentials
+                      key: RESTIC_B2_BUCKET
+                - name: RESTIC_REPOSITORY
+                  value: "b2:$(RESTIC_B2_BUCKET):vaultwarden"
+                - name: RESTIC_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: vaultwarden-restic-credentials
+                      key: RESTIC_PASSWORD
+                - name: B2_ACCOUNT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: vaultwarden-restic-credentials
+                      key: B2_ACCOUNT_ID
+                - name: B2_ACCOUNT_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: vaultwarden-restic-credentials
+                      key: B2_ACCOUNT_KEY
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m

--- a/apps/vaultwarden/restic-external-secret.yaml
+++ b/apps/vaultwarden/restic-external-secret.yaml
@@ -1,0 +1,36 @@
+# restic + Backblaze B2 の共通credential。immich(T-0068)/coder-postgres(T-0070)のCronJobでも
+# 同じDopplerキーを各アプリのnamespaceのExternalSecretから参照する想定
+# （リポジトリパス末尾の "vaultwarden" だけが restic-backup-cronjob.yaml 側でアプリ固有）。
+# Requires: ClusterSecretStore 'doppler' (apps/external-secrets/cluster-secret-store.yaml)
+# Requires: Doppler secrets（T-0067, ops/backlog.json 参照。バケット作成・キー発行は人間の作業）
+#   RESTIC_PASSWORD      — restic リポジトリの暗号化パスワード（新規に決めて登録する。復元時に必要）
+#   RESTIC_B2_BUCKET      — Backblaze B2 のバケット名
+#   RESTIC_B2_ACCOUNT_ID  — B2 application key ID（append-only キー）
+#   RESTIC_B2_ACCOUNT_KEY — B2 application key（同上）
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: vaultwarden-restic-credentials
+  namespace: vaultwarden
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler
+  target:
+    name: vaultwarden-restic-credentials
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: RESTIC_PASSWORD
+      remoteRef:
+        key: RESTIC_PASSWORD
+    - secretKey: RESTIC_B2_BUCKET
+      remoteRef:
+        key: RESTIC_B2_BUCKET
+    - secretKey: B2_ACCOUNT_ID
+      remoteRef:
+        key: RESTIC_B2_ACCOUNT_ID
+    - secretKey: B2_ACCOUNT_KEY
+      remoteRef:
+        key: RESTIC_B2_ACCOUNT_KEY

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -43,6 +43,39 @@ issue #56 (2026-08-05 04:40:59) で人間から新方針: **PBS は重すぎる�
 | `coder-postgres-data` | Coder 制御プレーン（ユーザー・workspace・監査ログ） | T-0070 |
 | `coder-<workspace-id>-home`（動的作成、`apps/coder/templates/personal/main.tf`） | workspace ごとの `/home/coder`（dotfiles・ghq clone 等） | **未起票**。T-0070 の対象外（別 PVC 群）のため、別途タスク化が必要 |
 
+## vaultwarden の restic バックアップ (T-0069, 実装済み・credential 登録待ち)
+
+`apps/vaultwarden/restic-backup-cronjob.yaml` に2つの CronJob を実装した。
+
+- **`vaultwarden-restic-backup`**（毎日 03:40 UTC）: `/data` を直接 restic に渡すと
+  `db.sqlite3-wal`/`-shm` と本体の不整合を持ち込む（vaultwarden 公式 wiki の注意）ため、
+  initContainer で SQLite の Online Backup API（`sqlite3 -readonly db.sqlite3 ".backup ..."`。
+  稼働中でも一貫性のあるコピーが取れる）を使い db.sqlite3 だけ一貫コピーしてから、
+  本体コンテナが「PVC（db.sqlite3系・icon_cache を除く）+ 一貫コピー済み db.sqlite3」の
+  2 パスをまとめて1スナップショットにする。`rsa_key*.pem`（JWT 署名鍵、失うと全セッション
+  無効化）・`attachments/`・`config.json` は PVC 側からそのまま含まれる
+- **`vaultwarden-restic-retention`**（毎週日曜 04:00 UTC）: `restic forget --keep-daily 7
+  --keep-weekly 4 --keep-monthly 6 --prune`
+- 保存先は Backblaze B2（`b2:<bucket>:vaultwarden`）。immich（T-0068）・coder-postgres
+  （T-0070）も同じ bucket・同じ credential でパス末尾だけ変える設計にした
+- **復元時の注意**: 復元前に vaultwarden コンテナを止め、既存の `db.sqlite3-wal`/`db.sqlite3-shm`
+  を削除してから復元後の `db.sqlite3` を配置すること（stale な WAL が残ると起動時に不整合を起こしうる）
+
+### 必要な Doppler 登録（T-0067）
+
+`apps/vaultwarden/restic-external-secret.yaml` が参照するキー。immich/coder-postgres 実装時も
+同じキーを使い回す想定（バケットを分けたい場合は別途相談）。
+
+| Doppler キー | 内容 |
+|---|---|
+| `RESTIC_PASSWORD` | restic リポジトリの暗号化パスワード（新規に決めて登録） |
+| `RESTIC_B2_BUCKET` | Backblaze B2 のバケット名 |
+| `RESTIC_B2_ACCOUNT_ID` | B2 application key ID（**append-only** キーを推奨。node01 が乗っ取られてもバックアップを消せないように） |
+| `RESTIC_B2_ACCOUNT_KEY` | 同上 application key |
+
+登録後、`ops-health-report`（`pod_issues`）で `vaultwarden-restic-backup` CronJob の Job が
+Failed になっていないことを確認できれば実際に動作したとみなせる（T-0097）。
+
 ## わかっていること（repo から）
 
 - PBS (Proxmox Backup Server) VM が `qemu/112` として稼働中。手動管理

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 97,
+  "next_id": 99,
   "updated": "2026-08-05T10:30:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
@@ -1233,10 +1233,11 @@
       "priority": 36,
       "why": "issue #56 (2026-08-05 04:40:59) の人間の新方針。restic ベースのバックアップに保存先が要る。構築セッションの調査では Backblaze B2（$2.09/300GB・復元エグレス無料枠あり）を推奨、ライブラリが 1TB に近いなら Hetzner Storage Box（固定 €3.20）が逆転する（T-0066 の実測結果で確定する）",
       "dod": "T-0066 の実測結果を踏まえて保存先を確定し、アカウントを作成、restic リポジトリ用の append-only なアプリケーションキー（node01 が乗っ取られてもバックアップを消せないように）を発行し、Doppler の homelab/prd に登録する。登録先キー名は実装時（T-0068〜T-0070）にこちらで backlog へ追記する",
-      "needs_human_reason": "外部サービスのアカウント作成とコストが動く契約、および credential の発行・Doppler への登録。CHARTER §4『人間に渡してよいもの』の『権限・認証の手作業』『コストや契約が動くもの』に該当し、エージェントからは手が届かない",
+      "needs_human_reason": "外部サービスのアカウント作成とコストが動く契約、および credential の発行・Doppler への登録。CHARTER §4『人間に渡してよいもの』の『権限・認証の手作業』『コストや契約が動くもの』に該当し、エージェントからは手が届かない。T-0069 (#191) で実装した ExternalSecret が参照するキー名が確定したので、以下をそのまま Doppler の homelab/prd に登録してほしい: `RESTIC_PASSWORD`（暗号化パスワード、新規に生成して登録）/ `RESTIC_B2_BUCKET`（B2 バケット名）/ `RESTIC_B2_ACCOUNT_ID` / `RESTIC_B2_ACCOUNT_KEY`（B2 application key、append-only 推奨）。詳細は docs/backup.md 参照",
       "blocked_by": "T-0066（保存先の選定に実サイズが要る）",
       "refs": [
-        "docs/backup.md"
+        "docs/backup.md",
+        "apps/vaultwarden/restic-external-secret.yaml"
       ],
       "created": "2026-08-05",
       "pr": null
@@ -1265,17 +1266,17 @@
       "title": "vaultwarden 用 backup CronJob（sqlite .backup + restic）を追加する",
       "kind": "feature",
       "risk": "medium",
-      "status": "in_progress",
+      "status": "done",
       "priority": 40,
       "why": "issue #56 (2026-08-05 04:40:59) の人間の新方針・構築セッションの調査。`/data` を丸ごと restic するのは NG（`-wal`/`-shm` と本体の不整合）。`sqlite3 .backup` か vaultwarden 内蔵の `/vaultwarden backup`（1.32.1+、このリポジトリは 1.37.1 で対象）を使い、その出力を restic で保存する",
       "dod": "CronJob が vaultwarden 内蔵の backup 機能（またはsqlite3 .backup）でリストア可能な単一ファイルを作り、restic で T-0067 の保存先へ push する。復元時は既存の db.sqlite3-wal を先に消す必要がある旨を手順として docs/backup.md に残す。retention は T-0068 と同じ方針。credential (RESTIC_PASSWORD/RESTIC_REPOSITORY/B2 キー) は Doppler のキー名をこのタスクで決め、T-0067 の登録依頼に反映する",
-      "notes": "run #48: issue #56 (10:29:40) の指摘を受け blocked → in_progress に変更し着手。restic の暗号化 push 自体は T-0067（credential）待ちだが、CronJob/ExternalSecret の manifest は先に書く",
+      "notes": "run #48: issue #56 (10:29:40) の指摘を受け blocked → in_progress に変更し着手。subagent 調査で vaultwarden wiki の公式手順（SQLite Online Backup API は稼働中でも安全、vaultwarden イメージに sqlite3 CLI は同梱されていない）を確認したうえで実装。initContainer (alpine + sqlite3) で db.sqlite3 のみ一貫コピーし、restic-backup コンテナ (restic/restic:0.19.1) が PVC 直接読み（db.sqlite3系・icon_cache 除く）と一貫コピーを1スナップショットにまとめる設計。retention (forget --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --prune) も同じ PR (#191) で実装した。memory limit は実測なしで新設しない（CPU limit のみ、CHARTER §4）ため縛る変更のクールダウン対象外と判断し即マージ。実際に restic push が成功するかは T-0067（credential 登録）待ちのため T-0097 として確認タスクを別途起票した。done とするが、DoD の『restic で保存先へ push する』が実際に成功したことの確認は T-0097 が担う",
       "refs": [
         "apps/vaultwarden/",
         "docs/backup.md"
       ],
       "created": "2026-08-05",
-      "pr": null
+      "pr": 191
     },
     {
       "id": "T-0070",
@@ -1759,6 +1760,41 @@
         "ops/check_doc_commands.py",
         ".github/workflows/ci.yml",
         "justfile"
+      ],
+      "created": "2026-08-05",
+      "pr": null
+    },
+    {
+      "id": "T-0097",
+      "domain": "homelab",
+      "title": "T-0069（vaultwarden restic backup）が実際に成功しているか確認する",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "blocked",
+      "priority": 41,
+      "why": "T-0069 (#191) は manifest 実装のみで、実際に restic push が成功するかは T-0067 の credential 登録が終わるまで検証できない（このクラウドサンドボックスは k8s Job のログを見られない）。CHARTER §4『PR 本文に残った不確実性を書いたら同じ PR で backlog にも軽量な確認待ちタスクとして起票する』に従い分離",
+      "dod": "T-0067 の Doppler 登録後、次回以降の起動で ops-health-report の pod_issues に `vaultwarden-restic-backup`/`vaultwarden-restic-retention` の CronJob の Job が Failed で出ていないかを確認する。問題なければ docs/backup.md に成功日時を記録して done にする。継続的に失敗するなら症状を記録し、原因調査を新規タスクとして起票する",
+      "blocked_by": "T-0067（credential 登録。登録完了後の確認作業自体は autopilot が行う）",
+      "refs": [
+        "apps/vaultwarden/restic-backup-cronjob.yaml",
+        "docs/backup.md"
+      ],
+      "created": "2026-08-05",
+      "pr": 191
+    },
+    {
+      "id": "T-0098",
+      "domain": "homelab",
+      "title": "restic/restic イメージタグの同一ファイル内重複を check_version_sync.py の監視対象に追加する",
+      "kind": "ci",
+      "risk": "low",
+      "status": "todo",
+      "priority": 45,
+      "why": "T-0069 (#191) で apps/vaultwarden/restic-backup-cronjob.yaml に restic/restic:0.19.1 が2箇所（backup と retention の CronJob）独立して書かれた。T-0090/T-0082 と同型のドリフトパターンで、片方だけ更新した PR が CI green のまま素通りしうる",
+      "dod": "ops/check_version_sync.py の GROUPS に restic-backup-cronjob.yaml 内の2出現を追加する。意図的に値をずらして CI が exit 1 になることを確認する",
+      "refs": [
+        "ops/check_version_sync.py",
+        "apps/vaultwarden/restic-backup-cronjob.yaml"
       ],
       "created": "2026-08-05",
       "pr": null

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -341,6 +341,30 @@
       "policy": "auto",
       "note": "terraform job がインストールする terraform バイナリ本体のバージョン。terraform/proxmox/providers.tf の required_version (\"~> 1.15\") の範囲内で揃える。T-0091 (run #43) で発見時点 1.15.0 が最新 1.15.8 より8パッチ遅れていた（required_version の範囲は満たすため CI は気づけない）ことを機に新設。CHANGELOG 全文確認（1.15.1〜1.15.8）で breaking change 無し、fmt/validate/init への影響も軽微（backend block validation の追加→撤回、ログ整形のみ）と確認済み",
       "observability_impact": "terraform validate job が使用。壊れると terraform validate の CI が動かなくなる"
+    },
+    {
+      "id": "vaultwarden-restic-image",
+      "kind": "image",
+      "name": "restic/restic (backup CronJob)",
+      "current": "0.19.1",
+      "file": "apps/vaultwarden/restic-backup-cronjob.yaml",
+      "match": "restic/restic:",
+      "upstream": "github:restic/restic",
+      "policy": "auto",
+      "note": "T-0069 で新設。同一ファイル内に vaultwarden-restic-backup（バックアップ）と vaultwarden-restic-retention（forget/prune）の2箇所で使用しており、check_version_sync.py の GROUPS には未登録（T-0098 で追う。手動更新時は2箇所とも揃えること）",
+      "observability_impact": "vaultwarden の restic バックアップ・retention CronJob が使用。壊れるとバックアップが取れなくなるが vaultwarden 本体の可用性には影響しない"
+    },
+    {
+      "id": "vaultwarden-restic-sqlite-alpine",
+      "kind": "image",
+      "name": "alpine (restic backup CronJob の sqlite-snapshot initContainer)",
+      "current": "3.22.5",
+      "file": "apps/vaultwarden/restic-backup-cronjob.yaml",
+      "match": "alpine:",
+      "upstream": "dockerhub:library/alpine",
+      "policy": "auto",
+      "note": "T-0069 で新設。sqlite3 CLI を apk で都度インストールして db.sqlite3 の一貫バックアップを取る initContainer 用",
+      "observability_impact": "vaultwarden の restic バックアップ CronJob が使用。壊れるとバックアップが取れなくなるが vaultwarden 本体の可用性には影響しない"
     }
   ]
 }


### PR DESCRIPTION
## 変更点

issue #56 (2026-08-05 04:40:59) の人間の新方針（PBSを軽くし、k8sより上をIaCで完全記述してrestic
ベースのアプリ単位バックアップへ移行する）に基づく実装。同10:29:40の指摘（credential待ちで丸ごと
blockedにせず、manifestの設計・記述は先に進める）を受けてこの起動で着手した。

- `apps/vaultwarden/restic-backup-cronjob.yaml`: 2つのCronJobを新設
  - `vaultwarden-restic-backup`（毎日03:40 UTC）: `/data`を直接resticに渡すと`db.sqlite3-wal`/`-shm`
    と本体の不整合を持ち込む（vaultwarden公式wikiの注意）ため、initContainerでSQLiteの
    Online Backup API（`sqlite3 -readonly db.sqlite3 ".backup ..."`。稼働中でも一貫性のある
    コピーが取れる）を使いdb.sqlite3だけ一貫コピーしてから、本体コンテナ（restic/restic:0.19.1）が
    「PVC直接読み（db.sqlite3系・icon_cache除く）+ 一貫コピー済みdb.sqlite3」の2パスを
    まとめて1スナップショットにする。`rsa_key*.pem`（JWT署名鍵）・`attachments/`・`config.json`は
    PVC側からそのまま含まれる
  - `vaultwarden-restic-retention`（毎週日曜04:00 UTC）: `restic forget --keep-daily 7
    --keep-weekly 4 --keep-monthly 6 --prune`
  - securityContextはT-0080（pvc-usage-cronjob.yaml, #163/#165）と同じ既承認パターン
    （`runAsUser: 0` + `capabilities: drop ALL, add DAC_READ_SEARCH`のみ）を再利用。
    memory limitは実測なしで新設していない（CPU limitのみ設定。CHARTER §4「縛る変更」対象外）
- `apps/vaultwarden/restic-external-secret.yaml`: restic/B2のcredential用ExternalSecretを新設。
  Dopplerのキー名を決定（`RESTIC_PASSWORD`/`RESTIC_B2_BUCKET`/`RESTIC_B2_ACCOUNT_ID`/
  `RESTIC_B2_ACCOUNT_KEY`）し、T-0067の`needs_human_reason`に反映した。immich（T-0068）・
  coder-postgres（T-0070）も同じcredentialでリポジトリパス末尾だけ変える設計
- `docs/backup.md`, `ops/inventory.json`, `ops/backlog.json`: 実装内容の記録、T-0069をdoneに、
  T-0067のneeds_human_reasonを具体化、T-0097（実際の成功確認、T-0067待ちでblocked）・
  T-0098（restic/resticタグの同一ファイル内重複をCI監視対象に追加、todo）を新規起票

## 検証したこと

- `python3 ops/validate.py` → 0 error（既存warning 7件は本PRと無関係の既知事項）
- vaultwardenのwiki・ソース（`dani-garcia/vaultwarden`）でSQLite Online Backup APIが稼働中でも
  安全であること、vaultwardenイメージにsqlite3 CLIが同梱されていないことをsubagentで確認済み
- restic/restic:0.19.1が現行安定版であること、Dockerfileがalpine baseでshellを持つことを
  GitHub上のソースで確認済み
- CIでは実際にcredentialが無いためCronJobの動作そのものは検証できない（構造のみ`kustomize build`
  で検証）。実際の成功確認はT-0097としてT-0067待ちで分離した

## ロールバック手順

このPRはvaultwarden namespaceに新規リソース（ExternalSecret・CronJob×2）を追加するのみで、
既存のvaultwarden Deployment/PVC/Serviceには一切触れていない。revertすればCronJobと
ExternalSecretが消えるだけで、vaultwarden本体の可用性・データには影響しない。DBのバックアップ
という性質上「revertするとバックアップが取れなくなる」点はあるが、それ自体はrevert前の状態
（バックアップが無い）に戻るだけで、データを失うものではない。

## backlog task id

T-0069（本PRで完遂）。派生: T-0067（needs_human_reasonを更新）、T-0097（needs-human/blocked、
新規起票）、T-0098（todo、新規起票）

---
_Generated by [Claude Code](https://claude.ai/code/session_01922FLpCxKNWyQ7SoL5yGm2)_