### PR TITLE
ドキュメントが案内する just recipe の実在を CI で検証する (T-0096)

### DIFF
--- a/.claude/commands/deploy-preview.md
+++ b/.claude/commands/deploy-preview.md
@@ -31,5 +31,4 @@ ArgoCD を使ったフィーチャーブランチのデプロイ検証フロー�
 ## 注意事項
 
 - preview 中はルート `apps` Application の auto-sync が無効になる（既存アプリの場合）
-- テスト完了後は必ず `preview-reset` で復元すること
-- `just argocd-bootstrap` はルート Application を main の状態で再適用する（AutoSync 有効化用）
+- テスト完了後は必ず `preview-reset` で復元すること（`just preview-reset apps` がルート Application を HEAD に戻し auto-sync も復元する）

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,8 @@ jobs:
         run: python3 ops/check_version_sync.py
       - name: check pvc-usage-reporter script is in sync across namespaces
         run: python3 ops/check_pvc_usage_script_sync.py
+      - name: check docs reference only existing just recipes
+        run: python3 ops/check_doc_commands.py
       - name: dashboard build.py runs without error
         # index.html は生成物なので git 管理していない（T-0035）。壊れていないことだけここで担保する
         run: python3 ops/dashboard/build.py

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -43,6 +43,24 @@ issue #56 (2026-08-05 04:40:59) で人間から新方針: **PBS は重すぎる�
 | `coder-postgres-data` | Coder 制御プレーン（ユーザー・workspace・監査ログ） | T-0070（実装済み・credential 登録待ち） |
 | `coder-<workspace-id>-home`（動的作成、`apps/coder/templates/personal/main.tf`） | workspace ごとの `/home/coder`（dotfiles・ghq clone 等） | **未起票**。T-0070 の対象外（別 PVC 群）のため、別途タスク化が必要 |
 
+## 実サイズの実測 (T-0066, run #50)
+
+T-0080（`pvc-usage-reporter`）が稼働したことで、当初 needs-human だった実サイズ測定は human の
+手を借りずに完了した。`ops/health/latest.json` の `pvc_usage`（2026-08-05T12:30:04Z 時点）:
+
+| PVC | 実使用量 |
+|---|---|
+| `immich-library` | 約 332 MiB |
+| `immich-postgres-data` | 約 302 MiB |
+| `vaultwarden-data` | 約 4.6 MiB |
+| `coder-postgres-data` | 小さい（immich と同程度以下） |
+
+**合計 1 GiB 未満。** T-0066 の why で懸念していた「300GB か 1TB か」という規模の想定は的外れで、
+node01 の実ディスク容量（約48.9GiB、T-0079）の 2% にも満たない。T-0067（restic 保存先アカウント）の
+判断はこれで確定する: **Backblaze B2 の無料枠（10GB）に収まり、月額コストは実質ゼロ。** Hetzner Storage
+Box との比較検討は不要。宣言値（PVC の `requested`）と実測値は 2 桁近く乖離しており、判断は実測が
+入るまで宣言値に依存すべきではない。
+
 ## vaultwarden の restic バックアップ (T-0069, 実装済み・credential 登録待ち)
 
 `apps/vaultwarden/restic-backup-cronjob.yaml` に2つの CronJob を実装した。

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 102,
-  "updated": "2026-08-05T10:30:00Z",
+  "updated": "2026-08-05T13:35:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）",
   "tasks": [
     {
@@ -1211,7 +1211,7 @@
       "title": "バックアップ対象（immich ライブラリ等）の実サイズを測定してほしい",
       "kind": "investigate",
       "risk": "low",
-      "status": "needs-human",
+      "status": "done",
       "priority": 36,
       "why": "issue #56 (2026-08-05 04:40:59) の人間の新方針。immich ライブラリが 300GB か 1TB かで restic の保存先の最適解が変わる（300GB/月なら Backblaze B2 が $2.09、1TB 級なら Hetzner Storage Box の固定 €3.20 が逆転する）",
       "dod": "immich ライブラリ（UPLOAD_LOCATION の PVC）、vaultwarden の /data、coder-postgres・immich-postgres の DB サイズを実機で測定し、docs/backup.md に記録する。T-0067 の保存先選定の判断材料にする",
@@ -1220,8 +1220,8 @@
         "docs/backup.md"
       ],
       "created": "2026-08-05",
-      "pr": null,
-      "notes": "run #31: issue #56 (05:35:04) で上限が判明。ops-health-report (05:30:09) の node allocatable ephemeral-storage が 51250152Ki（≈48.9GiB）しか無く、immich ライブラリは物理的に 49GiB を超えられない。300GB/1TB 想定は前提から外れ、保存先は Backblaze B2 で確定（Hetzner Storage Box との比較は不要）。ただし正確な実使用バイト数（T-0077 待ち）と、そもそも disk 全体が 48.9GiB しか無いという事実自体の確認（T-0079）はまだ完了していないため needs-human のまま"
+      "pr": 199,
+      "notes": "run #31: issue #56 (05:35:04) で上限が判明。ops-health-report (05:30:09) の node allocatable ephemeral-storage が 51250152Ki（≈48.9GiB）しか無く、immich ライブラリは物理的に 49GiB を超えられない。300GB/1TB 想定は前提から外れ、保存先は Backblaze B2 で確定（Hetzner Storage Box との比較は不要）。ただし正確な実使用バイト数（T-0077 待ち）と、そもそも disk 全体が 48.9GiB しか無いという事実自体の確認（T-0079）はまだ完了していないため needs-human のまま | run #50: T-0080 (pvc-usage-reporter) が実際に稼働し、human の手を借りずに実測できた。immich-library 約332MiB、immich-postgres-data 約302MiB、vaultwarden-data 約4.6MiB、coder-postgres-data も小。合計1GiB未満（ops/health/latest.json pvc_usage, 2026-08-05T12:30:04Z）。docs/backup.md に記録し、T-0067 の needs_human_reason にも反映。done とする。"
     },
     {
       "id": "T-0067",
@@ -1233,14 +1233,15 @@
       "priority": 36,
       "why": "issue #56 (2026-08-05 04:40:59) の人間の新方針。restic ベースのバックアップに保存先が要る。構築セッションの調査では Backblaze B2（$2.09/300GB・復元エグレス無料枠あり）を推奨、ライブラリが 1TB に近いなら Hetzner Storage Box（固定 €3.20）が逆転する（T-0066 の実測結果で確定する）",
       "dod": "T-0066 の実測結果を踏まえて保存先を確定し、アカウントを作成、restic リポジトリ用の append-only なアプリケーションキー（node01 が乗っ取られてもバックアップを消せないように）を発行し、Doppler の homelab/prd に登録する。登録先キー名は実装時（T-0068〜T-0070）にこちらで backlog へ追記する",
-      "needs_human_reason": "外部サービスのアカウント作成とコストが動く契約、および credential の発行・Doppler への登録。CHARTER §4『人間に渡してよいもの』の『権限・認証の手作業』『コストや契約が動くもの』に該当し、エージェントからは手が届かない。T-0069 (#191) で実装した ExternalSecret が参照するキー名が確定したので、以下をそのまま Doppler の homelab/prd に登録してほしい: `RESTIC_PASSWORD`（暗号化パスワード、新規に生成して登録）/ `RESTIC_B2_BUCKET`（B2 バケット名）/ `RESTIC_B2_ACCOUNT_ID` / `RESTIC_B2_ACCOUNT_KEY`（B2 application key、append-only 推奨）。詳細は docs/backup.md 参照",
+      "needs_human_reason": "外部サービスのアカウント作成とコストが動く契約、および credential の発行・Doppler への登録。CHARTER §4『人間に渡してよいもの』の『権限・認証の手作業』『コストや契約が動くもの』に該当し、エージェントからは手が届かない。T-0069 (#191) で実装した ExternalSecret が参照するキー名が確定したので、以下をそのまま Doppler の homelab/prd に登録してほしい: `RESTIC_PASSWORD`（暗号化パスワード、新規に生成して登録）/ `RESTIC_B2_BUCKET`（B2 バケット名）/ `RESTIC_B2_ACCOUNT_ID` / `RESTIC_B2_ACCOUNT_KEY`（B2 application key、append-only 推奨）。詳細は docs/backup.md 参照 【run #50 追記】実サイズが判明（T-0066 done、docs/backup.md 参照）: 全データ合計 1GiB 未満。Backblaze B2 の無料枠（10GB）に収まり、月額コストは実質ゼロと見込める。Hetzner との比較検討は不要。",
       "blocked_by": "T-0066（保存先の選定に実サイズが要る）",
       "refs": [
         "docs/backup.md",
         "apps/vaultwarden/restic-external-secret.yaml"
       ],
       "created": "2026-08-05",
-      "pr": null
+      "pr": null,
+      "notes": "run #50: ops-health-report で観測。T-0067 未完了のまま T-0068/T-0069/T-0070 のrestic-external-secret.yaml (creationPolicy: Owner) が Doppler に無いキーを参照しており、ExternalSecret が同期できず Secret が作られない状態が続いている。ArgoCD はこれを検知してvaultwarden/coder/immich の3 Application を Degraded と報告する（history: 08-05 11:30 まで全10アプリHealthy → 12:00 vaultwardenのみDegraded (T-0069 #191/#192 merge直後) → 13:00 coder/immichも追加でDegraded (T-0070 #195, T-0068 #196 merge後)、時系列が完全一致）。各アプリ本体（vaultwarden/coder/immich自体のPod）は正常で、Degradedの実体はrestic用のExternalSecretが解決できないことによるものと推定（このクラウドサンドボックスからはkubectl/ArgoCD MCPともに到達できず個々のリソースの健全性までは直接確認できていない）。T-0067（Doppler credential登録）が完了すれば解消される見込み。次回以降、T-0067完了後のrun で3アプリがHealthyに戻ることを確認すること。"
     },
     {
       "id": "T-0068",
@@ -1312,12 +1313,13 @@
       "why": "issue #56 (2026-08-05 04:40:59) の人間の新方針。『試したことのないバックアップは、バックアップではありません』。T-0068〜T-0070 で作った CronJob が実際に復元可能なデータを作れているかを、別 namespace か使い捨て環境に実際に復元して確認する。T-0023/T-0027/T-0029（データを失いうるメジャー更新）はこれが通るまで着手できない（T-0034 dropped に伴い、これらの blocked_by をここに張り替え済み）",
       "dod": "immich / vaultwarden / coder-postgres それぞれについて、restic のバックアップから使い捨て環境（別 namespace 等）に実際に復元し、データが読めることを確認する。**復元にかかった時間を実測して記録する**（PBS 退役判断の材料になる、人間の依頼どおり）。結果を docs/backup.md に記録する",
       "needs_human_reason": "復元試験にはクラスタへの到達（別 namespace の作成、restic restore コマンドの実行）が要る。autopilot のクラウドサンドボックスは到達できない（CHARTER §5.2）。ただし実装（CronJob の manifest、restic restore の手順書）自体はブロックされずに進められるため blocked のままにし、needs-human への切り替えは T-0068〜T-0070 が終わってから判断する",
-      "blocked_by": "T-0068, T-0069, T-0070（復元試験には先にバックアップが取れている必要がある）",
+      "blocked_by": "T-0067（restic/B2 credential 登録。T-0068〜T-0070 の実装自体は完了済みだが、実際にバックアップが成功していないと復元試験もできない）",
       "refs": [
         "docs/backup.md"
       ],
       "created": "2026-08-05",
-      "pr": null
+      "pr": null,
+      "notes": " | run #50: issue #56 (12:48:16) の指摘で、immich がまだほとんど使われていない（332MiB）今のうちに復元試験まで通しておくべきと助言された。T-0068〜T-0070 の実装は完了済みのため blocked_by を T-0067 のみに絞った。T-0067 が片付き次第、最優先で着手する。"
     },
     {
       "id": "T-0072",
@@ -1435,10 +1437,10 @@
       "kind": "investigate",
       "risk": "high",
       "status": "needs-human",
-      "priority": 1,
-      "why": "issue #56 (2026-08-05 05:35:04, 構築セッション経由)。ops-health-report ブランチ (generated_at: 2026-08-05T05:30:09Z) が報告する node の allocatable/capacity ephemeral-storage は 51250152Ki（≈48.9GiB）。一方 `terraform/proxmox/vm-nixos.tf` の `size = 256`（GiB）、`docs/node01-storage.md`（『2026-08-04 に 50GiB→256GiB へ拡張した』）、`CLAUDE.md`（『node01 の root disk は 256 GiB』）は全て 256GiB を前提にしている。**PVC requested 合計は 215Gi（immich-library 単体で 50Gi）で、実測どおり 48.9GiB しか無いなら既に定義上のオーバーコミット状態。** local-path は実ディスクを予約しないため、使用量が実容量に達した時点で node 上の全データ（immich 写真・vaultwarden シークレット・coder workspace・両 postgres）が同時に破損しうる。system Pod（argocd/coredns/local-path-provisioner/metrics-server 等）の restarts が軒並み 19 回で揃っており、手動で行った growpart/resize2fs がノード再起動の過程で失われた可能性がある",
+      "priority": 30,
+      "why": "issue #56 (2026-08-05 05:35:04, 構築セッション経由)。ops-health-report ブランチ (generated_at: 2026-08-05T05:30:09Z) が報告する node の allocatable/capacity ephemeral-storage は 51250152Ki（≈48.9GiB）。一方 `terraform/proxmox/vm-nixos.tf` の `size = 256`（GiB）、`docs/node01-storage.md`（『2026-08-04 に 50GiB→256GiB へ拡張した』）、`CLAUDE.md`（『node01 の root disk は 256 GiB』）は全て 256GiB を前提にしている。**PVC requested 合計は 215Gi（immich-library 単体で 50Gi）で、実測どおり 48.9GiB しか無いなら既に定義上のオーバーコミット状態。** local-path は実ディスクを予約しないため、使用量が実容量に達した時点で node 上の全データ（immich 写真・vaultwarden シークレット・coder workspace・両 postgres）が同時に破損しうる。system Pod（argocd/coredns/local-path-provisioner/metrics-server 等）の restarts が軒並み 19 回で揃っており、手動で行った growpart/resize2fs がノード再起動の過程で失われた可能性がある 【run #50 追記】T-0080 (pvc-usage-reporter) の実測により、実データ使用量は全 PVC 合計で1GiB未満（48.9GiBの2%未満）と判明した。当面の逼迫・データ同時破損の切迫感は無い。ただし『256GiB のはずが 48.9GiB しか見えていない』という記述と実測の食い違い自体は解消していないため、確認は引き続き必要（緊急ではないが記述整合性のために確認したい）。",
       "dod": "人間が node01 で `df -h /` と `lsblk` を実行し、(1) パーティション/ファイルシステムの実サイズ、(2) 256GiB へ拡張したはずの領域が実際に root ファイルシステムまで反映されているか、を確認する。結果を踏まえて次のいずれかに分岐する: (a) 実ディスクが本当に48.9GiB程度しか無い→ growpart/resize2fs をやり直すか、terraform の size を実態に合わせて修正し、215Gi分のPVC要求をどう減らす/どこに逃がすかを検討する新タスクを起票する (b) kubelet 側の ephemeral-storage 計算が古い/誤り（再起動で直る等）→ health report 側の実装かCronJobの再起動を疑う。**autopilot 側では docs/terraform を先に『直さない』**（構築セッションの助言どおり、実態が未確定のうちにドキュメントだけ書き換えると誤った事実が固定化する）",
-      "needs_human_reason": "node01 の実機（Proxmox ホストまたは NixOS 本体）で `df -h` / `lsblk` を実行してほしい。Tailscale 越しに到達できる人間の環境でしか実行できず、autopilot のクラウドサンドボックスは物理的に到達できない（CHARTER §5.2）",
+      "needs_human_reason": "node01 の実機（Proxmox ホストまたは NixOS 本体）で `df -h` / `lsblk` を実行してほしい。Tailscale 越しに到達できる人間の環境でしか実行できず、autopilot のクラウドサンドボックスは物理的に到達できない（CHARTER §5.2）。【run #50 追記】急ぎではない: 実データ使用量は1GiB未満（T-0080実測）で当面のディスク逼迫リスクは無いと分かっている。記述（terraform/docs/CLAUDE.md の256GiB）を実態に合わせたいので、手が空いたときに `df -h`/`lsblk` の結果を教えてほしい、という位置づけ",
       "refs": [
         "terraform/proxmox/vm-nixos.tf",
         "docs/node01-storage.md",
@@ -1758,7 +1760,7 @@
       "title": "ドキュメントが参照する `just <recipe>` の実在を CI で検証する",
       "kind": "ci",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 45,
       "why": "run #47 の subagent 調査で発見。T-0095（apps/README.md が存在しない `just inject-secrets` を案内していた）と同型のドキュメント drift は、今の CI (check_version_sync.py / validate.py) では検出できない。バージョン pin の重複や state ファイルの不変条件は見ているが『ドキュメントが実在しないコマンドを指している』は対象外",
       "dod": "README.md/apps/README.md/CLAUDE.md 等から `` `just <word>` `` の出現を抽出し、justfile の実際の recipe 名と突き合わせる標準ライブラリのみのスクリプト（例: ops/check_doc_commands.py）を追加し、ops job に組み込む。意図的に存在しない recipe 名を書いて CI が exit 1 になることを確認する",
@@ -1768,7 +1770,8 @@
         "justfile"
       ],
       "created": "2026-08-05",
-      "pr": null
+      "pr": 199,
+      "notes": "run #50: ops/check_doc_commands.py を追加。実行したところ .claude/commands/deploy-preview.md が存在しない `just argocd-bootstrap` を案内していたのを検出（本来の目的どおり真の drift を1件発見）。`just preview-reset apps`が同じ役割を果たすため実態に合わせて記述を修正し、CI (ops job) に組み込んだ。"
     },
     {
       "id": "T-0097",

--- a/ops/check_doc_commands.py
+++ b/ops/check_doc_commands.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+ドキュメントが案内する `just <recipe>` が justfile に実在するか検証する。CI (ops job) から実行する。
+
+T-0095（apps/README.md が存在しない `just inject-secrets` を案内していた）と同型の drift は、
+既存の CI (check_version_sync.py / validate.py) では検出できない。ドキュメント内の
+`` `just <recipe>` `` を機械的に抜き出し、justfile の実際の recipe 名と突き合わせる。
+標準ライブラリのみで動く。
+"""
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# ドキュメントとして扱うファイル。ops/journal/ は起動ごとの履歴記録であり、
+# 当時実在した recipe が後で改名/削除されても「事実の記録」として直さないため対象外。
+DOC_PATHS = [
+    "README.md",
+    "CLAUDE.md",
+    "Maintenance.md",
+    "Plans.md",
+    "apps/README.md",
+    "ops/CHARTER.md",
+    "ops/VISION.md",
+    *sorted(str(p.relative_to(ROOT)) for p in ROOT.glob("docs/*.md")),
+    *sorted(str(p.relative_to(ROOT)) for p in ROOT.glob(".claude/commands/*.md")),
+]
+
+# `just <recipe>` の出現を拾う。バッククォート越しでもそうでなくても検出する。
+# recipe 名だけを group(1) で取る（引数・文言はここでは見ない）。
+JUST_CALL_RE = re.compile(r"\bjust\s+([a-zA-Z_][a-zA-Z0-9_-]*)")
+
+# justfile の recipe 定義行。`name param1 param2:` の形で、変数代入 (`name := value`) とは
+# `:=` の有無で区別する。
+RECIPE_DEF_RE = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_-]*)(?:\s+[a-zA-Z0-9_+*=\"'-]+)*\s*:(?!=)")
+
+
+def extract_recipe_names(justfile_text: str) -> set:
+    names = set()
+    for line in justfile_text.splitlines():
+        if line.startswith((" ", "\t", "#", "@")):
+            continue
+        m = RECIPE_DEF_RE.match(line)
+        if m:
+            names.add(m.group(1))
+    return names
+
+
+def extract_doc_calls(doc_path: Path) -> list:
+    text = doc_path.read_text()
+    calls = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for m in JUST_CALL_RE.finditer(line):
+            recipe = m.group(1)
+            if recipe == "*":
+                # `just *` はワイルドカードの案内（CLAUDE.md の許可リスト表記）であり、
+                # 特定の recipe を指していない
+                continue
+            calls.append((lineno, recipe))
+    return calls
+
+
+def main() -> int:
+    justfile_path = ROOT / "justfile"
+    if not justfile_path.exists():
+        print(f"::error::justfile が見つからない: {justfile_path}", file=sys.stderr)
+        return 1
+    recipes = extract_recipe_names(justfile_path.read_text())
+    if not recipes:
+        print("::error::justfile から recipe を1つも抽出できなかった", file=sys.stderr)
+        return 1
+
+    errors = []
+    for rel_path in DOC_PATHS:
+        doc_path = ROOT / rel_path
+        if not doc_path.exists():
+            continue
+        for lineno, recipe in extract_doc_calls(doc_path):
+            if recipe not in recipes:
+                errors.append(f"{rel_path}:{lineno}: `just {recipe}` は justfile に存在しない")
+
+    if errors:
+        for e in errors:
+            print(f"::error::{e}")
+        print(f"\n{len(errors)} 件の drift。justfile の recipe: {sorted(recipes)}", file=sys.stderr)
+        return 1
+
+    print(f"ok: justfile recipe {len(recipes)} 件、ドキュメント {len(DOC_PATHS)} 件を確認")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,28 @@
 {
   "open": [
     {
-      "number": 198,
-      "title": "immich 内蔵バックアップの実在検証を pvc-usage-reporter に追加 (T-0068 follow-up)",
-      "url": "https://github.com/hikuohiku/homelab/pull/198",
+      "number": 199,
+      "title": "ドキュメントが案内する just recipe の実在を CI で検証する (T-0096)",
+      "url": "https://github.com/hikuohiku/homelab/pull/199",
       "isDraft": false,
-      "createdAt": "2026-08-05T12:46:36Z",
+      "createdAt": "2026-08-05T13:36:01Z",
       "statusCheckRollup": [
         {
           "conclusion": "PENDING"
         }
       ],
-      "headRefName": "autopilot/T-0068-followup-verify-immich-backup-dump",
+      "headRefName": "autopilot/T-0096-doc-just-recipe-check",
       "autoMergeRequest": null
     }
   ],
   "merged": [
+    {
+      "number": 198,
+      "title": "immich 内蔵バックアップの実在検証を pvc-usage-reporter に追加 (T-0068 follow-up)",
+      "url": "https://github.com/hikuohiku/homelab/pull/198",
+      "mergedAt": "2026-08-05T12:49:06Z",
+      "headRefName": "autopilot/T-0068-followup-verify-immich-backup-dump"
+    },
     {
       "number": 197,
       "title": "restic/restic イメージタグの重複を check_version_sync.py の監視対象に追加 (T-0098)",
@@ -428,13 +435,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/133",
       "mergedAt": "2026-08-05T02:53:27Z",
       "headRefName": "autopilot/run23-wrapup"
-    },
-    {
-      "number": 132,
-      "title": "refactor(immich): server/machine-learning/valkey に resources を設定する (T-0055)",
-      "url": "https://github.com/hikuohiku/homelab/pull/132",
-      "mergedAt": "2026-08-05T02:51:02Z",
-      "headRefName": "autopilot/T-0055-immich-resources"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1456,3 +1456,41 @@
   確認可能）。T-0097/T-0099/T-0100（restic push の実成功確認、いずれも T-0067 待ちで blocked）。
   T-0067（restic/B2 credential 登録、needs-human・priority 36）と T-0079（node01 実ディスク
   容量、needs-human・priority 1）は引き続き人間待ち
+
+## 2026-08-05 22:20 JST — run #50
+
+- 前回の中断確認: オープン PR・`autopilot/*` ブランチともに無し。中断なし
+- 読んだフィードバック: issue #56 の未読2件（12:46:50, 12:48:16）
+  1. (12:46:50, 人間) run #49 の対応への謝辞・確認のみ、追加アクションなし
+  2. (12:48:16, 構築セッション経由) T-0080 実測で PVC 使用量が判明: immich-library 約332MiB・
+     immich-postgres-data 約302MiB・vaultwarden-data 約4.6MiB・coder-postgres-data 小、
+     **合計1GiB未満**（ディスク容量48.9GiBの2%未満）。これを受けて反映: T-0066（実サイズ測定）を
+     done にし docs/backup.md に実測値を記録、T-0067（restic保存先credential）の
+     needs_human_reason に「B2無料枠で足りる、Hetzner比較不要」を追記、T-0079（node01ディスク
+     食い違い確認）は緊急度を下げ priority 1→30・文言を「危険」から「記述を実態に合わせたい」に
+     変更、T-0071（復元試験）の blocked_by を T-0068〜T-0070（実装済み）から T-0067 のみに絞り
+     「今がやりやすい時期」という助言を notes に反映。T-0080 の blocked_by 解除提案は run #35 で
+     既に対応済みだったため今回は変更なし
+- **見つけたこと（重要）**: ops-health-report を確認したところ、coder/immich/vaultwarden の
+  3 Application が Degraded と報告されていた。history (`ops/health/history/2026-08-05.jsonl`) を
+  辿ると 11:30 まで全10アプリHealthy → 12:00 vaultwardenのみDegraded（T-0069 #191/#192 merge
+  直後）→ 13:00 coder/immichも追加でDegraded（T-0070 #195, T-0068 #196 merge後）と、各 restic
+  backup CronJob 追加のタイミングと完全に一致。restic-external-secret.yaml
+  （creationPolicy: Owner）が参照する Doppler キー（RESTIC_PASSWORD 等）は T-0067 未完了のため
+  存在せず、ExternalSecret が同期できていないと推定される（このクラウドサンドボックスは
+  kubectl/ArgoCD MCP ともに到達できないため、個々のリソースの健全性までは直接確認できていない。
+  各アプリ本体—vaultwarden/coder/immich自体のPod—は pod_issues に異常が出ておらず正常と見られる）。
+  T-0067 の needs_human_reason にこの事実（放置すると ArgoCD ダッシュボードが3アプリ Degraded の
+  ままになる）を反映し、人間には push 通知で直接伝えた。**T-0067 完了後、次回以降の run でこの
+  3アプリが Healthy に戻ることを確認すること**
+- T-0096（ドキュメントが案内する `just <recipe>` の実在を CI で検証する）に着手・完遂。
+  `ops/check_doc_commands.py` を新設し CI (ops job) に組み込んだ。実行したところ実際に
+  `.claude/commands/deploy-preview.md` が存在しない `just argocd-bootstrap` を案内していた
+  drift を検出（`just preview-reset apps` が同じ役割を果たすため実態に合わせて修正）。
+  意図的に壊して exit 1 になることも確認済み（PR #199）
+- 次の起動へ: backlog の todo は T-0101（immich backup_listing の実データ確認。immich の
+  pvc-usage-reporter は `5 */6 * * *` で次回実行は 18:05 UTC、#198 merge (12:49) 後の初回分は
+  まだ届いていないため今回は確認見送り）のみ。**T-0067 が完了したら ops-health-report で
+  vaultwarden/coder/immich の3アプリが Healthy に戻ったか確認すること**（このrunで見つけた
+  Degraded の件）。T-0079（node01実ディスク、needs-human・priority 30 に降格）・T-0067
+  （restic/B2 credential 登録、needs-human・priority 36）は引き続き人間待ち

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-05T12:47:00Z",
+  "updated": "2026-08-05T13:40:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-05T12:35:47Z"
+    "last_read": "2026-08-05T12:48:16Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -561,6 +561,16 @@
         196,
         197,
         198
+      ]
+    },
+    {
+      "n": 50,
+      "at": "2026-08-05T13:20:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 の未読2件を反映: T-0080 の実測でPVC使用量が全体で1GiB未満と判明したのを受け、T-0066を done化しdocs/backup.mdに記録、T-0067のneeds_human_reasonにB2無料枠で足りる旨を追記、T-0079の緊急度をpriority 1→30に引き下げ、T-0071のblocked_byをT-0067のみに絞った。ops-health-reportを確認したところcoder/immich/vaultwardenの3アプリがDegradedと判明。history上、各restic backup CronJob (T-0068/T-0069/T-0070) のmerge直後に順次Degraded化しており、原因はT-0067未完了でrestic用ExternalSecretが同期できていないことと推定（アプリ本体は正常）。T-0067のneeds_human_reasonに反映しpush通知で人間に伝えた。続けてT-0096（ドキュメントのjust recipe実在をCIで検証）を完遂。ops/check_doc_commands.pyを新設し、実際に.claude/commands/deploy-preview.mdの存在しないrecipe参照（drift）を1件検出・修正した（#199）。",
+      "prs": [
+        199
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

- `ops/check_doc_commands.py` を追加。README.md / CLAUDE.md / apps/README.md / ops/CHARTER.md / ops/VISION.md / docs/*.md / .claude/commands/*.md から `` `just <recipe>` `` の出現を抽出し、justfile の実際の recipe 名と突き合わせる（標準ライブラリのみ）。
- CI (`ops` job) にステップを追加。
- 実行したところ `.claude/commands/deploy-preview.md` が存在しない `just argocd-bootstrap` を案内していたのを検出したため、実態（`just preview-reset apps` が同じ役割を果たす）に合わせて記述を修正した。

## 検証したこと

- `python3 ops/check_doc_commands.py` が現在の repo に対して exit 0 で通ることを確認。
- 意図的に存在しない recipe 名（`just totally-fake-recipe`）をドキュメントに書き加えて exit 1 になることを確認し、元に戻して差分ゼロを確認済み。

## ロールバック手順

このコミットを revert すれば元に戻る。DB・状態を持つ変更ではないため revert 後の不整合は無い。

## backlog task id

T-0096（risk: low, repo 内で閉じる変更のため CI green なら auto-merge 対象）


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3BMqd9Kv1m5LD6vkF7o3B)_