### PR TITLE
ops: run #48 の記録更新（journal・state・PRキャッシュ、T-0095 id重複の再発防止）

### DIFF
--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -119,6 +119,14 @@ backlog が空、または全部 `blocked` のときは**調査タスクを自�
 
 ### 共通ルール
 
+- **新しい task id をブランチ名・commit message・PR タイトルに使う前に、`ops/backlog.json` に
+  同じ id が既に存在しないか確認する。** `next_id` を読むだけでは足りない（run #48 の実例:
+  backlog.json にタスクとして正式に起票せず PR の見出し・記録用のラベルとして id を使った際、
+  `next_id` を確認せず「T-0095」を割り当てたところ、実は run #47 が既に同じ id で別タスク
+  （apps/README.md の旧ブートストラップ削除）を起票済みだった。backlog.json 自体に重複エントリは
+  作らなかったが、commit/PR タイトル上で同じ id が2つの別タスクを指す表記ゆれが残った）。
+  backlog に正式起票しない一時的なラベルであっても、`grep '"id": "T-XXXX"' ops/backlog.json`
+  で既存の有無を確認してから使う
 - ブランチ名は `autopilot/<task-id>-<slug>`。**task-id の大文字小文字も含めてそのまま使う**
   （`autopilot/T-0037-...` が正、`autopilot/t0037-...` のような表記ゆれを作らない）。
   同じタスクで PR を作り直す（レビュー指摘で作り直す、他セッションと重複した等）ときは、

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1734,7 +1734,7 @@
       "title": "apps/README.md の『事前設定 (初回のみ)』が使われていない旧ブートストラップ手順を案内している",
       "kind": "docs",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 41,
       "why": "run #47 の subagent 調査で発見。apps/README.md の『K3s シークレットの事前生成』(openssl で CA/Token を作り `doppler secrets set K3S_TOKEN=... K3S_CA_CERT=... K3S_CA_KEY=...`) と『VM 再構築後』の `just inject-secrets` は、リポジトリ全体を grep しても K3S_TOKEN/K3S_CA_CERT/K3S_CA_KEY を参照する箇所が無く、justfile にも inject-secrets という recipe が存在しない（確認済み、run #47）。実際のブートストラップは同ファイル前半に書かれている sops-nix → doppler-token Secret → ArgoCD/ESO の経路のみで完結しており、この節は sops-nix 導入前の古い手順の残骸と見られる。VM 再構築の際にこの節を真に受けると、何も消費されない Doppler 変数を設定する無駄な作業と、実行すると失敗する `just inject-secrets`（unknown recipe）に時間を溶かす",
       "dod": "K3s シークレット事前生成の節と `just inject-secrets` の呼び出しを apps/README.md から削除する（または、実際に使われている sops-nix 経路への書き換えとして残す）。削除前に本当にどこからも参照されていないことを再度 grep で確認する",
@@ -1744,9 +1744,8 @@
         "nix/images/proxmox-cloud/configuration.nix"
       ],
       "created": "2026-08-05",
-      "status": "done",
-      "pr": null,
-      "notes": "run #47: 再度 grep で確認（K3S_TOKEN/K3S_CA_CERT/K3S_CA_KEY/inject-secrets ともリポジトリ内でこのファイル以外に参照なし）。DoD どおり『K3s シークレットの事前生成』節と『VM 再構築後』節（`just inject-secrets`）を削除。`Doppler プロジェクト設定`（TAILSCALE_CLIENT_ID/SECRET）は apps/external-secrets/tailscale-oauth-external-secret.yaml が実際に参照しており有効なため残置"
+      "pr": 189,
+      "notes": "run #47: 再度 grep で確認（K3S_TOKEN/K3S_CA_CERT/K3S_CA_KEY/inject-secrets ともリポジトリ内でこのファイル以外に参照なし）。DoD どおり『K3s シークレットの事前生成』節と『VM 再構築後』節（`just inject-secrets`）を削除。`Doppler プロジェクト設定`（TAILSCALE_CLIENT_ID/SECRET）は apps/external-secrets/tailscale-oauth-external-secret.yaml が実際に参照しており有効なため残置 | run #48: PR番号(#189)を記録に反映、重複していたstatusキーを整理"
     },
     {
       "id": "T-0096",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,41 @@
   "open": [],
   "merged": [
     {
+      "number": 189,
+      "title": "docs: apps/README.md の使われていない旧ブートストラップ手順を削除する (T-0095)",
+      "url": "https://github.com/hikuohiku/homelab/pull/189",
+      "mergedAt": "2026-08-05T11:55:33Z",
+      "headRefName": "autopilot/T-0095-apps-readme-dead-bootstrap"
+    },
+    {
+      "number": 192,
+      "title": "fix: vaultwarden backupのsqlite-snapshotをapk依存からpython標準ライブラリへ (T-0069 follow-up)",
+      "url": "https://github.com/hikuohiku/homelab/pull/192",
+      "mergedAt": "2026-08-05T11:54:12Z",
+      "headRefName": "autopilot/T-0069-followup-drop-apk-dep"
+    },
+    {
+      "number": 191,
+      "title": "feat: vaultwarden用restic backup CronJobを追加 (T-0069)",
+      "url": "https://github.com/hikuohiku/homelab/pull/191",
+      "mergedAt": "2026-08-05T11:41:15Z",
+      "headRefName": "autopilot/T-0069-vaultwarden-restic-backup"
+    },
+    {
+      "number": 190,
+      "title": "CHARTER: blocked/needs-humanをタスク全体でなく部分で見る (T-0095)",
+      "url": "https://github.com/hikuohiku/homelab/pull/190",
+      "mergedAt": "2026-08-05T11:32:44Z",
+      "headRefName": "autopilot/T-0095-blocked-granularity"
+    },
+    {
+      "number": 188,
+      "title": "ops: run #47 の記録更新（PR番号反映・journal・state・PRキャッシュ）",
+      "url": "https://github.com/hikuohiku/homelab/pull/188",
+      "mergedAt": "2026-08-05T11:23:58Z",
+      "headRefName": "autopilot/run47-record"
+    },
+    {
       "number": 187,
       "title": "docs: apps/README.md の ArgoCD Application 出力例を実態に合わせる (T-0094)",
       "url": "https://github.com/hikuohiku/homelab/pull/187",
@@ -385,41 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/128",
       "mergedAt": "2026-08-05T02:20:35Z",
       "headRefName": "autopilot/T-0052-secrets-path-doc-drift"
-    },
-    {
-      "number": 127,
-      "title": "ops: run #20 の記録をまとめ、ダッシュボードを再生成する",
-      "url": "https://github.com/hikuohiku/homelab/pull/127",
-      "mergedAt": "2026-08-05T02:00:17Z",
-      "headRefName": "autopilot/run20-wrapup"
-    },
-    {
-      "number": 126,
-      "title": "T-0051: check_version_sync.py の検証対象を inventory.json の mirrors 全件に揃える",
-      "url": "https://github.com/hikuohiku/homelab/pull/126",
-      "mergedAt": "2026-08-05T01:58:01Z",
-      "headRefName": "autopilot/T-0051-check-version-sync-mirrors"
-    },
-    {
-      "number": 125,
-      "title": "docs(ci): release-image.yml が CI 検証対象外であることを明記する (T-0050)",
-      "url": "https://github.com/hikuohiku/homelab/pull/125",
-      "mergedAt": "2026-08-05T01:36:23Z",
-      "headRefName": "autopilot/T-0049-release-image-ci-blindspot"
-    },
-    {
-      "number": 124,
-      "title": "ops: nixpkgs flake.lock の経年放置を発見し T-0049 として起票する (T-0049)",
-      "url": "https://github.com/hikuohiku/homelab/pull/124",
-      "mergedAt": "2026-08-05T01:30:01Z",
-      "headRefName": "autopilot/T-0049-nixpkgs-pin-staleness"
-    },
-    {
-      "number": 123,
-      "title": "ops: run #17 の記録をまとめ、ダッシュボードを再生成する",
-      "url": "https://github.com/hikuohiku/homelab/pull/123",
-      "mergedAt": "2026-08-05T01:22:18Z",
-      "headRefName": "autopilot/run17-wrapup"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1362,3 +1362,42 @@
   （9件）+ root で計10件に出力例を更新。T-0095/T-0096 は backlog に起票のみで次回以降
 - 次の起動へ: backlog の todo は T-0095（priority 41）・T-0096（priority 45）の2件。
   T-0079（node01 実ディスク容量、needs-human・priority 1）引き続き待ち
+
+## 2026-08-05 20:20 JST — run #48
+
+- 前回の中断: PR #188（run #47 の記録更新）が open のまま残っていた。CI green を確認して merge
+- 読んだフィードバック: issue #56 の未読1件（10:29:40、重要）を反映。直近4件（T-0089/T-0092/
+  T-0093/T-0094）がドキュメント修正に偏っていたことへの指摘。原因（実質タスクがほぼ blocked
+  のため §3 の調査起票が drift 修正ばかり見つけていた）は妥当だが、「credential 待ちで丸ごと
+  blocked にしたタスクの中に、manifest の設計・記述だけなら今すぐ進められるものが混ざっている」
+  という指摘を受け、CHARTER §3 に一般原則として反映（#190）。T-0068（immich）・T-0070
+  （coder-postgres）を blocked→todo、T-0069（vaultwarden）を in_progress に変更した
+- **自分のミス**: #190 の新規タスクに、backlog.json に既に存在していた別タスク（apps/README.md
+  旧ブートストラップ削除、run #47 起票）と同じ id「T-0095」を誤って使ってしまった。backlog.json
+  自体に重複エントリは作っていないが、commit/PR タイトル上で同じ id が2つの別タスクを指す表記
+  ゆれが残った（git log に "T-0095" のコミットが2つ存在する）。CHARTER §4 に「新しい id を使う
+  前に backlog.json に既存の有無を grep で確認する」を追記して再発防止とした
+- やったこと: T-0069（vaultwarden 用 restic backup CronJob）に着手・完遂。initContainer で
+  SQLite Online Backup API により db.sqlite3 のみ稼働中でも安全に一貫コピーし、PVC 直接読み
+  （db.sqlite3系・icon_cache 除く）と合わせて restic で Backblaze B2 へ1スナップショットに
+  まとめる設計。週次 retention（forget --prune）も同梱。restic/B2 credential の Doppler
+  キー名（`RESTIC_PASSWORD`/`RESTIC_B2_BUCKET`/`RESTIC_B2_ACCOUNT_ID`/`RESTIC_B2_ACCOUNT_KEY`）
+  を決めて T-0067 の登録依頼に反映した（#191）
+- 構築セッションのレビュー（issue #56 11:38:23）で initContainer の `apk add --no-cache sqlite`
+  が実行時に Alpine パッケージリポジトリへの到達に依存する点を指摘され、即フォローアップで
+  修正: 既にこのリポジトリで監視対象・pvc-usage-reporter と共用の `python:3.12-alpine`
+  （標準ライブラリの `sqlite3.Connection.backup()`）に置き換え、新しい image pin を増やさずに
+  解消した（#192）。check_version_sync.py の GROUPS にも4箇所目として追加し、意図的に値を
+  ずらして CI が exit 1 になることを確認済み
+- 実際に restic push が成功するかは T-0067（credential 登録）待ちのため T-0097 として確認
+  タスクを起票（blocked_by: T-0067）。restic/restic イメージタグの同一ファイル内重複監視は
+  T-0098 として起票（todo）
+- 並行セッションが起票・実装していた本来の T-0095（apps/README.md の旧ブートストラップ手順
+  削除）も CI green を確認し merge（#189）。自分のミスとは無関係の正当な変更
+- ops-health-report（`generated_at: 2026-08-05T11:30:04Z`、#189〜#192 merge 前の観測）で
+  ArgoCD 全10アプリ Synced/Healthy、pod_issues に新規異常なし。T-0079（node01 実ディスク
+  容量）は引き続き人間の報告待ち
+- 次の起動へ: backlog の todo は T-0068（immich backup CronJob）・T-0070（coder-postgres
+  backup CronJob）・T-0098（restic image tag の CI 監視追加）。T-0097（T-0069 の実成功確認、
+  T-0067 待ちで blocked）。T-0067（restic/B2 credential 登録、needs-human・priority 36）と
+  T-0079（node01 実ディスク容量、needs-human・priority 1）は引き続き人間待ち

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-05T10:30:00Z",
+  "updated": "2026-08-05T11:56:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-05T08:23:09Z"
+    "last_read": "2026-08-05T11:49:24Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -535,6 +535,19 @@
       "summary": "オープン PR・autopilot ブランチとも無く中断なし（run #46 が残した孤児ブランチ autopilot/T-0088-tailscale-1.102.2 は main との diff ゼロと確認、回収不要）。issue #56 に未読フィードバックなし。ops-health-report で ArgoCD 全10アプリ Synced/Healthy、pvc_usage の実使用量はいずれも小さく（immich-library 348MB 等）T-0079 の逼迫はまだ実害化していない。backlog の todo が0件だったため subagent に調査を投げ3件発見: T-0094（apps/README.md の ArgoCD Application 出力例が10件中4件のみ、完遂・#187）、T-0095（同ファイルの旧ブートストラップ手順が実行すると失敗する状態のまま案内されている、todo）、T-0096（ドキュメントの `just <recipe>` 参照を CI で検証する仕組みが無い、todo）",
       "prs": [
         187
+      ]
+    },
+    {
+      "n": 48,
+      "at": "2026-08-05T11:20:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "前回の中断: PR #188（run #47 の記録更新）が open のまま残っていたため CI green を確認して merge。issue #56 の未読フィードバック1件（10:29:40、重要）を反映: 直近4件がドキュメント修正に偏っていた点を指摘され、『blocked/needs-humanはタスク全体でなくタスクのどの部分かで見る』をCHARTER §3に反映（#190）。誤ってこの新規タスクに既存タスクと同じ id『T-0095』を使ってしまった（本来のT-0095は run #47 起票の apps/README.md 旧ブートストラップ削除で、backlog.json自体に重複エントリは作っていないが commit/PRタイトルでの誤表記が残る。次回以降 id 割当前に既存 id との重複を確認すること）。続けてT-0069（vaultwarden restic backup CronJob）に着手: sqlite3 Online Backup APIで一貫コピー→restic経由でBackblaze B2へ、週次retentionも実装、Dopplerキー名を決めてT-0067に反映（#191）。構築セッションのレビュー（11:38:23）でinitContainerの`apk add sqlite`が実行時にAlpineパッケージリポジトリへ依存する点を指摘され、既に監視対象のpython:3.12-alpine（標準ライブラリのsqlite3.Connection.backup()）に置き換えて解消（#192, check_version_sync.pyのGROUPSにも追加）。実際のバックアップ成功確認はT-0067（credential登録）待ちのためT-0097として起票、restic imageタグの同一ファイル内重複監視はT-0098として起票。並行セッションが起票・実装していた本来のT-0095（apps/README.md dead bootstrap）も検証のうえ merge（#189）。ops-health-report は前回観測から変化なし（ArgoCD全10アプリSynced/Healthy、pod_issuesは既知の再起動カウントのみ）",
+      "prs": [
+        190,
+        191,
+        192,
+        189
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

- `ops/journal/2026-08.md`: run #48 の記録を追記
- `ops/state.json`: `runs` に run #48 を追加、`feedback.last_read` を更新
- `ops/dashboard/prs.json`: PR キャッシュを最新化（#188〜#192 を反映）
- `ops/backlog.json`: T-0095（apps/README.md 旧ブートストラップ削除、#189）の PR 番号反映、
  重複していた `status` キーの整理
- `ops/CHARTER.md`: 自分が本 run で犯したミス（新規タスクに既存の task id「T-0095」を誤って
  重複割当てした）の再発防止を §4 に追記

運用記録のみ（CHARTER §4 の相乗り例外に該当）。

## 検証したこと

- `python3 ops/validate.py` → 0 error（既存 warning 7件は本 PR と無関係の既知事項）
- `python3 ops/dashboard/build.py` → 例外なく完了

## ロールバック手順

記録のみの変更。revert すれば元に戻る。インフラ状態への影響なし。

## backlog task id

なし（運用記録のみ）

---
_Generated by [Claude Code](https://claude.ai/code/session_01922FLpCxKNWyQ7SoL5yGm2)_