### PR TITLE
coder-postgres 用 restic backup CronJob を追加 (T-0070)

### DIFF
--- a/apps/coder/kustomization.yaml
+++ b/apps/coder/kustomization.yaml
@@ -10,3 +10,5 @@ resources:
   - service.yaml
   - ingress.yaml
   - pvc-usage-cronjob.yaml
+  - restic-external-secret.yaml
+  - restic-backup-cronjob.yaml

--- a/apps/coder/restic-backup-cronjob.yaml
+++ b/apps/coder/restic-backup-cronjob.yaml
@@ -1,0 +1,178 @@
+# coder-postgres (Coder の制御プレーンDB: ユーザー・workspace・監査ログ) を restic で
+# Backblaze B2 へバックアップする (T-0070)。
+#
+# PostgreSQL は稼働中の PGDATA を restic で直接舐めてはいけない（サーバを止めない限り
+# 一貫したスナップショットにならないと PostgreSQL 公式ドキュメントが明記）。そのため
+# initContainer で `pg_dump -Fc`（カスタム形式、pg_restore で復元）を使いネットワーク経由で
+# 論理ダンプを取り、それを emptyDir 経由で本体の restic-backup コンテナが1スナップショットに
+# まとめる。initContainer には apps/coder/postgres.yaml と同じ postgres:17.10 イメージを使う
+# （pg_dump はサーバと同バージョンのクライアントを使うのが安全なため。新しい image pin を
+# 増やさず、ops/inventory.json の coder-postgres エントリの mirrors としてバージョン同期を追う）。
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: coder-restic-backup
+  namespace: coder
+spec:
+  schedule: "10 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 1800
+      template:
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          initContainers:
+            - name: pg-dump
+              image: postgres:17.10
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  PGPASSWORD="$POSTGRES_PASSWORD" pg_dump \
+                    -h coder-postgres -U coder -d coder \
+                    -Fc -f /staging/coder-postgres.dump
+              env:
+                - name: POSTGRES_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: coder-postgres-credentials
+                      key: password
+              # postgres 公式イメージのデフォルトユーザー (UID/GID 999, T-0058 で確認済み)。
+              # ネットワーク経由の pg_dump のみで PVC には触れないため DAC_READ_SEARCH は不要
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 999
+                runAsGroup: 999
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: 20m
+                  memory: 64Mi
+                limits:
+                  cpu: 300m
+              volumeMounts:
+                - name: staging
+                  mountPath: /staging
+          containers:
+            - name: restic-backup
+              image: restic/restic:0.19.1
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  restic snapshots >/dev/null 2>&1 || restic init
+                  restic backup /staging/coder-postgres.dump
+              env:
+                - name: RESTIC_B2_BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      name: coder-restic-credentials
+                      key: RESTIC_B2_BUCKET
+                # bucket 名の後ろの "coder-postgres" がリポジトリパスの区切り。vaultwarden/immich
+                # とは同じ bucket・同じ credential で末尾だけ変える設計 (T-0069 参照)
+                - name: RESTIC_REPOSITORY
+                  value: "b2:$(RESTIC_B2_BUCKET):coder-postgres"
+                - name: RESTIC_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: coder-restic-credentials
+                      key: RESTIC_PASSWORD
+                - name: B2_ACCOUNT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: coder-restic-credentials
+                      key: B2_ACCOUNT_ID
+                - name: B2_ACCOUNT_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: coder-restic-credentials
+                      key: B2_ACCOUNT_KEY
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+              volumeMounts:
+                - name: staging
+                  mountPath: /staging
+                  readOnly: true
+          volumes:
+            - name: staging
+              emptyDir: {}
+---
+# 週次で古い世代を刈る (restic forget --prune)。DB には触れないため pg_dump 不要。
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: coder-restic-retention
+  namespace: coder
+spec:
+  schedule: "10 4 * * 0"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 1800
+      template:
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          containers:
+            - name: restic-forget
+              image: restic/restic:0.19.1
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  restic snapshots >/dev/null 2>&1 || { echo "repository not initialized yet, skipping"; exit 0; }
+                  restic forget --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --prune
+              env:
+                - name: RESTIC_B2_BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      name: coder-restic-credentials
+                      key: RESTIC_B2_BUCKET
+                - name: RESTIC_REPOSITORY
+                  value: "b2:$(RESTIC_B2_BUCKET):coder-postgres"
+                - name: RESTIC_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: coder-restic-credentials
+                      key: RESTIC_PASSWORD
+                - name: B2_ACCOUNT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: coder-restic-credentials
+                      key: B2_ACCOUNT_ID
+                - name: B2_ACCOUNT_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: coder-restic-credentials
+                      key: B2_ACCOUNT_KEY
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m

--- a/apps/coder/restic-external-secret.yaml
+++ b/apps/coder/restic-external-secret.yaml
@@ -1,0 +1,36 @@
+# restic + Backblaze B2 の共通credential。vaultwarden(T-0069)/immich(T-0068)と同じDopplerキーを
+# このnamespaceのExternalSecretからも参照する（リポジトリパス末尾の "coder-postgres" だけが
+# restic-backup-cronjob.yaml 側でアプリ固有）。
+# Requires: ClusterSecretStore 'doppler' (apps/external-secrets/cluster-secret-store.yaml)
+# Requires: Doppler secrets（T-0067, ops/backlog.json 参照。バケット作成・キー発行は人間の作業）
+#   RESTIC_PASSWORD      — restic リポジトリの暗号化パスワード（vaultwarden と共通）
+#   RESTIC_B2_BUCKET      — Backblaze B2 のバケット名
+#   RESTIC_B2_ACCOUNT_ID  — B2 application key ID（append-only キー）
+#   RESTIC_B2_ACCOUNT_KEY — B2 application key（同上）
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: coder-restic-credentials
+  namespace: coder
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler
+  target:
+    name: coder-restic-credentials
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: RESTIC_PASSWORD
+      remoteRef:
+        key: RESTIC_PASSWORD
+    - secretKey: RESTIC_B2_BUCKET
+      remoteRef:
+        key: RESTIC_B2_BUCKET
+    - secretKey: B2_ACCOUNT_ID
+      remoteRef:
+        key: RESTIC_B2_ACCOUNT_ID
+    - secretKey: B2_ACCOUNT_KEY
+      remoteRef:
+        key: RESTIC_B2_ACCOUNT_KEY

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -40,7 +40,7 @@ issue #56 (2026-08-05 04:40:59) で人間から新方針: **PBS は重すぎる�
 | `immich-library` | 写真/動画原本・サムネイル・変換済み動画 | T-0068 |
 | `immich-postgres-data` | immich アセットメタデータ・CLIP埋め込み | T-0068 と同時（T-0029 側で拡張検討） |
 | `vaultwarden-data` | パスワードマネージャ本体（SQLite） | T-0069 |
-| `coder-postgres-data` | Coder 制御プレーン（ユーザー・workspace・監査ログ） | T-0070 |
+| `coder-postgres-data` | Coder 制御プレーン（ユーザー・workspace・監査ログ） | T-0070（実装済み・credential 登録待ち） |
 | `coder-<workspace-id>-home`（動的作成、`apps/coder/templates/personal/main.tf`） | workspace ごとの `/home/coder`（dotfiles・ghq clone 等） | **未起票**。T-0070 の対象外（別 PVC 群）のため、別途タスク化が必要 |
 
 ## vaultwarden の restic バックアップ (T-0069, 実装済み・credential 登録待ち)
@@ -68,10 +68,36 @@ issue #56 (2026-08-05 04:40:59) で人間から新方針: **PBS は重すぎる�
 - **復元時の注意**: 復元前に vaultwarden コンテナを止め、既存の `db.sqlite3-wal`/`db.sqlite3-shm`
   を削除してから復元後の `db.sqlite3` を配置すること（stale な WAL が残ると起動時に不整合を起こしうる）
 
+## coder-postgres の restic バックアップ (T-0070, 実装済み・credential 登録待ち)
+
+`apps/coder/restic-backup-cronjob.yaml` に2つの CronJob を実装した。vaultwarden（T-0069）と
+同じ設計思想（稼働中の DB を直接 restic に渡さず、一貫性のあるダンプを先に作る）を
+PostgreSQL 向けに適用したもの。
+
+- **`coder-restic-backup`**（毎日 03:10 UTC）: PostgreSQL は稼働中の PGDATA を restic で
+  直接舐めてはいけない（サーバを止めない限り一貫したスナップショットにならないと
+  PostgreSQL 公式ドキュメントが明記）ため、initContainer で `pg_dump -Fc`（カスタム形式、
+  `pg_restore` で復元）を使いネットワーク経由で論理ダンプを取り、emptyDir 経由で本体の
+  restic-backup コンテナが1スナップショットにまとめる。initContainer は
+  `apps/coder/postgres.yaml` と同じ `postgres:17.10` イメージを使う（pg_dump はサーバと
+  同バージョンのクライアントを使うのが安全なため。新しい image pin を増やさず、
+  `ops/inventory.json` の `coder-postgres` エントリの `mirrors` としてバージョン同期を
+  `check_version_sync.py` の CI で追う）。PVC には触れず DB へのネットワーク接続のみのため、
+  vaultwarden の sqlite-snapshot initContainerと違い `DAC_READ_SEARCH` は不要
+- **`coder-restic-retention`**（毎週日曜 04:10 UTC）: `restic forget --keep-daily 7
+  --keep-weekly 4 --keep-monthly 6 --prune`
+- 保存先は vaultwarden と同じ Backblaze B2 バケット、パス末尾のみ `coder-postgres`
+  （`b2:<bucket>:coder-postgres`）
+- **immich-postgres は対象外**（cloudnative-vectorchord の拡張を含めた扱いが別途要るため
+  T-0029 側で検討。上表参照）
+- **復元時の注意**: `pg_restore` で復元する前に coder-postgres の既存データをクリアするか
+  新規 DB に復元してから切り替えること。`coder server` は起動時に DB migration を自動適用する
+  ため、リストア後に起動する `coder` のバージョンと migration の整合を確認する
+
 ### 必要な Doppler 登録（T-0067）
 
-`apps/vaultwarden/restic-external-secret.yaml` が参照するキー。immich/coder-postgres 実装時も
-同じキーを使い回す想定（バケットを分けたい場合は別途相談）。
+`apps/vaultwarden/restic-external-secret.yaml` / `apps/coder/restic-external-secret.yaml` が
+参照するキー。immich 実装時も同じキーを使い回す想定（バケットを分けたい場合は別途相談）。
 
 | Doppler キー | 内容 |
 |---|---|

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 99,
+  "next_id": 100,
   "updated": "2026-08-05T10:30:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
@@ -1284,13 +1284,15 @@
       "title": "coder-postgres 用 backup CronJob（pg_dump + restic）を追加する",
       "kind": "feature",
       "risk": "medium",
-      "status": "todo",
+      "status": "done",
       "priority": 40,
       "why": "issue #56 (2026-08-05 04:40:59) の人間の新方針・構築セッションの調査。PostgreSQL は restic で PGDATA を直接舐めてはいけない（サーバを止めない限り一貫したスナップショットにならないと PostgreSQL 公式が明記）。`pg_dump` を使う。immich-postgres（cloudnative-vectorchord）は対象外（拡張本体を含めた扱いが別途要るため T-0029 側で検討）、まず coder-postgres（素の postgres）から着手する",
       "dod": "CronJob が `pg_dump` の出力を restic で T-0067 の保存先へ push する。retention は T-0068 と同じ方針。credential は既存の coder-postgres Secret を流用し、restic 側のキー名は T-0069 に揃える",
-      "notes": "run #48: issue #56 (10:29:40) の指摘を受け blocked → todo に変更。manifest の設計・記述は T-0067（credential 発行）を待たずに進められる",
+      "notes": "run #48: issue #56 (10:29:40) の指摘を受け blocked → todo に変更。manifest の設計・記述は T-0067（credential 発行）を待たずに進められる | run #49: T-0069 と同じ設計（稼働中 DB を直接 restic に渡さず、一貫性のあるダンプを先に作る）を PostgreSQL 向けに適用。initContainer で `pg_dump -Fc` を実行（apps/coder/postgres.yaml と同じ postgres:17.10 イメージを再利用、新規 image pin を増やさないため ops/inventory.json の coder-postgres エントリに mirrors を追加し check_version_sync.py に対応する GROUP を新設、意図的にタグをずらして CI が exit 1 になることを確認した）。restic-backup/retention コンテナは vaultwarden (T-0069) と同じく新規の memory limit は設定していない（CHARTER §4『縛る変更には実測が要る』、CPU limit のみ）ため cooldown 対象外と判断し auto-merge の対象とした。coder 自身の Deployment には触れておらず（新規 CronJob/ExternalSecret の追加のみ）、coder の可用性・観測経路には影響しない。実際に restic push が成功するかは T-0067（credential 登録）待ちのため T-0099 として確認タスクを別途起票した。done とするが、DoD の『保存先へ push する』が実際に成功したことの確認は T-0099 が担う",
       "refs": [
         "apps/coder/postgres.yaml",
+        "apps/coder/restic-backup-cronjob.yaml",
+        "apps/coder/restic-external-secret.yaml",
         "docs/backup.md"
       ],
       "created": "2026-08-05",
@@ -1786,16 +1788,36 @@
     {
       "id": "T-0098",
       "domain": "homelab",
-      "title": "restic/restic イメージタグの同一ファイル内重複を check_version_sync.py の監視対象に追加する",
+      "title": "restic/restic イメージタグの重複を check_version_sync.py の監視対象に追加する",
       "kind": "ci",
       "risk": "low",
       "status": "todo",
       "priority": 45,
-      "why": "T-0069 (#191) で apps/vaultwarden/restic-backup-cronjob.yaml に restic/restic:0.19.1 が2箇所（backup と retention の CronJob）独立して書かれた。T-0090/T-0082 と同型のドリフトパターンで、片方だけ更新した PR が CI green のまま素通りしうる",
-      "dod": "ops/check_version_sync.py の GROUPS に restic-backup-cronjob.yaml 内の2出現を追加する。意図的に値をずらして CI が exit 1 になることを確認する",
+      "why": "T-0069 (#191) で apps/vaultwarden/restic-backup-cronjob.yaml に restic/restic:0.19.1 が2箇所（backup と retention の CronJob）独立して書かれた。T-0090/T-0082 と同型のドリフトパターンで、片方だけ更新した PR が CI green のまま素通りしうる。T-0070 (run #49) で apps/coder/restic-backup-cronjob.yaml にも同じタグの CronJob が2つ追加され、ファイル間（vaultwarden ⇔ coder-postgres）でも同じ重複が生じている。対象はこの4箇所（vaultwarden の2つ、coder-postgres の2つ）に拡張する",
+      "dod": "ops/check_version_sync.py の GROUPS に apps/vaultwarden/restic-backup-cronjob.yaml と apps/coder/restic-backup-cronjob.yaml、それぞれ内部の2出現（backup/retention）を1つの GROUP として追加する（ops/inventory.json の vaultwarden-restic-image / coder-postgres-restic-image エントリの note も『未登録』の記述を削除して更新する）。意図的に値をずらして CI が exit 1 になることを確認する",
       "refs": [
         "ops/check_version_sync.py",
-        "apps/vaultwarden/restic-backup-cronjob.yaml"
+        "apps/vaultwarden/restic-backup-cronjob.yaml",
+        "apps/coder/restic-backup-cronjob.yaml",
+        "ops/inventory.json"
+      ],
+      "created": "2026-08-05",
+      "pr": null
+    },
+    {
+      "id": "T-0099",
+      "domain": "homelab",
+      "title": "T-0070（coder-postgres restic backup）が実際に成功しているか確認する",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "blocked",
+      "priority": 41,
+      "why": "T-0070 は manifest 実装のみで、実際に restic push が成功するかは T-0067 の credential 登録が終わるまで検証できない（このクラウドサンドボックスは k8s Job のログを見られない）。T-0097（vaultwarden 版）と同型",
+      "dod": "T-0067 の Doppler 登録後、次回以降の起動で ops-health-report の pod_issues に `coder-restic-backup`/`coder-restic-retention` の CronJob の Job が Failed で出ていないかを確認する。問題なければ docs/backup.md に成功日時を記録して done にする。継続的に失敗するなら症状を記録し、原因調査を新規タスクとして起票する",
+      "blocked_by": "T-0067（credential 登録。登録完了後の確認作業自体は autopilot が行う）",
+      "refs": [
+        "apps/coder/restic-backup-cronjob.yaml",
+        "docs/backup.md"
       ],
       "created": "2026-08-05",
       "pr": null

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1296,7 +1296,7 @@
         "docs/backup.md"
       ],
       "created": "2026-08-05",
-      "pr": null
+      "pr": 195
     },
     {
       "id": "T-0071",

--- a/ops/check_version_sync.py
+++ b/ops/check_version_sync.py
@@ -263,6 +263,17 @@ GROUPS = [
             )),
         ],
     },
+    {
+        "name": "coder-postgres image tag (T-0070, inventory: coder-postgres)",
+        "targets": [
+            ("apps/coder/postgres.yaml", lambda: extract_image_tag(
+                "apps/coder/postgres.yaml", "image: postgres:"
+            )),
+            ("apps/coder/restic-backup-cronjob.yaml", lambda: extract_image_tag(
+                "apps/coder/restic-backup-cronjob.yaml", "image: postgres:"
+            )),
+        ],
+    },
 ]
 
 

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,28 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 195,
+      "title": "coder-postgres 用 restic backup CronJob を追加 (T-0070)",
+      "url": "https://github.com/hikuohiku/homelab/pull/195",
+      "isDraft": false,
+      "createdAt": "2026-08-05T12:26:13Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "PENDING"
+        }
+      ],
+      "headRefName": "autopilot/T-0070-coder-postgres-restic-backup",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 194,
+      "title": "ops: run #48 の記録更新（journal・state・PRキャッシュ、T-0095 id重複の再発防止）",
+      "url": "https://github.com/hikuohiku/homelab/pull/194",
+      "mergedAt": "2026-08-05T12:03:09Z",
+      "headRefName": "autopilot/run48-record"
+    },
     {
       "number": 189,
       "title": "docs: apps/README.md の使われていない旧ブートストラップ手順を削除する (T-0095)",
@@ -413,13 +435,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/129",
       "mergedAt": "2026-08-05T02:25:20Z",
       "headRefName": "autopilot/T-0053-node01-ip-dedup"
-    },
-    {
-      "number": 128,
-      "title": "docs: secrets/ ディレクトリ記述を実態に合わせる (T-0052)",
-      "url": "https://github.com/hikuohiku/homelab/pull/128",
-      "mergedAt": "2026-08-05T02:20:35Z",
-      "headRefName": "autopilot/T-0052-secrets-path-doc-drift"
     }
   ]
 }

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -93,7 +93,8 @@
       "match": "image: postgres:",
       "upstream": "dockerhub:library/postgres",
       "policy": "auto",
-      "note": "メジャー更新 (17→18) はデータ移行が要るので必ず人間へ",
+      "mirrors": ["apps/coder/restic-backup-cronjob.yaml"],
+      "note": "メジャー更新 (17→18) はデータ移行が要るので必ず人間へ。T-0070 で restic-backup-cronjob.yaml の pg-dump initContainer にも同じイメージを採用（pg_dump はサーバと同バージョンのクライアントを使うのが安全なため）したため mirrors に追加。check_version_sync.py の GROUPS にも対応するエントリを追加済み",
       "observability_impact": "coder の DB。壊れると Coder が起動できず、coder と同じ影響（開発環境・観測経路の喪失）が出る（T-0058, issue #56 2026-08-05 03:26:49）"
     },
     {
@@ -351,8 +352,20 @@
       "match": "restic/restic:",
       "upstream": "github:restic/restic",
       "policy": "auto",
-      "note": "T-0069 で新設。同一ファイル内に vaultwarden-restic-backup（バックアップ）と vaultwarden-restic-retention（forget/prune）の2箇所で使用しており、check_version_sync.py の GROUPS には未登録（T-0098 で追う。手動更新時は2箇所とも揃えること）",
+      "note": "T-0069 で新設。同一ファイル内に vaultwarden-restic-backup（バックアップ）と vaultwarden-restic-retention（forget/prune）の2箇所で使用しており、check_version_sync.py の GROUPS には未登録（T-0098 で追う。手動更新時は2箇所とも揃えること）。T-0070 で apps/coder/restic-backup-cronjob.yaml にも同じタグを採用したためファイル間でも重複しているが、こちらも T-0098 の対象外（未登録）",
       "observability_impact": "vaultwarden の restic バックアップ・retention CronJob が使用。壊れるとバックアップが取れなくなるが vaultwarden 本体の可用性には影響しない"
+    },
+    {
+      "id": "coder-postgres-restic-image",
+      "kind": "image",
+      "name": "restic/restic (backup CronJob)",
+      "current": "0.19.1",
+      "file": "apps/coder/restic-backup-cronjob.yaml",
+      "match": "restic/restic:",
+      "upstream": "github:restic/restic",
+      "policy": "auto",
+      "note": "T-0070 で新設。vaultwarden-restic-image と同じタグ (0.19.1) を使う設計。同一ファイル内に coder-restic-backup と coder-restic-retention の2箇所、かつ vaultwarden-restic-image ともファイル間で重複しており、check_version_sync.py の GROUPS には未登録（T-0098 の対象を拡張して追う）",
+      "observability_impact": "coder-postgres の restic バックアップ・retention CronJob が使用。壊れるとバックアップが取れなくなるが coder 本体の可用性には影響しない"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1401,3 +1401,30 @@
   backup CronJob）・T-0098（restic image tag の CI 監視追加）。T-0097（T-0069 の実成功確認、
   T-0067 待ちで blocked）。T-0067（restic/B2 credential 登録、needs-human・priority 36）と
   T-0079（node01 実ディスク容量、needs-human・priority 1）は引き続き人間待ち
+
+## 2026-08-05 21:26 JST — run #49
+
+- 前回の中断: なし。オープン PR・autopilot ブランチとも無く中断なし
+- issue #56 に未読フィードバックなし（last_read 以降新規コメント0件、全68件を機械的に確認）
+- backlog の todo（優先度昇順）は T-0068（immich backup CronJob）・T-0070（coder-postgres
+  backup CronJob、ともに priority 40）・T-0096・T-0098（priority 45）だった。T-0070 に着手
+- やったこと: T-0070（coder-postgres 用 restic backup CronJob）を実装・完遂（#195）。
+  T-0069（vaultwarden）と同じ設計思想を PostgreSQL 向けに適用: PGDATA を直接 restic で
+  舐めず、initContainer で `pg_dump -Fc` を実行しネットワーク経由で一貫したダンプを取り、
+  emptyDir 経由で restic-backup コンテナが1スナップショットにまとめる。initContainer は
+  `apps/coder/postgres.yaml` と同じ `postgres:17.10` を再利用し、新規 image pin を増やさない
+  代わりに ops/inventory.json の coder-postgres エントリに mirrors を追加、
+  check_version_sync.py に対応する GROUP を新設（意図的にタグをずらして CI が exit 1 に
+  なることを手元で確認済み）。credential は vaultwarden と同じ Doppler キーを再利用するため
+  T-0067 への追加登録依頼は無し。restic-backup/retention コンテナは vaultwarden と同じく
+  新規の memory limit は設定していない（CHARTER §4、CPU limit のみ）ため縛る変更の
+  クールダウン対象外と判断
+- coder 自身の Deployment には触れていない（新規 CronJob/ExternalSecret の追加のみ）ため、
+  coder の可用性・観測経路への影響なしと PR に明記
+- 実際に restic push が成功するかは T-0067（credential 登録）待ちのため T-0099 として確認
+  タスクを分離。T-0098（restic image tag の重複監視）の対象を vaultwarden 分に加え
+  coder-postgres 分（ファイル間の重複含む）にも拡張した
+- 次の起動へ: backlog の todo は T-0068（immich backup CronJob）・T-0096・T-0098。
+  T-0097/T-0099（restic push の実成功確認、ともに T-0067 待ちで blocked）。T-0067（restic/B2
+  credential 登録、needs-human・priority 36）と T-0079（node01 実ディスク容量、needs-human・
+  priority 1）は引き続き人間待ち

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T11:56:00Z",
+  "updated": "2026-08-05T12:26:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -548,6 +548,16 @@
         191,
         192,
         189
+      ]
+    },
+    {
+      "n": 49,
+      "at": "2026-08-05T12:26:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。backlog の todo（priority昇順）から T-0070（coder-postgres 用 restic backup CronJob）に着手・完遂。T-0069（vaultwarden）と同じ設計思想を PostgreSQL 向けに適用し、initContainer の pg_dump -Fc でネットワーク経由の一貫したダンプを取ってから restic で Backblaze B2 へ push する。pg_dump の initContainer は apps/coder/postgres.yaml と同じ postgres:17.10 を再利用し、新規 image pin を増やさない代わりに ops/inventory.json の mirrors + check_version_sync.py の GROUP を新設した（意図的にタグをずらして CI が exit 1 になることを確認済み）。credential は vaultwarden と同じ Doppler キーを再利用するため追加の登録依頼は無し。実際の push 成功確認は T-0067（credential 登録）待ちのため T-0099 として分離、T-0098（restic image tag 重複監視）の対象を coder-postgres 分に拡張した（#195）",
+      "prs": [
+        195
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

coder-postgres（Coder 制御プレーンDB: ユーザー・workspace・監査ログ）を restic で Backblaze B2 へバックアップする CronJob を追加した（`apps/coder/restic-backup-cronjob.yaml`）。vaultwarden（T-0069, #191）と同じ保存先・credential 設計を踏襲。

- `coder-restic-backup`（毎日 03:10 UTC）: PostgreSQL は稼働中の PGDATA を restic で直接舐めてはいけない（サーバを止めない限り一貫したスナップショットにならないと公式が明記）ため、initContainer で `pg_dump -Fc`（カスタム形式）を実行しネットワーク経由で論理ダンプを取り、emptyDir 経由で restic-backup コンテナが1スナップショットにまとめる
- `coder-restic-retention`（毎週日曜 04:10 UTC）: `restic forget --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --prune`
- pg_dump の initContainer には `apps/coder/postgres.yaml` と同じ `postgres:17.10` を再利用（サーバと同バージョンのクライアントを使うのが安全なため）。新しい image pin を増やさない代わりに `ops/inventory.json` の `coder-postgres` エントリに `mirrors` を追加し、`ops/check_version_sync.py` に対応する GROUP を新設した（意図的にタグをずらして CI が exit 1 になることを手元で確認済み）
- credential は `apps/coder/restic-external-secret.yaml`（新規 ExternalSecret、`coder-restic-credentials`）経由。vaultwarden と同じ Doppler キー（`RESTIC_PASSWORD`/`RESTIC_B2_BUCKET`/`RESTIC_B2_ACCOUNT_ID`/`RESTIC_B2_ACCOUNT_KEY`）を再利用するため新規の Doppler 登録依頼は無い（T-0067 が既にカバー）
- `ops/backlog.json`: T-0070 を done に。実際に restic push が成功したかの確認は T-0067（credential 登録）待ちのため T-0099 として分離。T-0098（restic イメージタグの重複監視）の対象をこのファイルにも拡張

## 検証したこと

- `python3 ops/check_version_sync.py` → 0 error（意図的に `postgres:17.11` へ書き換えて exit 1 になることも確認済み）
- `python3 ops/validate.py` → 0 error
- YAML として2ファイルとも `yaml.safe_load_all` でパース可能なことを確認
- CI（`kustomize build` 等）は本 PR 側でも実行される

## 経路への影響

`apps/coder/` に新規リソース（CronJob 2つ、ExternalSecret 1つ）を追加するのみで、既存の `coder` Deployment（人間・構築セッションがこの homelab を観測・操作する経路の一つ）には触れない。ArgoCD sync でこの PR の内容が反映されても coder 自体の再起動は発生しない。

## ロールバック手順

このコミットを revert すれば CronJob/ExternalSecret ごと削除される。**pg_dump/restic は読み取り専用の操作**（coder-postgres の既存データには一切書き込まない）ため、revert してもデータ不整合は生じない。B2 側に蓄積された過去のバックアップスナップショットは revert 後も残るが、実害はない（次回の T-0072 の PBS 退役判断・保持ポリシー見直しまでは放置してよい）。

## backlog task id

T-0070（done）。関連: T-0067（credential 登録、needs-human）、T-0098（restic イメージタグ重複監視、拡張）、T-0099（新規、実際の push 成功確認）


---
_Generated by [Claude Code](https://claude.ai/code/session_01NnhgfZp6dd1exxFJwxunCd)_