### PR TITLE
immich 内蔵バックアップの実在検証を pvc-usage-reporter に追加 (T-0068 follow-up)

### DIFF
--- a/apps/coder/pvc-usage-cronjob.yaml
+++ b/apps/coder/pvc-usage-cronjob.yaml
@@ -97,6 +97,31 @@ data:
         return total
 
 
+    def list_backup_files(path):
+        # アプリ内蔵のバックアップ機能（例: immich の日次 DB ダンプ）が実際に生成物を
+        # 落としているかを検証するための、対象ディレクトリ直下のファイル一覧。
+        # BACKUP_LISTING_DIR が設定されているジョブ（immich のみ、T-0068 のレビュー対応）
+        # だけがこの関数を呼ぶ。未設定の namespace（vaultwarden/coder）には影響しない
+        try:
+            entries = []
+            with os.scandir(path) as it:
+                for entry in it:
+                    if not entry.is_file(follow_symlinks=False):
+                        continue
+                    st = entry.stat(follow_symlinks=False)
+                    entries.append({
+                        "name": entry.name,
+                        "bytes": st.st_size,
+                        "mtime": datetime.datetime.fromtimestamp(
+                            st.st_mtime, tz=datetime.timezone.utc
+                        ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    })
+        except OSError as e:
+            return {"dir": path, "error": "{}: {}".format(type(e).__name__, e)}
+        entries.sort(key=lambda e: e["mtime"])
+        return {"dir": path, "files": entries}
+
+
     def parse_mounts(spec):
         # "name:/mnt/path,name2:/mnt/path2" 形式
         out = []
@@ -139,6 +164,9 @@ data:
             for pvc_name, mount_path in mounts
         ]
         report = {"generated_at": generated_at, "namespace": NAMESPACE, "usage": usage}
+        backup_listing_dir = os.environ.get("BACKUP_LISTING_DIR")
+        if backup_listing_dir:
+            report["backup_listing"] = list_backup_files(backup_listing_dir)
         put_configmap("pvc-usage-report", {"report.json": json.dumps(report, ensure_ascii=False)})
         print("pvc-usage-report ConfigMap を更新しました ({})".format(generated_at))
 

--- a/apps/immich/pvc-usage-cronjob.yaml
+++ b/apps/immich/pvc-usage-cronjob.yaml
@@ -97,6 +97,31 @@ data:
         return total
 
 
+    def list_backup_files(path):
+        # アプリ内蔵のバックアップ機能（例: immich の日次 DB ダンプ）が実際に生成物を
+        # 落としているかを検証するための、対象ディレクトリ直下のファイル一覧。
+        # BACKUP_LISTING_DIR が設定されているジョブ（immich のみ、T-0068 のレビュー対応）
+        # だけがこの関数を呼ぶ。未設定の namespace（vaultwarden/coder）には影響しない
+        try:
+            entries = []
+            with os.scandir(path) as it:
+                for entry in it:
+                    if not entry.is_file(follow_symlinks=False):
+                        continue
+                    st = entry.stat(follow_symlinks=False)
+                    entries.append({
+                        "name": entry.name,
+                        "bytes": st.st_size,
+                        "mtime": datetime.datetime.fromtimestamp(
+                            st.st_mtime, tz=datetime.timezone.utc
+                        ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    })
+        except OSError as e:
+            return {"dir": path, "error": "{}: {}".format(type(e).__name__, e)}
+        entries.sort(key=lambda e: e["mtime"])
+        return {"dir": path, "files": entries}
+
+
     def parse_mounts(spec):
         # "name:/mnt/path,name2:/mnt/path2" 形式
         out = []
@@ -139,6 +164,9 @@ data:
             for pvc_name, mount_path in mounts
         ]
         report = {"generated_at": generated_at, "namespace": NAMESPACE, "usage": usage}
+        backup_listing_dir = os.environ.get("BACKUP_LISTING_DIR")
+        if backup_listing_dir:
+            report["backup_listing"] = list_backup_files(backup_listing_dir)
         put_configmap("pvc-usage-report", {"report.json": json.dumps(report, ensure_ascii=False)})
         print("pvc-usage-report ConfigMap を更新しました ({})".format(generated_at))
 
@@ -173,6 +201,13 @@ spec:
               env:
                 - name: PVC_MOUNTS
                   value: "immich-library:/mnt/immich-library,immich-postgres-data:/mnt/immich-postgres-data"
+                # immich 内蔵の日次 DB ダンプ (T-0068) が実際に UPLOAD_LOCATION/backups/ に
+                # 生成物を落としているかを検証するための一覧化 (issue #56, 2026-08-05 12:35:47
+                # のレビュー: 「CronJob を作った」ではなく「取れているものが期待どおりだと確認した」
+                # までが実装、という指摘)。immich-library は既に読み取り専用でマウント済みのため
+                # 追加のマウントは不要。vaultwarden/coder はこの env を設定しないため無効のまま
+                - name: BACKUP_LISTING_DIR
+                  value: "/mnt/immich-library/backups"
                 - name: PYTHONDONTWRITEBYTECODE
                   value: "1"
               # PVC の中身は immich-server/postgres コンテナのそれぞれ異なる UID

--- a/apps/vaultwarden/pvc-usage-cronjob.yaml
+++ b/apps/vaultwarden/pvc-usage-cronjob.yaml
@@ -97,6 +97,31 @@ data:
         return total
 
 
+    def list_backup_files(path):
+        # アプリ内蔵のバックアップ機能（例: immich の日次 DB ダンプ）が実際に生成物を
+        # 落としているかを検証するための、対象ディレクトリ直下のファイル一覧。
+        # BACKUP_LISTING_DIR が設定されているジョブ（immich のみ、T-0068 のレビュー対応）
+        # だけがこの関数を呼ぶ。未設定の namespace（vaultwarden/coder）には影響しない
+        try:
+            entries = []
+            with os.scandir(path) as it:
+                for entry in it:
+                    if not entry.is_file(follow_symlinks=False):
+                        continue
+                    st = entry.stat(follow_symlinks=False)
+                    entries.append({
+                        "name": entry.name,
+                        "bytes": st.st_size,
+                        "mtime": datetime.datetime.fromtimestamp(
+                            st.st_mtime, tz=datetime.timezone.utc
+                        ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    })
+        except OSError as e:
+            return {"dir": path, "error": "{}: {}".format(type(e).__name__, e)}
+        entries.sort(key=lambda e: e["mtime"])
+        return {"dir": path, "files": entries}
+
+
     def parse_mounts(spec):
         # "name:/mnt/path,name2:/mnt/path2" 形式
         out = []
@@ -139,6 +164,9 @@ data:
             for pvc_name, mount_path in mounts
         ]
         report = {"generated_at": generated_at, "namespace": NAMESPACE, "usage": usage}
+        backup_listing_dir = os.environ.get("BACKUP_LISTING_DIR")
+        if backup_listing_dir:
+            report["backup_listing"] = list_backup_files(backup_listing_dir)
         put_configmap("pvc-usage-report", {"report.json": json.dumps(report, ensure_ascii=False)})
         print("pvc-usage-report ConfigMap を更新しました ({})".format(generated_at))
 

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -92,6 +92,16 @@ issue #56 (2026-08-05 04:40:59) で人間から新方針: **PBS は重すぎる�
   流し込める想定）で immich-postgres へ復元する。復元時のバージョン整合（ダンプ生成時の
   immich/postgres バージョンとファイル名の `v{serverVersion}-pg{postgresVersion}` を突き合わせる）
   を事前に確認すること
+- **内蔵ダンプの継続監視**（issue #56, 2026-08-05 12:35:47 のレビュー対応）: 「内蔵の日次 DB
+  ダンプが `UPLOAD_LOCATION/backups/` に落ちている」という T-0068 の前提はソースコードでの
+  確認にとどまり、実機では未検証だった。これが崩れていると写真だけあって DB が無いバックアップ
+  になり、実際に復元するまで気づけない。`apps/immich/pvc-usage-cronjob.yaml`（T-0080 の
+  pvc-usage-reporter、3 namespace 共通スクリプト）に `BACKUP_LISTING_DIR` を設定（immich のみ）
+  し、`backups/` 直下のファイル一覧（name/bytes/mtime）を `pvc-usage-report` ConfigMap の
+  `backup_listing` キーに書き戻すようにした。vaultwarden/coder はこの env を設定しないため
+  スクリプトは共通のまま影響を受けない（`ops/check_pvc_usage_script_sync.py` で3ファイル一致を
+  引き続き検証）。ops-health-report の `pvc_usage`（immich エントリ）を読むたびに
+  `backup_listing.files` の有無と最新 `mtime` を確認すること（`ops/CHARTER.md` §2 に手順追記）
 
 ## coder-postgres の restic バックアップ (T-0070, 実装済み・credential 登録待ち)
 

--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -57,6 +57,16 @@ PVC 実使用量・コンテナ/ノードの実メモリ・CPU 使用量は `pvc
 `ops/health/history/YYYY-MM-DD.jsonl`（1行1回分、T-0083）を辿る。値の妥当性は単点観測では判断できない
 （issue #56, 2026-08-05 07:25:18 の指摘。アイドル時の数字だけで memory limits 等を決めない）。
 
+**バックアップ CronJob 自身が「取れているはず」と主張しているだけでは足りない**（issue #56,
+2026-08-05 12:35:47 の指摘。T-0068 は immich 内蔵の日次 DB ダンプが `UPLOAD_LOCATION/backups/`
+に落ちている前提だったが、これはソースコードで確認しただけで実機で見ていなかった。前提が崩れて
+いれば「写真だけあって DB が無い」使えないバックアップになるのに、実際に復元するまで気づけない）。
+`pvc_usage` の immich エントリには `backup_listing`（`dir`/`files`: `name`/`bytes`/`mtime` の配列、
+または取得失敗時は `error`）が追加されている（T-0068 フォローアップ, run #49）。ops-health-report
+を読むたびに、immich の `backup_listing.files` が空でないこと・最新ファイルの `mtime` が直近
+24時間以内であることを確認する。空または古いままなら immich 内蔵バックアップの異常を疑い、
+T-0068 のバックアップは実質機能していないとみなして調査タスクを起票する。
+
 **`pvc_usage` の `error`（404 相当）は「まだ」と「ずっと」を区別すること**（issue #56, 2026-08-05
 07:41:02 の指摘）。対象の `pvc-usage-reporter` CronJob（`immich`/`vaultwarden`/`coder`、schedule は
 それぞれ `5 */6 * * *` / `15 */6 * * *` / `25 */6 * * *`、つまり毎日 00:05・06:05・12:05・18:05 UTC

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 101,
+  "next_id": 102,
   "updated": "2026-08-05T10:30:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
@@ -1252,11 +1252,13 @@
       "priority": 40,
       "why": "issue #56 (2026-08-05 04:40:59) の人間の新方針・構築セッションの調査。immich は内蔵の日次 DB ダンプが UPLOAD_LOCATION/backups に 14 世代落ちる仕様のため、これが有効なら library PVC を restic で 1 本取るだけでライブラリと DB dump が同時に取れる（要確認）。稼働中に取る場合は DB dump が先、ファイルが後の順（DB に無い余分なファイルが残るだけで済む）",
       "dod": "immich の内蔵日次 DB ダンプが有効か確認したうえで、CronJob が restic でライブラリ PVC（DB dump を含む）を snapshot し、T-0067 の保存先へ push する。retention（`restic forget --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --prune` 相当）を週次で走らせる仕組みも同じ PR に含める。credential は Doppler → External Secrets 経由（キー名は T-0069 で決めた命名規則に揃える）",
-      "notes": "run #48: issue #56 (10:29:40) の指摘を受け blocked → todo に変更。manifest（CronJob・ExternalSecret）の設計・記述は T-0067（credential 発行）を待たずに進められる。実際に暗号化 push が成功するかの確認だけが T-0067 待ち | run #49: subagent に immich v2.7.5 タグの実ソースを直接確認させ、内蔵 Database Backup がデフォルト有効（毎日02:00 UTC, keepLastAmount:14）で UPLOAD_LOCATION（=immich-library PVC）配下に pg_dump 相当のフルダンプ（拡張含め除外なし）を .tmp→rename の atomic write で書き出すことを裏取りした。これにより immich-postgres-data の生 PVC を別途バックアップする必要は無いと確定（DoD の『要確認』が解消）。immich-library PVC を restic で1本取るだけの CronJob（coder-postgres のような pg_dump initContainer は不要）を実装。immich 自身のダンプ完了を待つため backup スケジュールを 02:45 UTC（ダンプ開始 02:00 の45分後）にした。restic-backup コンテナは pvc-usage-cronjob.yaml (T-0080) と同じ runAsUser:0 + DAC_READ_SEARCH パターンを再利用（PVC所有権が immich-server コンテナの UID のため）。実際に restic push が成功するかは T-0067（credential 登録）待ちのため T-0100 として確認タスクを別途起票した。done とするが、DoD の『保存先へ push する』が実際に成功したことの確認は T-0100 が担う",
+      "notes": "run #48: issue #56 (10:29:40) の指摘を受け blocked → todo に変更。manifest（CronJob・ExternalSecret）の設計・記述は T-0067（credential 発行）を待たずに進められる。実際に暗号化 push が成功するかの確認だけが T-0067 待ち | run #49: subagent に immich v2.7.5 タグの実ソースを直接確認させ、内蔵 Database Backup がデフォルト有効（毎日02:00 UTC, keepLastAmount:14）で UPLOAD_LOCATION（=immich-library PVC）配下に pg_dump 相当のフルダンプ（拡張含め除外なし）を .tmp→rename の atomic write で書き出すことを裏取りした。これにより immich-postgres-data の生 PVC を別途バックアップする必要は無いと確定（DoD の『要確認』が解消）。immich-library PVC を restic で1本取るだけの CronJob（coder-postgres のような pg_dump initContainer は不要）を実装。immich 自身のダンプ完了を待つため backup スケジュールを 02:45 UTC（ダンプ開始 02:00 の45分後）にした。restic-backup コンテナは pvc-usage-cronjob.yaml (T-0080) と同じ runAsUser:0 + DAC_READ_SEARCH パターンを再利用（PVC所有権が immich-server コンテナの UID のため）。実際に restic push が成功するかは T-0067（credential 登録）待ちのため T-0100 として確認タスクを別途起票した。done とするが、DoD の『保存先へ push する』が実際に成功したことの確認は T-0100 が担う | run #49 追記: issue #56 (12:35:47) のレビューで、内蔵 DB ダンプの前提（`UPLOAD_LOCATION/backups/` に実際に落ちているか）はソースコード確認のみで実機未検証と指摘された。これは T-0067 待ちの restic push 成功確認（T-0100）とは独立に、pvc-usage-reporter（T-0080）を使って即座に検証可能なため、apps/immich/pvc-usage-cronjob.yaml（3 namespace 共通スクリプト）に任意の `BACKUP_LISTING_DIR` 環境変数対応を追加し（未設定の vaultwarden/coder には影響なし、check_pvc_usage_script_sync.py で3ファイル一致を確認済み）、immich のみ `backups/` 配下のファイル一覧を `pvc-usage-report` ConfigMap の `backup_listing` キーに書き戻すようにした。ops-health-report 経由でこれを読む手順を CHARTER §2 に追記。次回以降の起動で `backup_listing.files` が実際に埋まっているかを T-0101 として確認する",
       "refs": [
         "apps/immich/restic-backup-cronjob.yaml",
         "apps/immich/restic-external-secret.yaml",
-        "docs/backup.md"
+        "apps/immich/pvc-usage-cronjob.yaml",
+        "docs/backup.md",
+        "ops/CHARTER.md"
       ],
       "created": "2026-08-05",
       "pr": 196
@@ -1821,6 +1823,24 @@
       "refs": [
         "apps/immich/restic-backup-cronjob.yaml",
         "docs/backup.md"
+      ],
+      "created": "2026-08-05",
+      "pr": null
+    },
+    {
+      "id": "T-0101",
+      "domain": "homelab",
+      "title": "immich 内蔵バックアップの backup_listing が実際に埋まっているか確認する",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "todo",
+      "priority": 41,
+      "why": "issue #56 (2026-08-05 12:35:47) のレビュー対応。T-0068 は immich 内蔵の日次 DB ダンプが UPLOAD_LOCATION/backups/ に落ちている前提だったが、ソースコード確認のみで実機未検証だった。pvc-usage-reporter (T-0080) に BACKUP_LISTING_DIR 対応を追加し backup_listing を書き戻すようにしたので、これは T-0100（restic push 成功確認、T-0067 待ちで blocked）とは独立に、次回以降の起動で ops-health-report が更新され次第すぐ確認できる（credential 登録を待つ必要が無い）",
+      "dod": "ops-health-report の pvc_usage（immich エントリ）の backup_listing.files が空でないこと、最新ファイルの mtime が直近24時間以内であることを確認する。空・古いまま・error のいずれかなら immich 内蔵バックアップの異常を疑い、原因調査タスクを新規に起票する（pvc-usage-reporter CronJob 自体は 5 */6 * * * で実行されるため、immich-restic-backup (02:45 UTC) より後の 06:05 UTC 実行分を待つ必要がある）。問題なければ docs/backup.md に確認日時・世代数を記録して done にする",
+      "refs": [
+        "apps/immich/pvc-usage-cronjob.yaml",
+        "docs/backup.md",
+        "ops/CHARTER.md"
       ],
       "created": "2026-08-05",
       "pr": null

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,28 @@
 {
   "open": [
     {
-      "number": 197,
-      "title": "restic/restic イメージタグの重複を check_version_sync.py の監視対象に追加 (T-0098)",
-      "url": "https://github.com/hikuohiku/homelab/pull/197",
+      "number": 198,
+      "title": "immich 内蔵バックアップの実在検証を pvc-usage-reporter に追加 (T-0068 follow-up)",
+      "url": "https://github.com/hikuohiku/homelab/pull/198",
       "isDraft": false,
-      "createdAt": "2026-08-05T12:39:01Z",
+      "createdAt": "2026-08-05T12:46:36Z",
       "statusCheckRollup": [
         {
           "conclusion": "PENDING"
         }
       ],
-      "headRefName": "autopilot/T-0098-restic-image-tag-ci",
+      "headRefName": "autopilot/T-0068-followup-verify-immich-backup-dump",
       "autoMergeRequest": null
     }
   ],
   "merged": [
+    {
+      "number": 197,
+      "title": "restic/restic イメージタグの重複を check_version_sync.py の監視対象に追加 (T-0098)",
+      "url": "https://github.com/hikuohiku/homelab/pull/197",
+      "mergedAt": "2026-08-05T12:41:04Z",
+      "headRefName": "autopilot/T-0098-restic-image-tag-ci"
+    },
     {
       "number": 196,
       "title": "immich-library 用 restic backup CronJob を追加 (T-0068)",
@@ -428,13 +435,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/132",
       "mergedAt": "2026-08-05T02:51:02Z",
       "headRefName": "autopilot/T-0055-immich-resources"
-    },
-    {
-      "number": 131,
-      "title": "docs: .gitignore の secrets/ エントリを実態に合わせる (T-0054)",
-      "url": "https://github.com/hikuohiku/homelab/pull/131",
-      "mergedAt": "2026-08-05T02:48:13Z",
-      "headRefName": "autopilot/T-0054-gitignore-secrets-path"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1441,6 +1441,18 @@
   vaultwarden/coder-postgres/immich の3ファイルを1つの GROUP にまとめた。ファイル内不一致
   （backup/retention の片方だけずらす）とファイル間不一致（1ファイル全体を別バージョンにずらす）
   の両方を検出できることを実地で確認した
-- 次の起動へ: backlog の todo は T-0096 のみ。T-0097/T-0099/T-0100（restic push の実成功確認、
-  いずれも T-0067 待ちで blocked）。T-0067（restic/B2 credential 登録、needs-human・priority 36）
-  と T-0079（node01 実ディスク容量、needs-human・priority 1）は引き続き人間待ち
+- ラップアップ中に issue #56 の未読フィードバック1件（12:35:47）を発見。#195 は問題無しとの
+  評価、#196（immich）は「内蔵 DB ダンプが `UPLOAD_LOCATION/backups/` に落ちている」という
+  T-0068 の前提がソース確認のみで実機未検証という指摘（前提が崩れると写真だけあって DB が無い
+  使えないバックアップになる）。T-0100（T-0067 待ちで blocked）とは独立に、pvc-usage-reporter
+  （T-0080）を使えば credential 無しで確認できると気づき即対応: apps/{immich,vaultwarden,coder}/
+  pvc-usage-cronjob.yaml の共通スクリプトに任意の `BACKUP_LISTING_DIR` 対応を追加し（未設定の
+  vaultwarden/coder には影響なし、check_pvc_usage_script_sync.py で一致確認済み）、immich のみ
+  `backups/` 配下のファイル一覧を `pvc-usage-report` ConfigMap の `backup_listing` キーに書き
+  戻すようにした（#198）。report.py 側は report.json をそのまま透過するため変更不要だった。
+  CHARTER §2 に読む手順を追記し、次回以降に実データを確認する T-0101 を起票。issue #56 に
+  返信し last_read を更新した
+- 次の起動へ: backlog の todo は T-0096・T-0101（T-0101 は次回の ops-health-report 更新後に
+  確認可能）。T-0097/T-0099/T-0100（restic push の実成功確認、いずれも T-0067 待ちで blocked）。
+  T-0067（restic/B2 credential 登録、needs-human・priority 36）と T-0079（node01 実ディスク
+  容量、needs-human・priority 1）は引き続き人間待ち

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-05T12:26:00Z",
+  "updated": "2026-08-05T12:47:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-05T11:49:24Z"
+    "last_read": "2026-08-05T12:35:47Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -555,11 +555,12 @@
       "at": "2026-08-05T12:26:00Z",
       "kind": "scheduled",
       "by": "cloud routine",
-      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。backlog の todo（priority昇順）から T-0070（coder-postgres 用 restic backup CronJob）に着手・完遂。T-0069（vaultwarden）と同じ設計思想を PostgreSQL 向けに適用し、initContainer の pg_dump -Fc でネットワーク経由の一貫したダンプを取ってから restic で Backblaze B2 へ push する。pg_dump の initContainer は apps/coder/postgres.yaml と同じ postgres:17.10 を再利用し、新規 image pin を増やさない代わりに ops/inventory.json の mirrors + check_version_sync.py の GROUP を新設した（意図的にタグをずらして CI が exit 1 になることを確認済み）。credential は vaultwarden と同じ Doppler キーを再利用するため追加の登録依頼は無し。実際の push 成功確認は T-0067（credential 登録）待ちのため T-0099 として分離、T-0098（restic image tag 重複監視）の対象を coder-postgres 分に拡張した（#195, merged）。続けて T-0068（immich 用 restic backup CronJob）に着手・完遂。着手前に subagent へ immich v2.7.5 タグの実ソース確認を依頼し、内蔵 Database Backup がデフォルト有効（毎日02:00 UTC, keepLastAmount:14）で immich-library PVC 内に pg_dump 相当のフルダンプを atomic write で書き出すことを裏取り。これにより immich-library PVC を restic で1本取るだけでライブラリ本体とDBダンプが同時に取れると確定し、coder-postgres のような専用 pg_dump initContainer は不要と判断した。immich 自身のダンプ完了を待つため backup スケジュールを 02:45 UTC にした。T-0098 の対象を immich 分（3ファイル×2箇所=6箇所）にも拡張し、T-0100（実成功確認、T-0067 待ち）を新規起票した（#196, merged）。続けて T-0098（restic/restic イメージタグ重複の CI 監視）を完遂: extract_all_action_tags と同じ考え方の extract_image_tag_all を新設し、vaultwarden/coder-postgres/immich の3ファイルを1つの GROUP にまとめた。ファイル内不一致・ファイル間不一致の両方を意図的に発生させて検出できることを確認済み（#197）",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。backlog の todo（priority昇順）から T-0070（coder-postgres 用 restic backup CronJob）に着手・完遂。T-0069（vaultwarden）と同じ設計思想を PostgreSQL 向けに適用し、initContainer の pg_dump -Fc でネットワーク経由の一貫したダンプを取ってから restic で Backblaze B2 へ push する。pg_dump の initContainer は apps/coder/postgres.yaml と同じ postgres:17.10 を再利用し、新規 image pin を増やさない代わりに ops/inventory.json の mirrors + check_version_sync.py の GROUP を新設した（意図的にタグをずらして CI が exit 1 になることを確認済み）。credential は vaultwarden と同じ Doppler キーを再利用するため追加の登録依頼は無し。実際の push 成功確認は T-0067（credential 登録）待ちのため T-0099 として分離、T-0098（restic image tag 重複監視）の対象を coder-postgres 分に拡張した（#195, merged）。続けて T-0068（immich 用 restic backup CronJob）に着手・完遂。着手前に subagent へ immich v2.7.5 タグの実ソース確認を依頼し、内蔵 Database Backup がデフォルト有効（毎日02:00 UTC, keepLastAmount:14）で immich-library PVC 内に pg_dump 相当のフルダンプを atomic write で書き出すことを裏取り。これにより immich-library PVC を restic で1本取るだけでライブラリ本体とDBダンプが同時に取れると確定し、coder-postgres のような専用 pg_dump initContainer は不要と判断した。immich 自身のダンプ完了を待つため backup スケジュールを 02:45 UTC にした。T-0098 の対象を immich 分（3ファイル×2箇所=6箇所）にも拡張し、T-0100（実成功確認、T-0067 待ち）を新規起票した（#196, merged）。続けて T-0098（restic/restic イメージタグ重複の CI 監視）を完遂: extract_all_action_tags と同じ考え方の extract_image_tag_all を新設し、vaultwarden/coder-postgres/immich の3ファイルを1つの GROUP にまとめた。ファイル内不一致・ファイル間不一致の両方を意図的に発生させて検出できることを確認済み（#197）。ラップアップ中に issue #56 の未読フィードバック1件（12:35:47）を発見: #196（immich）の前提（内蔵 DB ダンプが UPLOAD_LOCATION/backups/ に落ちている）がソース確認のみで実機未検証という指摘。T-0100（T-0067 待ちで blocked）とは独立に pvc-usage-reporter（T-0080）で検証できると気づき、共通スクリプトに任意の BACKUP_LISTING_DIR 対応を追加（immich のみ有効化、vaultwarden/coder は無影響）し backup_listing を ops-health-report に書き戻すようにした（#198）。CHARTER §2 に読む手順を追記し、次回確認する T-0101 を起票。issue に返信し last_read を更新した",
       "prs": [
         195,
         196,
-        197
+        197,
+        198
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

issue #56（2026-08-05 12:35:47）のレビュー対応。T-0068（#196）は immich 内蔵の日次 DB ダンプが `UPLOAD_LOCATION/backups/` に落ちていることを前提にしていたが、これはソースコード確認のみで実機では未検証だった。前提が崩れていると「写真だけあって DB が無い」使えないバックアップになり、実際に復元しようとするまで気づけない。

- `apps/{immich,vaultwarden,coder}/pvc-usage-cronjob.yaml`（T-0080, 3 namespace 共通の埋め込みスクリプト）に、任意の `BACKUP_LISTING_DIR` 環境変数対応を追加。設定されたジョブだけ、対象ディレクトリ直下のファイル一覧（`name`/`bytes`/`mtime`）を `pvc-usage-report` ConfigMap の `backup_listing` キーに書き戻す
- `apps/immich/pvc-usage-cronjob.yaml` のみ `BACKUP_LISTING_DIR=/mnt/immich-library/backups` を設定（マウント済みの `immich-library` の部分ディレクトリなので追加マウント不要）。vaultwarden/coder はこの env を設定しないため、スクリプトが共通のままでも挙動に影響しない
- `ops-health-reporter`（`report.py`）は `pvc-usage-report` ConfigMap の `report.json` 全体をそのまま `pvc_usage` に含めているため、`report.py`/RBAC の変更は不要（新しいキーがそのまま流れる）
- `ops/CHARTER.md` §2 に、ops-health-report を読むたびに immich の `backup_listing.files` の有無と最新 `mtime`（直近24時間以内か）を確認する手順を追記
- `ops/backlog.json`: T-0068 の notes にこの follow-up を追記。T-0100（restic push 成功確認、T-0067 credential 登録待ちで blocked）とは独立に確認できる新規タスク T-0101 を起票（credential 不要、次回以降の ops-health-report 更新を待つだけ）

## 検証したこと

- `python3 ops/check_pvc_usage_script_sync.py` → 3ファイル一致（0 error）
- `python3 ops/check_version_sync.py` / `python3 ops/validate.py` → 0 error
- 追加した `list_backup_files` 関数を抽出して単体で実行し、ファイル一覧の取得（name/bytes/mtime、mtime 昇順ソート）とディレクトリ不在時のエラーハンドリング（`{"dir": ..., "error": ...}`）の両方を確認
- YAML として3ファイルとも `yaml.safe_load_all` でパース可能なことを確認

## ロールバック手順

このコミットを revert すれば `BACKUP_LISTING_DIR` の設定と `list_backup_files` 関数が消え、`backup_listing` キーが report.json に含まれなくなるだけ。既存の `usage`（PVC 実使用量）フィールドには影響しない。読み取り専用の追加のため、データを失いうる懸念は無い。

## backlog task id

T-0068（done、follow-up）。関連: T-0101（新規、次回以降に backup_listing の実データを確認）


---
_Generated by [Claude Code](https://claude.ai/code/session_01NnhgfZp6dd1exxFJwxunCd)_