### PR TITLE
immich-library 用 restic backup CronJob を追加 (T-0068)

### DIFF
--- a/apps/immich/kustomization.yaml
+++ b/apps/immich/kustomization.yaml
@@ -15,3 +15,5 @@ resources:
   - postgres.yaml
   - postgres-external-secret.yaml
   - pvc-usage-cronjob.yaml
+  - restic-external-secret.yaml
+  - restic-backup-cronjob.yaml

--- a/apps/immich/restic-backup-cronjob.yaml
+++ b/apps/immich/restic-backup-cronjob.yaml
@@ -1,0 +1,156 @@
+# immich-library PVC (写真/動画原本・サムネイル・変換済み動画 + immich 内蔵の日次DBダンプ) を
+# restic で Backblaze B2 へバックアップする (T-0068)。
+#
+# immich server v2.7.5 は "Database Backup" 機能がデフォルトで有効 (server/src/config.ts の
+# backup.database: enabled: true, cronExpression: 毎日02:00 UTC, keepLastAmount: 14) で、
+# pg_dump 相当のフルダンプ（拡張含む pgvector/embeddings テーブルも対象、除外なし）を
+# UPLOAD_LOCATION/backups/ 配下に *.sql.gz として書き出す。UPLOAD_LOCATION はこの
+# immich-library PVC そのもの (apps/immich/values.yaml の immich.persistence.library) のため、
+# このライブラリ PVC を restic で1本取るだけでライブラリ本体と DB ダンプが同時に取れる。
+# よって coder-postgres (T-0070) のような専用 pg_dump initContainer は不要。
+#
+# ダンプはトークンファイル (.tmp) への書き込み後に rename で確定するため (immich source:
+# database-backup.service.ts)、restic が走査中に immich 側の日次ダンプが完了していれば
+# 中途半端なファイルを掴むことはない。念のため本ジョブは immich のダンプ完了 (02:00 UTC 開始)
+# から45分後に開始する
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: immich-restic-backup
+  namespace: immich
+spec:
+  schedule: "45 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 3600
+      template:
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          containers:
+            - name: restic-backup
+              image: restic/restic:0.19.1
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  restic snapshots >/dev/null 2>&1 || restic init
+                  restic backup /mnt/immich-library
+              env:
+                - name: RESTIC_B2_BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-restic-credentials
+                      key: RESTIC_B2_BUCKET
+                # bucket 名の後ろの "immich" がリポジトリパスの区切り。vaultwarden/coder-postgres
+                # とは同じ bucket・同じ credential で末尾だけ変える設計 (T-0069/T-0070 参照)
+                - name: RESTIC_REPOSITORY
+                  value: "b2:$(RESTIC_B2_BUCKET):immich"
+                - name: RESTIC_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-restic-credentials
+                      key: RESTIC_PASSWORD
+                - name: B2_ACCOUNT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-restic-credentials
+                      key: B2_ACCOUNT_ID
+                - name: B2_ACCOUNT_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-restic-credentials
+                      key: B2_ACCOUNT_KEY
+              # immich-library PVC は immich-server コンテナの UID で書かれており、このジョブは
+              # 所有権に関わらず正しく読む必要があるため pvc-usage-cronjob.yaml (T-0080) と同じ
+              # 最小権限パターンを使う: 読み取り専用の権限チェック回避のみ許可しフルの root 権限は
+              # 持たせない。書き込みは readOnly: true でも構造的に禁止している
+              securityContext:
+                runAsUser: 0
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+                  add: ["DAC_READ_SEARCH"]
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+              volumeMounts:
+                - name: immich-library
+                  mountPath: /mnt/immich-library
+                  readOnly: true
+          volumes:
+            - name: immich-library
+              persistentVolumeClaim:
+                claimName: immich-library
+                readOnly: true
+---
+# 週次で古い世代を刈る (restic forget --prune)。PVC には触れないため readOnly マウント不要。
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: immich-restic-retention
+  namespace: immich
+spec:
+  schedule: "45 3 * * 0"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 1800
+      template:
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          containers:
+            - name: restic-forget
+              image: restic/restic:0.19.1
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  restic snapshots >/dev/null 2>&1 || { echo "repository not initialized yet, skipping"; exit 0; }
+                  restic forget --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --prune
+              env:
+                - name: RESTIC_B2_BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-restic-credentials
+                      key: RESTIC_B2_BUCKET
+                - name: RESTIC_REPOSITORY
+                  value: "b2:$(RESTIC_B2_BUCKET):immich"
+                - name: RESTIC_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-restic-credentials
+                      key: RESTIC_PASSWORD
+                - name: B2_ACCOUNT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-restic-credentials
+                      key: B2_ACCOUNT_ID
+                - name: B2_ACCOUNT_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: immich-restic-credentials
+                      key: B2_ACCOUNT_KEY
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m

--- a/apps/immich/restic-external-secret.yaml
+++ b/apps/immich/restic-external-secret.yaml
@@ -1,0 +1,36 @@
+# restic + Backblaze B2 の共通credential。vaultwarden(T-0069)/coder-postgres(T-0070)と同じ
+# Dopplerキーをこのnamespaceのexternal-secretからも参照する（リポジトリパス末尾の "immich" だけが
+# restic-backup-cronjob.yaml 側でアプリ固有）。
+# Requires: ClusterSecretStore 'doppler' (apps/external-secrets/cluster-secret-store.yaml)
+# Requires: Doppler secrets（T-0067, ops/backlog.json 参照。バケット作成・キー発行は人間の作業）
+#   RESTIC_PASSWORD      — restic リポジトリの暗号化パスワード（vaultwarden/coder-postgres と共通）
+#   RESTIC_B2_BUCKET      — Backblaze B2 のバケット名
+#   RESTIC_B2_ACCOUNT_ID  — B2 application key ID（append-only キー）
+#   RESTIC_B2_ACCOUNT_KEY — B2 application key（同上）
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: immich-restic-credentials
+  namespace: immich
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler
+  target:
+    name: immich-restic-credentials
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: RESTIC_PASSWORD
+      remoteRef:
+        key: RESTIC_PASSWORD
+    - secretKey: RESTIC_B2_BUCKET
+      remoteRef:
+        key: RESTIC_B2_BUCKET
+    - secretKey: B2_ACCOUNT_ID
+      remoteRef:
+        key: RESTIC_B2_ACCOUNT_ID
+    - secretKey: B2_ACCOUNT_KEY
+      remoteRef:
+        key: RESTIC_B2_ACCOUNT_KEY

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -37,8 +37,8 @@ issue #56 (2026-08-05 04:40:59) で人間から新方針: **PBS は重すぎる�
 
 | PVC / データ | 用途 | backup CronJob タスク |
 |---|---|---|
-| `immich-library` | 写真/動画原本・サムネイル・変換済み動画 | T-0068 |
-| `immich-postgres-data` | immich アセットメタデータ・CLIP埋め込み | T-0068 と同時（T-0029 側で拡張検討） |
+| `immich-library` | 写真/動画原本・サムネイル・変換済み動画 | T-0068（実装済み・credential 登録待ち） |
+| `immich-postgres-data` | immich アセットメタデータ・CLIP埋め込み | T-0068 の immich 内蔵日次DBダンプ（`immich-library` 内）で代替。生 PVC 自体のバックアップは対象外 |
 | `vaultwarden-data` | パスワードマネージャ本体（SQLite） | T-0069 |
 | `coder-postgres-data` | Coder 制御プレーン（ユーザー・workspace・監査ログ） | T-0070（実装済み・credential 登録待ち） |
 | `coder-<workspace-id>-home`（動的作成、`apps/coder/templates/personal/main.tf`） | workspace ごとの `/home/coder`（dotfiles・ghq clone 等） | **未起票**。T-0070 の対象外（別 PVC 群）のため、別途タスク化が必要 |
@@ -67,6 +67,31 @@ issue #56 (2026-08-05 04:40:59) で人間から新方針: **PBS は重すぎる�
   （T-0070）も同じ bucket・同じ credential でパス末尾だけ変える設計にした
 - **復元時の注意**: 復元前に vaultwarden コンテナを止め、既存の `db.sqlite3-wal`/`db.sqlite3-shm`
   を削除してから復元後の `db.sqlite3` を配置すること（stale な WAL が残ると起動時に不整合を起こしうる）
+
+## immich の restic バックアップ (T-0068, 実装済み・credential 登録待ち)
+
+`apps/immich/restic-backup-cronjob.yaml` に2つの CronJob を実装した。
+
+- immich server v2.7.5 には "Database Backup" 機能がデフォルトで有効（`server/src/config.ts`
+  の `backup.database`: `enabled: true`、毎日 02:00 UTC 実行、`keepLastAmount: 14`）で、
+  pg_dump 相当のフルダンプ（pgvector/embeddings テーブル含め除外なし）を `.tmp` へ書いてから
+  rename する形で `UPLOAD_LOCATION/backups/*.sql.gz` に確定させる（サブエージェントが v2.7.5
+  タグの実ソース `database-backup.service.ts` を直接確認して裏取り済み）。`UPLOAD_LOCATION`
+  は `immich-library` PVC そのもの（`apps/immich/values.yaml` の `immich.persistence.library`）
+  のため、**`immich-library` PVC を restic で1本取るだけでライブラリ本体と DB ダンプ
+  （immich-postgres-data 相当のデータを含む）が同時に取れる。** coder-postgres（T-0070）の
+  ような専用 `pg_dump` initContainer は不要だった
+- **`immich-restic-backup`**（毎日 02:45 UTC、immich 自身のダンプ完了を待つため45分後に開始）:
+  `immich-library` PVC をそのまま restic backup する
+- **`immich-restic-retention`**（毎週日曜 03:45 UTC）: `restic forget --keep-daily 7
+  --keep-weekly 4 --keep-monthly 6 --prune`
+- 保存先は vaultwarden/coder-postgres と同じ Backblaze B2 バケット、パス末尾のみ `immich`
+  （`b2:<bucket>:immich`）
+- **復元時の注意**: `immich-library` PVC をリストア後、`backups/` 配下の最新 `.sql.gz` を
+  `gunzip` して `psql`（`--clean --if-exists` 付きダンプなので既存オブジェクトを DROP しつつ
+  流し込める想定）で immich-postgres へ復元する。復元時のバージョン整合（ダンプ生成時の
+  immich/postgres バージョンとファイル名の `v{serverVersion}-pg{postgresVersion}` を突き合わせる）
+  を事前に確認すること
 
 ## coder-postgres の restic バックアップ (T-0070, 実装済み・credential 登録待ち)
 

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 100,
+  "next_id": 101,
   "updated": "2026-08-05T10:30:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
@@ -1248,13 +1248,14 @@
       "title": "immich 用 backup CronJob（日次内蔵DBダンプ + restic でライブラリごと）を追加する",
       "kind": "feature",
       "risk": "medium",
-      "status": "todo",
+      "status": "done",
       "priority": 40,
       "why": "issue #56 (2026-08-05 04:40:59) の人間の新方針・構築セッションの調査。immich は内蔵の日次 DB ダンプが UPLOAD_LOCATION/backups に 14 世代落ちる仕様のため、これが有効なら library PVC を restic で 1 本取るだけでライブラリと DB dump が同時に取れる（要確認）。稼働中に取る場合は DB dump が先、ファイルが後の順（DB に無い余分なファイルが残るだけで済む）",
       "dod": "immich の内蔵日次 DB ダンプが有効か確認したうえで、CronJob が restic でライブラリ PVC（DB dump を含む）を snapshot し、T-0067 の保存先へ push する。retention（`restic forget --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --prune` 相当）を週次で走らせる仕組みも同じ PR に含める。credential は Doppler → External Secrets 経由（キー名は T-0069 で決めた命名規則に揃える）",
-      "notes": "run #48: issue #56 (10:29:40) の指摘を受け blocked → todo に変更。manifest（CronJob・ExternalSecret）の設計・記述は T-0067（credential 発行）を待たずに進められる。実際に暗号化 push が成功するかの確認だけが T-0067 待ち",
+      "notes": "run #48: issue #56 (10:29:40) の指摘を受け blocked → todo に変更。manifest（CronJob・ExternalSecret）の設計・記述は T-0067（credential 発行）を待たずに進められる。実際に暗号化 push が成功するかの確認だけが T-0067 待ち | run #49: subagent に immich v2.7.5 タグの実ソースを直接確認させ、内蔵 Database Backup がデフォルト有効（毎日02:00 UTC, keepLastAmount:14）で UPLOAD_LOCATION（=immich-library PVC）配下に pg_dump 相当のフルダンプ（拡張含め除外なし）を .tmp→rename の atomic write で書き出すことを裏取りした。これにより immich-postgres-data の生 PVC を別途バックアップする必要は無いと確定（DoD の『要確認』が解消）。immich-library PVC を restic で1本取るだけの CronJob（coder-postgres のような pg_dump initContainer は不要）を実装。immich 自身のダンプ完了を待つため backup スケジュールを 02:45 UTC（ダンプ開始 02:00 の45分後）にした。restic-backup コンテナは pvc-usage-cronjob.yaml (T-0080) と同じ runAsUser:0 + DAC_READ_SEARCH パターンを再利用（PVC所有権が immich-server コンテナの UID のため）。実際に restic push が成功するかは T-0067（credential 登録）待ちのため T-0100 として確認タスクを別途起票した。done とするが、DoD の『保存先へ push する』が実際に成功したことの確認は T-0100 が担う",
       "refs": [
-        "apps/immich/",
+        "apps/immich/restic-backup-cronjob.yaml",
+        "apps/immich/restic-external-secret.yaml",
         "docs/backup.md"
       ],
       "created": "2026-08-05",
@@ -1793,13 +1794,32 @@
       "risk": "low",
       "status": "todo",
       "priority": 45,
-      "why": "T-0069 (#191) で apps/vaultwarden/restic-backup-cronjob.yaml に restic/restic:0.19.1 が2箇所（backup と retention の CronJob）独立して書かれた。T-0090/T-0082 と同型のドリフトパターンで、片方だけ更新した PR が CI green のまま素通りしうる。T-0070 (run #49) で apps/coder/restic-backup-cronjob.yaml にも同じタグの CronJob が2つ追加され、ファイル間（vaultwarden ⇔ coder-postgres）でも同じ重複が生じている。対象はこの4箇所（vaultwarden の2つ、coder-postgres の2つ）に拡張する",
-      "dod": "ops/check_version_sync.py の GROUPS に apps/vaultwarden/restic-backup-cronjob.yaml と apps/coder/restic-backup-cronjob.yaml、それぞれ内部の2出現（backup/retention）を1つの GROUP として追加する（ops/inventory.json の vaultwarden-restic-image / coder-postgres-restic-image エントリの note も『未登録』の記述を削除して更新する）。意図的に値をずらして CI が exit 1 になることを確認する",
+      "why": "T-0069 (#191) で apps/vaultwarden/restic-backup-cronjob.yaml に restic/restic:0.19.1 が2箇所（backup と retention の CronJob）独立して書かれた。T-0090/T-0082 と同型のドリフトパターンで、片方だけ更新した PR が CI green のまま素通りしうる。T-0070/T-0068 (run #49) で apps/coder/restic-backup-cronjob.yaml・apps/immich/restic-backup-cronjob.yaml にも同じタグの CronJob が2つずつ追加され、ファイル間（vaultwarden ⇔ coder-postgres ⇔ immich）でも同じ重複が生じている。対象はこの6箇所（3ファイル×backup/retentionの2つずつ）に拡張する",
+      "dod": "ops/check_version_sync.py の GROUPS に apps/vaultwarden/restic-backup-cronjob.yaml・apps/coder/restic-backup-cronjob.yaml・apps/immich/restic-backup-cronjob.yaml、それぞれ内部の2出現（backup/retention）を1つの GROUP として追加する（ops/inventory.json の vaultwarden-restic-image / coder-postgres-restic-image / immich-restic-image エントリの note も『未登録』の記述を削除して更新する）。意図的に値をずらして CI が exit 1 になることを確認する",
       "refs": [
         "ops/check_version_sync.py",
         "apps/vaultwarden/restic-backup-cronjob.yaml",
         "apps/coder/restic-backup-cronjob.yaml",
+        "apps/immich/restic-backup-cronjob.yaml",
         "ops/inventory.json"
+      ],
+      "created": "2026-08-05",
+      "pr": null
+    },
+    {
+      "id": "T-0100",
+      "domain": "homelab",
+      "title": "T-0068（immich restic backup）が実際に成功しているか確認する",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "blocked",
+      "priority": 41,
+      "why": "T-0068 は manifest 実装のみで、実際に restic push が成功するかは T-0067 の credential 登録が終わるまで検証できない（このクラウドサンドボックスは k8s Job のログを見られない）。T-0097（vaultwarden 版）/T-0099（coder-postgres 版）と同型",
+      "dod": "T-0067 の Doppler 登録後、次回以降の起動で ops-health-report の pod_issues に `immich-restic-backup`/`immich-restic-retention` の CronJob の Job が Failed で出ていないかを確認する。あわせて `immich-restic-backup` が想定どおり immich 自身の日次DBダンプ完了後（02:45 UTC）に走っていることも確認する。問題なければ docs/backup.md に成功日時を記録して done にする。継続的に失敗するなら症状を記録し、原因調査を新規タスクとして起票する",
+      "blocked_by": "T-0067（credential 登録。登録完了後の確認作業自体は autopilot が行う）",
+      "refs": [
+        "apps/immich/restic-backup-cronjob.yaml",
+        "docs/backup.md"
       ],
       "created": "2026-08-05",
       "pr": null

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1259,7 +1259,7 @@
         "docs/backup.md"
       ],
       "created": "2026-08-05",
-      "pr": null
+      "pr": 196
     },
     {
       "id": "T-0069",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,28 @@
 {
   "open": [
     {
-      "number": 195,
-      "title": "coder-postgres 用 restic backup CronJob を追加 (T-0070)",
-      "url": "https://github.com/hikuohiku/homelab/pull/195",
+      "number": 196,
+      "title": "immich-library 用 restic backup CronJob を追加 (T-0068)",
+      "url": "https://github.com/hikuohiku/homelab/pull/196",
       "isDraft": false,
-      "createdAt": "2026-08-05T12:26:13Z",
+      "createdAt": "2026-08-05T12:34:45Z",
       "statusCheckRollup": [
         {
           "conclusion": "PENDING"
         }
       ],
-      "headRefName": "autopilot/T-0070-coder-postgres-restic-backup",
+      "headRefName": "autopilot/T-0068-immich-restic-backup",
       "autoMergeRequest": null
     }
   ],
   "merged": [
+    {
+      "number": 195,
+      "title": "coder-postgres 用 restic backup CronJob を追加 (T-0070)",
+      "url": "https://github.com/hikuohiku/homelab/pull/195",
+      "mergedAt": "2026-08-05T12:28:53Z",
+      "headRefName": "autopilot/T-0070-coder-postgres-restic-backup"
+    },
     {
       "number": 194,
       "title": "ops: run #48 の記録更新（journal・state・PRキャッシュ、T-0095 id重複の再発防止）",
@@ -428,13 +435,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/130",
       "mergedAt": "2026-08-05T02:27:08Z",
       "headRefName": "autopilot/run22-wrapup"
-    },
-    {
-      "number": 129,
-      "title": "refactor(terraform): node01 の静的 IP の二重記述を locals に一本化する (T-0053)",
-      "url": "https://github.com/hikuohiku/homelab/pull/129",
-      "mergedAt": "2026-08-05T02:25:20Z",
-      "headRefName": "autopilot/T-0053-node01-ip-dedup"
     }
   ]
 }

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -352,7 +352,7 @@
       "match": "restic/restic:",
       "upstream": "github:restic/restic",
       "policy": "auto",
-      "note": "T-0069 で新設。同一ファイル内に vaultwarden-restic-backup（バックアップ）と vaultwarden-restic-retention（forget/prune）の2箇所で使用しており、check_version_sync.py の GROUPS には未登録（T-0098 で追う。手動更新時は2箇所とも揃えること）。T-0070 で apps/coder/restic-backup-cronjob.yaml にも同じタグを採用したためファイル間でも重複しているが、こちらも T-0098 の対象外（未登録）",
+      "note": "T-0069 で新設。同一ファイル内に vaultwarden-restic-backup（バックアップ）と vaultwarden-restic-retention（forget/prune）の2箇所で使用しており、check_version_sync.py の GROUPS には未登録（T-0098 で追う。手動更新時は2箇所とも揃えること）。T-0070/T-0068 で apps/coder/restic-backup-cronjob.yaml・apps/immich/restic-backup-cronjob.yaml にも同じタグを採用したためファイル間でも重複しているが、こちらも T-0098 の対象外（未登録）",
       "observability_impact": "vaultwarden の restic バックアップ・retention CronJob が使用。壊れるとバックアップが取れなくなるが vaultwarden 本体の可用性には影響しない"
     },
     {
@@ -364,8 +364,20 @@
       "match": "restic/restic:",
       "upstream": "github:restic/restic",
       "policy": "auto",
-      "note": "T-0070 で新設。vaultwarden-restic-image と同じタグ (0.19.1) を使う設計。同一ファイル内に coder-restic-backup と coder-restic-retention の2箇所、かつ vaultwarden-restic-image ともファイル間で重複しており、check_version_sync.py の GROUPS には未登録（T-0098 の対象を拡張して追う）",
+      "note": "T-0070 で新設。vaultwarden-restic-image と同じタグ (0.19.1) を使う設計。同一ファイル内に coder-restic-backup と coder-restic-retention の2箇所、かつ vaultwarden-restic-image / immich-restic-image ともファイル間で重複しており、check_version_sync.py の GROUPS には未登録（T-0098 の対象を拡張して追う）",
       "observability_impact": "coder-postgres の restic バックアップ・retention CronJob が使用。壊れるとバックアップが取れなくなるが coder 本体の可用性には影響しない"
+    },
+    {
+      "id": "immich-restic-image",
+      "kind": "image",
+      "name": "restic/restic (backup CronJob)",
+      "current": "0.19.1",
+      "file": "apps/immich/restic-backup-cronjob.yaml",
+      "match": "restic/restic:",
+      "upstream": "github:restic/restic",
+      "policy": "auto",
+      "note": "T-0068 で新設。vaultwarden-restic-image / coder-postgres-restic-image と同じタグ (0.19.1) を使う設計。同一ファイル内に immich-restic-backup と immich-restic-retention の2箇所、かつ他2ファイルともファイル間で重複しており、check_version_sync.py の GROUPS には未登録（T-0098 の対象を拡張して追う）",
+      "observability_impact": "immich の restic バックアップ・retention CronJob が使用。壊れるとバックアップが取れなくなるが immich 本体の可用性には影響しない"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1424,7 +1424,18 @@
 - 実際に restic push が成功するかは T-0067（credential 登録）待ちのため T-0099 として確認
   タスクを分離。T-0098（restic image tag の重複監視）の対象を vaultwarden 分に加え
   coder-postgres 分（ファイル間の重複含む）にも拡張した
-- 次の起動へ: backlog の todo は T-0068（immich backup CronJob）・T-0096・T-0098。
-  T-0097/T-0099（restic push の実成功確認、ともに T-0067 待ちで blocked）。T-0067（restic/B2
-  credential 登録、needs-human・priority 36）と T-0079（node01 実ディスク容量、needs-human・
-  priority 1）は引き続き人間待ち
+- 続けて T-0068（immich 用 restic backup CronJob）に着手・完遂（#196）。着手前に DoD の
+  「immich 内蔵の日次 DB ダンプが有効か確認する」を subagent に immich v2.7.5 タグの実ソース
+  （`server/src/config.ts`/`database-backup.service.ts`）で裏取りさせた: デフォルト有効
+  （毎日02:00 UTC, keepLastAmount:14）で `UPLOAD_LOCATION`（=`immich-library` PVC）配下に
+  pg_dump 相当のフルダンプ（拡張含め除外なし）を `.tmp`→rename の atomic write で書き出す。
+  これにより `immich-library` PVC を restic で1本取るだけでライブラリ本体とDBダンプが同時に
+  取れると確定し、coder-postgres のような専用 pg_dump initContainer は不要と判断。immich
+  自身のダンプ完了を待つため backup スケジュールを 02:45 UTC にした。restic-backup コンテナは
+  pvc-usage-cronjob.yaml (T-0080) と同じ runAsUser:0 + DAC_READ_SEARCH パターンを再利用
+- T-0098（restic image tag の重複監視）の対象を vaultwarden/coder-postgres に加え immich 分
+  にも拡張（3ファイル×2箇所=6箇所）。T-0100（T-0068 の実成功確認、T-0067 待ちで blocked）を
+  新規起票
+- 次の起動へ: backlog の todo は T-0096・T-0098。T-0097/T-0099/T-0100（restic push の実成功
+  確認、いずれも T-0067 待ちで blocked）。T-0067（restic/B2 credential 登録、needs-human・
+  priority 36）と T-0079（node01 実ディスク容量、needs-human・priority 1）は引き続き人間待ち

--- a/ops/state.json
+++ b/ops/state.json
@@ -555,9 +555,10 @@
       "at": "2026-08-05T12:26:00Z",
       "kind": "scheduled",
       "by": "cloud routine",
-      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。backlog の todo（priority昇順）から T-0070（coder-postgres 用 restic backup CronJob）に着手・完遂。T-0069（vaultwarden）と同じ設計思想を PostgreSQL 向けに適用し、initContainer の pg_dump -Fc でネットワーク経由の一貫したダンプを取ってから restic で Backblaze B2 へ push する。pg_dump の initContainer は apps/coder/postgres.yaml と同じ postgres:17.10 を再利用し、新規 image pin を増やさない代わりに ops/inventory.json の mirrors + check_version_sync.py の GROUP を新設した（意図的にタグをずらして CI が exit 1 になることを確認済み）。credential は vaultwarden と同じ Doppler キーを再利用するため追加の登録依頼は無し。実際の push 成功確認は T-0067（credential 登録）待ちのため T-0099 として分離、T-0098（restic image tag 重複監視）の対象を coder-postgres 分に拡張した（#195）",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。backlog の todo（priority昇順）から T-0070（coder-postgres 用 restic backup CronJob）に着手・完遂。T-0069（vaultwarden）と同じ設計思想を PostgreSQL 向けに適用し、initContainer の pg_dump -Fc でネットワーク経由の一貫したダンプを取ってから restic で Backblaze B2 へ push する。pg_dump の initContainer は apps/coder/postgres.yaml と同じ postgres:17.10 を再利用し、新規 image pin を増やさない代わりに ops/inventory.json の mirrors + check_version_sync.py の GROUP を新設した（意図的にタグをずらして CI が exit 1 になることを確認済み）。credential は vaultwarden と同じ Doppler キーを再利用するため追加の登録依頼は無し。実際の push 成功確認は T-0067（credential 登録）待ちのため T-0099 として分離、T-0098（restic image tag 重複監視）の対象を coder-postgres 分に拡張した（#195, merged）。続けて T-0068（immich 用 restic backup CronJob）に着手・完遂。着手前に subagent へ immich v2.7.5 タグの実ソース確認を依頼し、内蔵 Database Backup がデフォルト有効（毎日02:00 UTC, keepLastAmount:14）で immich-library PVC 内に pg_dump 相当のフルダンプを atomic write で書き出すことを裏取り。これにより immich-library PVC を restic で1本取るだけでライブラリ本体とDBダンプが同時に取れると確定し、coder-postgres のような専用 pg_dump initContainer は不要と判断した。immich 自身のダンプ完了を待つため backup スケジュールを 02:45 UTC にした。T-0098 の対象を immich 分（3ファイル×2箇所=6箇所）にも拡張し、T-0100（実成功確認、T-0067 待ち）を新規起票した（#196）",
       "prs": [
-        195
+        195,
+        196
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

immich-library PVC（写真/動画原本・サムネイル・変換済み動画）を restic で Backblaze B2 へバックアップする CronJob を追加した（`apps/immich/restic-backup-cronjob.yaml`）。vaultwarden（T-0069, #191）・coder-postgres（T-0070, #195）と同じ保存先・credential 設計を踏襲。

- **事前確認**: immich server v2.7.5 タグの実ソース（`server/src/config.ts`、`database-backup.service.ts`）を直接確認し、内蔵 "Database Backup" 機能がデフォルト有効（毎日 02:00 UTC, `keepLastAmount: 14`）で、pg_dump 相当のフルダンプ（pgvector/embeddings テーブル含め除外なし）を `.tmp` へ書いてから rename する atomic write で `UPLOAD_LOCATION/backups/*.sql.gz` に確定させることを裏取りした。`UPLOAD_LOCATION` は `immich-library` PVC そのもの（`apps/immich/values.yaml` の `immich.persistence.library`）のため、**このライブラリ PVC を restic で1本取るだけでライブラリ本体と DB ダンプが同時に取れる**。coder-postgres（T-0070）のような専用 `pg_dump` initContainer は不要と判断した
- `immich-restic-backup`（毎日 02:45 UTC、immich 自身のダンプ開始 02:00 の45分後）: `immich-library` PVC をそのまま restic backup する
- `immich-restic-retention`（毎週日曜 03:45 UTC）: `restic forget --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --prune`
- restic-backup コンテナは `apps/immich/pvc-usage-cronjob.yaml`（T-0080）と同じ `runAsUser: 0` + `capabilities.add: [DAC_READ_SEARCH]` パターンを再利用（PVC の所有権が immich-server コンテナの UID のため、フルの root 権限は持たせない）
- credential は `apps/immich/restic-external-secret.yaml`（新規 ExternalSecret、`immich-restic-credentials`）経由。vaultwarden/coder-postgres と同じ Doppler キーを再利用するため新規の Doppler 登録依頼は無い（T-0067 が既にカバー）
- `ops/backlog.json`: T-0068 を done に。実際に restic push が成功したかの確認は T-0067（credential 登録）待ちのため T-0100 として分離。T-0098（restic イメージタグの重複監視）の対象をこのファイルにも拡張（3ファイル×2箇所=6箇所に）

## 検証したこと

- subagent に immich v2.7.5 タグの GitHub 実ソースを直接確認させ、上記の Database Backup の挙動（デフォルト有効・書き込み先・内容・atomic write・オンデマンドトリガー方法）を裏取りした
- `python3 ops/validate.py` → 0 error
- YAML として2ファイルとも `yaml.safe_load_all` でパース可能なことを確認
- CI（`kustomize build` 等）は本 PR 側でも実行される

## 経路への影響

`apps/immich/` に新規リソース（CronJob 2つ、ExternalSecret 1つ）を追加するのみで、既存の immich Deployment には触れない。ArgoCD sync でこの PR の内容が反映されても immich 自体の再起動は発生しない。immich は「homelab を観測・操作する経路」には該当しない（写真管理アプリであり autopilot/人間の作業経路ではない）。

## ロールバック手順

このコミットを revert すれば CronJob/ExternalSecret ごと削除される。**restic backup は読み取り専用の操作**（immich-library の既存データには一切書き込まない）ため、revert してもデータ不整合は生じない。B2 側に蓄積された過去のバックアップスナップショットは revert 後も残るが、実害はない。

## backlog task id

T-0068（done）。関連: T-0067（credential 登録、needs-human）、T-0098（restic イメージタグ重複監視、拡張）、T-0100（新規、実際の push 成功確認）


---
_Generated by [Claude Code](https://claude.ai/code/session_01NnhgfZp6dd1exxFJwxunCd)_