### PR TITLE
restic/restic イメージタグの重複を check_version_sync.py の監視対象に追加 (T-0098)

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1792,7 +1792,7 @@
       "title": "restic/restic イメージタグの重複を check_version_sync.py の監視対象に追加する",
       "kind": "ci",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 45,
       "why": "T-0069 (#191) で apps/vaultwarden/restic-backup-cronjob.yaml に restic/restic:0.19.1 が2箇所（backup と retention の CronJob）独立して書かれた。T-0090/T-0082 と同型のドリフトパターンで、片方だけ更新した PR が CI green のまま素通りしうる。T-0070/T-0068 (run #49) で apps/coder/restic-backup-cronjob.yaml・apps/immich/restic-backup-cronjob.yaml にも同じタグの CronJob が2つずつ追加され、ファイル間（vaultwarden ⇔ coder-postgres ⇔ immich）でも同じ重複が生じている。対象はこの6箇所（3ファイル×backup/retentionの2つずつ）に拡張する",
       "dod": "ops/check_version_sync.py の GROUPS に apps/vaultwarden/restic-backup-cronjob.yaml・apps/coder/restic-backup-cronjob.yaml・apps/immich/restic-backup-cronjob.yaml、それぞれ内部の2出現（backup/retention）を1つの GROUP として追加する（ops/inventory.json の vaultwarden-restic-image / coder-postgres-restic-image / immich-restic-image エントリの note も『未登録』の記述を削除して更新する）。意図的に値をずらして CI が exit 1 になることを確認する",
@@ -1804,6 +1804,7 @@
         "ops/inventory.json"
       ],
       "created": "2026-08-05",
+      "notes": "run #49: extract_all_action_tags と同じ考え方の extract_image_tag_all を新設（1ファイル内の複数出現が全て一致することを検証したうえで値を返す）。3ファイル（vaultwarden/coder/immich の restic-backup-cronjob.yaml）を1つの GROUP にまとめ、ファイル内・ファイル間の両方の不一致を検出できることを確認した: (1) vaultwarden ファイル内で backup/retention の2箇所だけ値をずらす→ファイル内不一致で exit 1、(2) coder ファイル全体を別バージョンにずらす→ファイル間不一致で exit 1。いずれも復元後 exit 0 に戻ることを確認。ops/inventory.json の3エントリの note から『未登録』の記述を削除して更新した",
       "pr": null
     },
     {

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1805,7 +1805,7 @@
       ],
       "created": "2026-08-05",
       "notes": "run #49: extract_all_action_tags と同じ考え方の extract_image_tag_all を新設（1ファイル内の複数出現が全て一致することを検証したうえで値を返す）。3ファイル（vaultwarden/coder/immich の restic-backup-cronjob.yaml）を1つの GROUP にまとめ、ファイル内・ファイル間の両方の不一致を検出できることを確認した: (1) vaultwarden ファイル内で backup/retention の2箇所だけ値をずらす→ファイル内不一致で exit 1、(2) coder ファイル全体を別バージョンにずらす→ファイル間不一致で exit 1。いずれも復元後 exit 0 に戻ることを確認。ops/inventory.json の3エントリの note から『未登録』の記述を削除して更新した",
-      "pr": null
+      "pr": 197
     },
     {
       "id": "T-0100",

--- a/ops/check_version_sync.py
+++ b/ops/check_version_sync.py
@@ -21,6 +21,20 @@ def read(path: str) -> str:
     return (ROOT / path).read_text()
 
 
+def extract_image_tag_all(path: str, image_prefix: str) -> str:
+    """`<image_prefix><tag>` を全箇所拾い、ファイル内で全て一致することを確認して返す。
+    1 ファイルに同じイメージが複数回（例: backup CronJob と retention CronJob）出てくる
+    場合でも、ファイル内の割れをそのまま見逃さない（extract_all_action_tags と同じ考え方）。"""
+    text = read(path)
+    matches = re.findall(rf"{re.escape(image_prefix)}(\S+)", text)
+    if not matches:
+        raise ValueError(f"{path}: {image_prefix} が見つからない")
+    uniq = sorted(set(matches))
+    if len(uniq) > 1:
+        raise ValueError(f"{path}: {image_prefix} のタグがファイル内で不一致 ({uniq})")
+    return uniq[0]
+
+
 def extract_yaml_top_level_block(path: str, top_key: str) -> str:
     """トップレベルキー（0-indent の `<top_key>:`）から、次のトップレベルキーまたは末尾までの
     範囲をブロックとして返す。同じファイル内に複数の image/tag ペアがあっても、無関係な
@@ -271,6 +285,20 @@ GROUPS = [
             )),
             ("apps/coder/restic-backup-cronjob.yaml", lambda: extract_image_tag(
                 "apps/coder/restic-backup-cronjob.yaml", "image: postgres:"
+            )),
+        ],
+    },
+    {
+        "name": "restic/restic backup CronJob image tag (T-0098, inventory: vaultwarden-restic-image/coder-postgres-restic-image/immich-restic-image)",
+        "targets": [
+            ("apps/vaultwarden/restic-backup-cronjob.yaml", lambda: extract_image_tag_all(
+                "apps/vaultwarden/restic-backup-cronjob.yaml", "image: restic/restic:"
+            )),
+            ("apps/coder/restic-backup-cronjob.yaml", lambda: extract_image_tag_all(
+                "apps/coder/restic-backup-cronjob.yaml", "image: restic/restic:"
+            )),
+            ("apps/immich/restic-backup-cronjob.yaml", lambda: extract_image_tag_all(
+                "apps/immich/restic-backup-cronjob.yaml", "image: restic/restic:"
             )),
         ],
     },

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,28 @@
 {
   "open": [
     {
-      "number": 196,
-      "title": "immich-library 用 restic backup CronJob を追加 (T-0068)",
-      "url": "https://github.com/hikuohiku/homelab/pull/196",
+      "number": 197,
+      "title": "restic/restic イメージタグの重複を check_version_sync.py の監視対象に追加 (T-0098)",
+      "url": "https://github.com/hikuohiku/homelab/pull/197",
       "isDraft": false,
-      "createdAt": "2026-08-05T12:34:45Z",
+      "createdAt": "2026-08-05T12:39:01Z",
       "statusCheckRollup": [
         {
           "conclusion": "PENDING"
         }
       ],
-      "headRefName": "autopilot/T-0068-immich-restic-backup",
+      "headRefName": "autopilot/T-0098-restic-image-tag-ci",
       "autoMergeRequest": null
     }
   ],
   "merged": [
+    {
+      "number": 196,
+      "title": "immich-library 用 restic backup CronJob を追加 (T-0068)",
+      "url": "https://github.com/hikuohiku/homelab/pull/196",
+      "mergedAt": "2026-08-05T12:37:04Z",
+      "headRefName": "autopilot/T-0068-immich-restic-backup"
+    },
     {
       "number": 195,
       "title": "coder-postgres 用 restic backup CronJob を追加 (T-0070)",
@@ -428,13 +435,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/131",
       "mergedAt": "2026-08-05T02:48:13Z",
       "headRefName": "autopilot/T-0054-gitignore-secrets-path"
-    },
-    {
-      "number": 130,
-      "title": "ops: run #22 の記録をまとめ、ダッシュボードを再生成する",
-      "url": "https://github.com/hikuohiku/homelab/pull/130",
-      "mergedAt": "2026-08-05T02:27:08Z",
-      "headRefName": "autopilot/run22-wrapup"
     }
   ]
 }

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -352,7 +352,7 @@
       "match": "restic/restic:",
       "upstream": "github:restic/restic",
       "policy": "auto",
-      "note": "T-0069 で新設。同一ファイル内に vaultwarden-restic-backup（バックアップ）と vaultwarden-restic-retention（forget/prune）の2箇所で使用しており、check_version_sync.py の GROUPS には未登録（T-0098 で追う。手動更新時は2箇所とも揃えること）。T-0070/T-0068 で apps/coder/restic-backup-cronjob.yaml・apps/immich/restic-backup-cronjob.yaml にも同じタグを採用したためファイル間でも重複しているが、こちらも T-0098 の対象外（未登録）",
+      "note": "T-0069 で新設。同一ファイル内に vaultwarden-restic-backup（バックアップ）と vaultwarden-restic-retention（forget/prune）の2箇所で使用。T-0070/T-0068 で apps/coder/restic-backup-cronjob.yaml・apps/immich/restic-backup-cronjob.yaml にも同じタグを採用しファイル間でも重複していたが、T-0098 (run #49) で check_version_sync.py の GROUPS にファイル内・ファイル間の両方を1つの GROUP としてまとめて登録済み（extract_image_tag_all で各ファイル内の一致を検証したうえで3ファイル間の一致も検証する）。手動更新時は3ファイル×2箇所＝6箇所とも揃えること",
       "observability_impact": "vaultwarden の restic バックアップ・retention CronJob が使用。壊れるとバックアップが取れなくなるが vaultwarden 本体の可用性には影響しない"
     },
     {
@@ -364,7 +364,7 @@
       "match": "restic/restic:",
       "upstream": "github:restic/restic",
       "policy": "auto",
-      "note": "T-0070 で新設。vaultwarden-restic-image と同じタグ (0.19.1) を使う設計。同一ファイル内に coder-restic-backup と coder-restic-retention の2箇所、かつ vaultwarden-restic-image / immich-restic-image ともファイル間で重複しており、check_version_sync.py の GROUPS には未登録（T-0098 の対象を拡張して追う）",
+      "note": "T-0070 で新設。vaultwarden-restic-image と同じタグ (0.19.1) を使う設計。同一ファイル内に coder-restic-backup と coder-restic-retention の2箇所、かつ vaultwarden-restic-image / immich-restic-image ともファイル間で重複しているが、T-0098 (run #49) で check_version_sync.py の GROUPS に登録済み（vaultwarden-restic-image の note 参照）",
       "observability_impact": "coder-postgres の restic バックアップ・retention CronJob が使用。壊れるとバックアップが取れなくなるが coder 本体の可用性には影響しない"
     },
     {
@@ -376,7 +376,7 @@
       "match": "restic/restic:",
       "upstream": "github:restic/restic",
       "policy": "auto",
-      "note": "T-0068 で新設。vaultwarden-restic-image / coder-postgres-restic-image と同じタグ (0.19.1) を使う設計。同一ファイル内に immich-restic-backup と immich-restic-retention の2箇所、かつ他2ファイルともファイル間で重複しており、check_version_sync.py の GROUPS には未登録（T-0098 の対象を拡張して追う）",
+      "note": "T-0068 で新設。vaultwarden-restic-image / coder-postgres-restic-image と同じタグ (0.19.1) を使う設計。同一ファイル内に immich-restic-backup と immich-restic-retention の2箇所、かつ他2ファイルともファイル間で重複しているが、T-0098 (run #49) で check_version_sync.py の GROUPS に登録済み（vaultwarden-restic-image の note 参照）",
       "observability_impact": "immich の restic バックアップ・retention CronJob が使用。壊れるとバックアップが取れなくなるが immich 本体の可用性には影響しない"
     }
   ]

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1436,6 +1436,11 @@
 - T-0098（restic image tag の重複監視）の対象を vaultwarden/coder-postgres に加え immich 分
   にも拡張（3ファイル×2箇所=6箇所）。T-0100（T-0068 の実成功確認、T-0067 待ちで blocked）を
   新規起票
-- 次の起動へ: backlog の todo は T-0096・T-0098。T-0097/T-0099/T-0100（restic push の実成功
-  確認、いずれも T-0067 待ちで blocked）。T-0067（restic/B2 credential 登録、needs-human・
-  priority 36）と T-0079（node01 実ディスク容量、needs-human・priority 1）は引き続き人間待ち
+- 続けて T-0098（restic/restic イメージタグの重複を check_version_sync.py の監視対象に追加）
+  に着手・完遂（#197）。extract_all_action_tags と同じ考え方の extract_image_tag_all を新設し、
+  vaultwarden/coder-postgres/immich の3ファイルを1つの GROUP にまとめた。ファイル内不一致
+  （backup/retention の片方だけずらす）とファイル間不一致（1ファイル全体を別バージョンにずらす）
+  の両方を検出できることを実地で確認した
+- 次の起動へ: backlog の todo は T-0096 のみ。T-0097/T-0099/T-0100（restic push の実成功確認、
+  いずれも T-0067 待ちで blocked）。T-0067（restic/B2 credential 登録、needs-human・priority 36）
+  と T-0079（node01 実ディスク容量、needs-human・priority 1）は引き続き人間待ち

--- a/ops/state.json
+++ b/ops/state.json
@@ -555,10 +555,11 @@
       "at": "2026-08-05T12:26:00Z",
       "kind": "scheduled",
       "by": "cloud routine",
-      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。backlog の todo（priority昇順）から T-0070（coder-postgres 用 restic backup CronJob）に着手・完遂。T-0069（vaultwarden）と同じ設計思想を PostgreSQL 向けに適用し、initContainer の pg_dump -Fc でネットワーク経由の一貫したダンプを取ってから restic で Backblaze B2 へ push する。pg_dump の initContainer は apps/coder/postgres.yaml と同じ postgres:17.10 を再利用し、新規 image pin を増やさない代わりに ops/inventory.json の mirrors + check_version_sync.py の GROUP を新設した（意図的にタグをずらして CI が exit 1 になることを確認済み）。credential は vaultwarden と同じ Doppler キーを再利用するため追加の登録依頼は無し。実際の push 成功確認は T-0067（credential 登録）待ちのため T-0099 として分離、T-0098（restic image tag 重複監視）の対象を coder-postgres 分に拡張した（#195, merged）。続けて T-0068（immich 用 restic backup CronJob）に着手・完遂。着手前に subagent へ immich v2.7.5 タグの実ソース確認を依頼し、内蔵 Database Backup がデフォルト有効（毎日02:00 UTC, keepLastAmount:14）で immich-library PVC 内に pg_dump 相当のフルダンプを atomic write で書き出すことを裏取り。これにより immich-library PVC を restic で1本取るだけでライブラリ本体とDBダンプが同時に取れると確定し、coder-postgres のような専用 pg_dump initContainer は不要と判断した。immich 自身のダンプ完了を待つため backup スケジュールを 02:45 UTC にした。T-0098 の対象を immich 分（3ファイル×2箇所=6箇所）にも拡張し、T-0100（実成功確認、T-0067 待ち）を新規起票した（#196）",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。backlog の todo（priority昇順）から T-0070（coder-postgres 用 restic backup CronJob）に着手・完遂。T-0069（vaultwarden）と同じ設計思想を PostgreSQL 向けに適用し、initContainer の pg_dump -Fc でネットワーク経由の一貫したダンプを取ってから restic で Backblaze B2 へ push する。pg_dump の initContainer は apps/coder/postgres.yaml と同じ postgres:17.10 を再利用し、新規 image pin を増やさない代わりに ops/inventory.json の mirrors + check_version_sync.py の GROUP を新設した（意図的にタグをずらして CI が exit 1 になることを確認済み）。credential は vaultwarden と同じ Doppler キーを再利用するため追加の登録依頼は無し。実際の push 成功確認は T-0067（credential 登録）待ちのため T-0099 として分離、T-0098（restic image tag 重複監視）の対象を coder-postgres 分に拡張した（#195, merged）。続けて T-0068（immich 用 restic backup CronJob）に着手・完遂。着手前に subagent へ immich v2.7.5 タグの実ソース確認を依頼し、内蔵 Database Backup がデフォルト有効（毎日02:00 UTC, keepLastAmount:14）で immich-library PVC 内に pg_dump 相当のフルダンプを atomic write で書き出すことを裏取り。これにより immich-library PVC を restic で1本取るだけでライブラリ本体とDBダンプが同時に取れると確定し、coder-postgres のような専用 pg_dump initContainer は不要と判断した。immich 自身のダンプ完了を待つため backup スケジュールを 02:45 UTC にした。T-0098 の対象を immich 分（3ファイル×2箇所=6箇所）にも拡張し、T-0100（実成功確認、T-0067 待ち）を新規起票した（#196, merged）。続けて T-0098（restic/restic イメージタグ重複の CI 監視）を完遂: extract_all_action_tags と同じ考え方の extract_image_tag_all を新設し、vaultwarden/coder-postgres/immich の3ファイルを1つの GROUP にまとめた。ファイル内不一致・ファイル間不一致の両方を意図的に発生させて検出できることを確認済み（#197）",
       "prs": [
         195,
-        196
+        196,
+        197
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

vaultwarden（T-0069, #191）・coder-postgres（T-0070, #195）・immich（T-0068, #196）の `restic-backup-cronjob.yaml` は、それぞれ backup/retention の2つの CronJob で `restic/restic:0.19.1` を独立に記述しており、かつ3ファイル間でも同じタグを使う設計だった。片方（またはどれか1ファイル）だけ更新した PR が CI green のまま素通りしうるドリフトパターンのため、`ops/check_version_sync.py` の監視対象に追加した。

- `extract_all_action_tags`（T-0043、1ファイル内の複数 `uses:` が全て一致することを検証）と同じ考え方の `extract_image_tag_all` を新設し、`image: restic/restic:` の全出現がファイル内で一致することを検証したうえで値を返すようにした
- 3ファイル（vaultwarden/coder/immich の `restic-backup-cronjob.yaml`）を1つの GROUP にまとめ、ファイル内・ファイル間の両方の不一致を1回のチェックで検出する
- `ops/inventory.json` の3エントリ（`vaultwarden-restic-image`/`coder-postgres-restic-image`/`immich-restic-image`）の note から「未登録」の記述を削除して更新

## 検証したこと

- `python3 ops/check_version_sync.py` → 0 error
- 意図的に (1) vaultwarden ファイル内の backup/retention の片方だけタグをずらす → ファイル内不一致で exit 1、(2) coder ファイル全体を別バージョンにずらす → ファイル間不一致で exit 1、のいずれも確認し、復元後 exit 0 に戻ることを確認
- `python3 ops/validate.py` → 0 error

## ロールバック手順

このコミットを revert すれば CI の検出対象から外れるだけで、既存の CronJob/manifest には一切影響しない。データを持つコンポーネントではないため、スキーマ等の巻き戻し懸念も無い。

## backlog task id

T-0098（done）


---
_Generated by [Claude Code](https://claude.ai/code/session_01NnhgfZp6dd1exxFJwxunCd)_