### PR TITLE
ops: run #47 の記録更新（T-0095 pr番号反映・status重複キー修正・journal/state）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1734,7 +1734,7 @@
       "title": "apps/README.md の『事前設定 (初回のみ)』が使われていない旧ブートストラップ手順を案内している",
       "kind": "docs",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 41,
       "why": "run #47 の subagent 調査で発見。apps/README.md の『K3s シークレットの事前生成』(openssl で CA/Token を作り `doppler secrets set K3S_TOKEN=... K3S_CA_CERT=... K3S_CA_KEY=...`) と『VM 再構築後』の `just inject-secrets` は、リポジトリ全体を grep しても K3S_TOKEN/K3S_CA_CERT/K3S_CA_KEY を参照する箇所が無く、justfile にも inject-secrets という recipe が存在しない（確認済み、run #47）。実際のブートストラップは同ファイル前半に書かれている sops-nix → doppler-token Secret → ArgoCD/ESO の経路のみで完結しており、この節は sops-nix 導入前の古い手順の残骸と見られる。VM 再構築の際にこの節を真に受けると、何も消費されない Doppler 変数を設定する無駄な作業と、実行すると失敗する `just inject-secrets`（unknown recipe）に時間を溶かす",
       "dod": "K3s シークレット事前生成の節と `just inject-secrets` の呼び出しを apps/README.md から削除する（または、実際に使われている sops-nix 経路への書き換えとして残す）。削除前に本当にどこからも参照されていないことを再度 grep で確認する",
@@ -1744,8 +1744,7 @@
         "nix/images/proxmox-cloud/configuration.nix"
       ],
       "created": "2026-08-05",
-      "status": "done",
-      "pr": null,
+      "pr": 189,
       "notes": "run #47: 再度 grep で確認（K3S_TOKEN/K3S_CA_CERT/K3S_CA_KEY/inject-secrets ともリポジトリ内でこのファイル以外に参照なし）。DoD どおり『K3s シークレットの事前生成』節と『VM 再構築後』節（`just inject-secrets`）を削除。`Doppler プロジェクト設定`（TAILSCALE_CLIENT_ID/SECRET）は apps/external-secrets/tailscale-oauth-external-secret.yaml が実際に参照しており有効なため残置"
     },
     {

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,10 +2,45 @@
   "open": [],
   "merged": [
     {
+      "number": 189,
+      "title": "docs: apps/README.md の使われていない旧ブートストラップ手順を削除する (T-0095)",
+      "url": "https://github.com/hikuohiku/homelab/pull/189",
+      "mergedAt": "2026-08-05T11:55:33Z",
+      "headRefName": "autopilot/T-0095-apps-readme-dead-bootstrap"
+    },
+    {
+      "number": 192,
+      "title": "fix: vaultwarden backupのsqlite-snapshotをapk依存からpython標準ライブラリへ (T-0069 follow-up)",
+      "url": "https://github.com/hikuohiku/homelab/pull/192",
+      "mergedAt": "2026-08-05T11:54:12Z",
+      "headRefName": "autopilot/T-0069-followup-drop-apk-dep"
+    },
+    {
+      "number": 191,
+      "title": "feat: vaultwarden用restic backup CronJobを追加 (T-0069)",
+      "url": "https://github.com/hikuohiku/homelab/pull/191",
+      "mergedAt": "2026-08-05T11:41:15Z",
+      "headRefName": "autopilot/T-0069-vaultwarden-restic-backup"
+    },
+    {
+      "number": 190,
+      "title": "CHARTER: blocked/needs-humanをタスク全体でなく部分で見る (T-0095)",
+      "url": "https://github.com/hikuohiku/homelab/pull/190",
+      "mergedAt": "2026-08-05T11:32:44Z",
+      "headRefName": "autopilot/T-0095-blocked-granularity"
+    },
+    {
+      "number": 188,
+      "title": "ops: run #47 の記録更新（PR番号反映・journal・state・PRキャッシュ）",
+      "url": "https://github.com/hikuohiku/homelab/pull/188",
+      "mergedAt": "2026-08-05T11:23:58Z",
+      "headRefName": "autopilot/run47-record"
+    },
+    {
       "number": 187,
       "title": "docs: apps/README.md の ArgoCD Application 出力例を実態に合わせる (T-0094)",
       "url": "https://github.com/hikuohiku/homelab/pull/187",
-      "mergedAt": "2026-08-05T10:33:00Z",
+      "mergedAt": "2026-08-05T10:29:02Z",
       "headRefName": "autopilot/T-0094-apps-readme-app-list"
     },
     {
@@ -385,41 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/128",
       "mergedAt": "2026-08-05T02:20:35Z",
       "headRefName": "autopilot/T-0052-secrets-path-doc-drift"
-    },
-    {
-      "number": 127,
-      "title": "ops: run #20 の記録をまとめ、ダッシュボードを再生成する",
-      "url": "https://github.com/hikuohiku/homelab/pull/127",
-      "mergedAt": "2026-08-05T02:00:17Z",
-      "headRefName": "autopilot/run20-wrapup"
-    },
-    {
-      "number": 126,
-      "title": "T-0051: check_version_sync.py の検証対象を inventory.json の mirrors 全件に揃える",
-      "url": "https://github.com/hikuohiku/homelab/pull/126",
-      "mergedAt": "2026-08-05T01:58:01Z",
-      "headRefName": "autopilot/T-0051-check-version-sync-mirrors"
-    },
-    {
-      "number": 125,
-      "title": "docs(ci): release-image.yml が CI 検証対象外であることを明記する (T-0050)",
-      "url": "https://github.com/hikuohiku/homelab/pull/125",
-      "mergedAt": "2026-08-05T01:36:23Z",
-      "headRefName": "autopilot/T-0049-release-image-ci-blindspot"
-    },
-    {
-      "number": 124,
-      "title": "ops: nixpkgs flake.lock の経年放置を発見し T-0049 として起票する (T-0049)",
-      "url": "https://github.com/hikuohiku/homelab/pull/124",
-      "mergedAt": "2026-08-05T01:30:01Z",
-      "headRefName": "autopilot/T-0049-nixpkgs-pin-staleness"
-    },
-    {
-      "number": 123,
-      "title": "ops: run #17 の記録をまとめ、ダッシュボードを再生成する",
-      "url": "https://github.com/hikuohiku/homelab/pull/123",
-      "mergedAt": "2026-08-05T01:22:18Z",
-      "headRefName": "autopilot/run17-wrapup"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1362,3 +1362,25 @@
   （9件）+ root で計10件に出力例を更新。T-0095/T-0096 は backlog に起票のみで次回以降
 - 次の起動へ: backlog の todo は T-0095（priority 41）・T-0096（priority 45）の2件。
   T-0079（node01 実ディスク容量、needs-human・priority 1）引き続き待ち
+
+## 2026-08-05 20:57 JST — run #47（続き）
+
+- PR #188（run #47 前半の記録更新）の merge を見届けた後、backlog の todo だった T-0095 に着手。
+  再度 grep で K3S_TOKEN/K3S_CA_CERT/K3S_CA_KEY/inject-secrets の参照が apps/README.md 以外に
+  無いことを確認し、『K3s シークレットの事前生成』『VM 再構築後』の2節を削除（Doppler プロジェクト
+  設定の節は apps/external-secrets/tailscale-oauth-external-secret.yaml が実際に参照しているため
+  残置）。PR #189 を作成後、待っている間に別セッションが CI green を確認して merge した（自分では
+  merge 操作をしていない）
+- 記録を反映しようとした際、T-0095 の backlog エントリに `"status"` キーを重複して書いてしまって
+  いたのを発見（当初 `"todo"` の行を残したまま、後続の Edit で `"status": "done"` を別の行に
+  追加していた。Python の json.load は後勝ちで実害は無かったが、部分置換で既存キーを見落とす
+  という同じ形のミスを次もやりうるため書き残す。教訓: 既存フィールドの値を変える Edit では、
+  古い値を含む行を old_string に必ず含める（新しい行を追加するだけで済ませない）
+- 同じタイミングで別セッションが並行して T-0069（vaultwarden 用 restic backup CronJob）を完遂
+  （#190〜192）し、T-0097（restic backup の実際の成功確認、needs-human 相当で blocked）・T-0098
+  （restic イメージタグの重複を check_version_sync.py の監視対象に追加、todo）を新規に起票していた。
+  自分側では着手せず、次回の起動でこれらを拾う
+- T-0095 の pr フィールド反映と重複 status キーの修正を本 run のラップアップ PR に含めた
+- 次の起動へ: backlog の todo は T-0096（priority 45）・T-0098（新規、優先度は次回確認）の2件。
+  T-0097 は blocked（restic backup の実機成功確認待ち）。T-0079（node01 実ディスク容量、
+  needs-human・priority 1）引き続き待ち

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T10:30:00Z",
+  "updated": "2026-08-05T11:57:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -532,9 +532,11 @@
       "at": "2026-08-05T10:27:00Z",
       "kind": "scheduled",
       "by": "cloud routine",
-      "summary": "オープン PR・autopilot ブランチとも無く中断なし（run #46 が残した孤児ブランチ autopilot/T-0088-tailscale-1.102.2 は main との diff ゼロと確認、回収不要）。issue #56 に未読フィードバックなし。ops-health-report で ArgoCD 全10アプリ Synced/Healthy、pvc_usage の実使用量はいずれも小さく（immich-library 348MB 等）T-0079 の逼迫はまだ実害化していない。backlog の todo が0件だったため subagent に調査を投げ3件発見: T-0094（apps/README.md の ArgoCD Application 出力例が10件中4件のみ、完遂・#187）、T-0095（同ファイルの旧ブートストラップ手順が実行すると失敗する状態のまま案内されている、todo）、T-0096（ドキュメントの `just <recipe>` 参照を CI で検証する仕組みが無い、todo）",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし（run #46 が残した孤児ブランチ autopilot/T-0088-tailscale-1.102.2 は main との diff ゼロと確認、回収不要）。issue #56 に未読フィードバックなし。ops-health-report で ArgoCD 全10アプリ Synced/Healthy、pvc_usage の実使用量はいずれも小さく（immich-library 348MB 等）T-0079 の逼迫はまだ実害化していない。backlog の todo が0件だったため subagent に調査を投げ3件発見: T-0094（apps/README.md の ArgoCD Application 出力例が10件中4件のみ、完遂・#187）、T-0095（同ファイルの旧ブートストラップ手順が実行すると失敗する状態のまま案内されている、完遂・#189）、T-0096（ドキュメントの `just <recipe>` 参照を CI で検証する仕組みが無い、todo）。作業中、backlog.json の編集で status キーを重複させる自分のミスに気づき修正。並行して別セッションが T-0069（vaultwarden restic backup）を完遂し T-0097/T-0098 を新規起票",
       "prs": [
-        187
+        187,
+        188,
+        189
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

- `ops/backlog.json`: T-0095 の `pr` フィールドを 189（merged 済み）に反映
- `ops/backlog.json`: T-0095 の編集ミスで生じていた `status` キーの重複（`"todo"` と `"done"` が両方残っていた。Python の `json.load` は後勝ちのため実害は無かった）を修正
- `ops/journal/2026-08.md`: run #47 後半（T-0095 完遂、並行セッションの T-0069/T-0097/T-0098 の把握）を追記
- `ops/state.json`: run #47 のエントリを更新（PR 187/188/189 を反映）
- `ops/dashboard/prs.json`: PR キャッシュを最新化

運用記録のみ。対象の T-0095 PR (#189) は既に merge 済みのため別 PR で即マージする。

## 検証したこと

- `python3 -c "json.loads(..., object_pairs_hook=...)"` で backlog.json 全体に重複キーが残っていないことを確認
- `python3 ops/validate.py` → 0 error（既存 warning 6件は本 PR と無関係の既知事項）
- `python3 ops/dashboard/build.py` → 例外なく完了

## ロールバック手順

記録のみの変更のため revert すれば元に戻る。インフラ状態への影響なし。

## backlog task id

なし（運用記録のみ）

---
_Generated by [Claude Code](https://claude.ai/code/session_018govyX4UhtzKereFhANSCE)_