### PR TITLE
ops: run #51 の記録更新（T-0102 完遂・journal・state・PRキャッシュ）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1872,7 +1872,7 @@
       "title": "ci.yml の azure/setup-helm version input (helm バイナリ) を v3.16.4 → v3.21.3 に上げる",
       "kind": "upgrade",
       "risk": "low",
-      "status": "in_progress",
+      "status": "done",
       "priority": 20,
       "why": "T-0090（run #43）で ops/inventory.json に gha-setup-helm-version として監視対象に加えたが、追加後に実際の上流最新版と比較したことが一度も無く 5 minor 分（v3.17〜v3.21）遅れていた。kustomize build --enable-helm（manifests job・manifest-diff job の両方）が使う helm バイナリ本体",
       "dod": "ci.yml の2箇所（manifests job・manifest-diff job）の version: が v3.21.3。ops/inventory.json の gha-setup-helm-version の current/match も更新。v3.17.0〜v3.21.3 の全リリースノートを原文確認し、helm template のレンダリング挙動に影響する breaking change が無いことを確認する",
@@ -1881,7 +1881,7 @@
         "ops/inventory.json"
       ],
       "created": "2026-08-05",
-      "pr": null,
+      "pr": 200,
       "notes": "subagent 2件で調査: (1) 既存 backlog に重複が無いことを確認したうえで発見（T-0045 は Action 自体の pin、T-0090 はファイル内2箇所の内部一致検証のみで上流比較は対象外だった）。(2) v3.16.4→v3.21.3 間の全25リリース（v3.17.0〜v3.21.3）の release note を原文確認。Capabilities.KubeVersion / APIVersions のデフォルトは不変、helm template のフラグ既定値変更なし、新規必須フィールドなし。narrow な非破壊的エッジケース3件（v3.17.1 の subchart values null override 修正、v3.18.5 の maintainers 空エントリ拒否、v3.21.1 の ClientOnly panic→エラー化）はいずれもこのリポジトリが使う argo-cd/dex/external-secrets/immich/tailscale-operator の標準的な chart には該当しない。CI green（kustomize build --enable-helm 自体が実地検証を兼ねる）を根拠に low risk のまま着手した"
     }
   ]

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,20 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
+    {
+      "number": 200,
+      "title": "ci: helm バイナリを v3.16.4 → v3.21.3 に更新 (T-0102)",
+      "url": "https://github.com/hikuohiku/homelab/pull/200",
+      "mergedAt": "2026-08-05T14:38:46Z",
+      "headRefName": "autopilot/T-0102-helm-binary-3.21.3"
+    },
     {
       "number": 199,
       "title": "ドキュメントが案内する just recipe の実在を CI で検証する (T-0096)",
       "url": "https://github.com/hikuohiku/homelab/pull/199",
-      "isDraft": false,
-      "createdAt": "2026-08-05T13:36:01Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "PENDING"
-        }
-      ],
-      "headRefName": "autopilot/T-0096-doc-just-recipe-check",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-05T13:41:09Z",
+      "headRefName": "autopilot/T-0096-doc-just-recipe-check"
+    },
     {
       "number": 198,
       "title": "immich 内蔵バックアップの実在検証を pvc-usage-reporter に追加 (T-0068 follow-up)",
@@ -90,7 +89,7 @@
       "number": 187,
       "title": "docs: apps/README.md の ArgoCD Application 出力例を実態に合わせる (T-0094)",
       "url": "https://github.com/hikuohiku/homelab/pull/187",
-      "mergedAt": "2026-08-05T10:33:00Z",
+      "mergedAt": "2026-08-05T10:29:02Z",
       "headRefName": "autopilot/T-0094-apps-readme-app-list"
     },
     {
@@ -379,62 +378,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/141",
       "mergedAt": "2026-08-05T03:58:37Z",
       "headRefName": "autopilot/run25-wrapup"
-    },
-    {
-      "number": 140,
-      "title": "feat(ops): inventory.json に observability_impact フィールドを追加する (T-0059)",
-      "url": "https://github.com/hikuohiku/homelab/pull/140",
-      "mergedAt": "2026-08-05T03:57:19Z",
-      "headRefName": "autopilot/T-0059-inventory-observability-impact"
-    },
-    {
-      "number": 139,
-      "title": "ops: issue #56 のフィードバックを反映する (T-0059)",
-      "url": "https://github.com/hikuohiku/homelab/pull/139",
-      "mergedAt": "2026-08-05T03:53:48Z",
-      "headRefName": "autopilot/T-0059-feedback-cooldown-pagination"
-    },
-    {
-      "number": 138,
-      "title": "ops: run #24 の記録をまとめ、ダッシュボードを再生成する",
-      "url": "https://github.com/hikuohiku/homelab/pull/138",
-      "mergedAt": "2026-08-05T03:31:16Z",
-      "headRefName": "autopilot/run24-wrapup"
-    },
-    {
-      "number": 137,
-      "title": "security(postgres): コンテナに securityContext を追加する (T-0058)",
-      "url": "https://github.com/hikuohiku/homelab/pull/137",
-      "mergedAt": "2026-08-05T03:25:53Z",
-      "headRefName": "autopilot/T-0058-postgres-securitycontext"
-    },
-    {
-      "number": 136,
-      "title": "docs: apps/README.md のディレクトリ構造図をアプリ追加に追随させる (T-0057)",
-      "url": "https://github.com/hikuohiku/homelab/pull/136",
-      "mergedAt": "2026-08-05T03:19:19Z",
-      "headRefName": "autopilot/T-0057-apps-readme-drift"
-    },
-    {
-      "number": 135,
-      "title": "docs: README.md の Terraform ファイル構成・前提バージョンを実態に合わせる (T-0056)",
-      "url": "https://github.com/hikuohiku/homelab/pull/135",
-      "mergedAt": "2026-08-05T03:17:24Z",
-      "headRefName": "autopilot/T-0056-readme-terraform-drift"
-    },
-    {
-      "number": 134,
-      "title": "fix(immich): 実測なしの memory limits を外す",
-      "url": "https://github.com/hikuohiku/homelab/pull/134",
-      "mergedAt": "2026-08-05T02:55:04Z",
-      "headRefName": "autopilot/immich-drop-mem-limits"
-    },
-    {
-      "number": 133,
-      "title": "ops: run #23 の記録をまとめ、ダッシュボードを再生成する",
-      "url": "https://github.com/hikuohiku/homelab/pull/133",
-      "mergedAt": "2026-08-05T02:53:27Z",
-      "headRefName": "autopilot/run23-wrapup"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1494,3 +1494,22 @@
   vaultwarden/coder/immich の3アプリが Healthy に戻ったか確認すること**（このrunで見つけた
   Degraded の件）。T-0079（node01実ディスク、needs-human・priority 30 に降格）・T-0067
   （restic/B2 credential 登録、needs-human・priority 36）は引き続き人間待ち
+
+## 2026-08-05 23:37 JST — run #51
+
+- 前回の中断確認: オープン PR・`autopilot/*` ブランチともに無し。中断なし
+- 読んだフィードバック: issue #56 に新規なし（last_read 以降の唯一のコメントは run #50 自身の
+  返信のエコー）
+- ops-health-report (14:00:04Z) を確認: coder/immich/vaultwarden は引き続き Degraded（T-0067
+  未完了のため想定内、run #50 から変化なし）。ArgoCD の他7アプリは Synced/Healthy。pvc_usage
+  は #198（backup_listing 対応）merge 前の09時台のままで、immich の次回実行（18:05 UTC）を
+  待たないと T-0101 は確認できない
+- backlog の todo は T-0101 のみで今は確認不可のため、CHARTER §3 に従い subagent で新しい
+  調査観点を探索。ci.yml の azure/setup-helm `version:` 入力（helm バイナリ本体、
+  `ops/inventory.json` の `gha-setup-helm-version`）が T-0090（run #43）で監視対象に加えられて
+  以降、一度も上流と比較されておらず v3.16.4 のまま5 minor 分（v3.17〜v3.21.3）遅れていたと
+  判明。別の subagent に v3.17.0〜v3.21.3 の全25リリースノートを原文確認させ、`helm template`
+  のレンダリング挙動に影響する破壊的変更が無いことを確認したうえで T-0102 として着手・完遂
+  （#200, low risk, auto-merge 有効化済み）
+- 次の起動へ: backlog の todo は T-0101（immich pvc-usage-reporter の18:05 UTC実行後に確認）
+  のみ。T-0067・T-0079 は引き続き人間待ち。#200 の merge を見届けること

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-05T13:40:00Z",
+  "updated": "2026-08-05T14:40:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-05T12:48:16Z"
+    "last_read": "2026-08-05T13:40:17Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -571,6 +571,16 @@
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 の未読2件を反映: T-0080 の実測でPVC使用量が全体で1GiB未満と判明したのを受け、T-0066を done化しdocs/backup.mdに記録、T-0067のneeds_human_reasonにB2無料枠で足りる旨を追記、T-0079の緊急度をpriority 1→30に引き下げ、T-0071のblocked_byをT-0067のみに絞った。ops-health-reportを確認したところcoder/immich/vaultwardenの3アプリがDegradedと判明。history上、各restic backup CronJob (T-0068/T-0069/T-0070) のmerge直後に順次Degraded化しており、原因はT-0067未完了でrestic用ExternalSecretが同期できていないことと推定（アプリ本体は正常）。T-0067のneeds_human_reasonに反映しpush通知で人間に伝えた。続けてT-0096（ドキュメントのjust recipe実在をCIで検証）を完遂。ops/check_doc_commands.pyを新設し、実際に.claude/commands/deploy-preview.mdの存在しないrecipe参照（drift）を1件検出・修正した（#199）。",
       "prs": [
         199
+      ]
+    },
+    {
+      "n": 51,
+      "at": "2026-08-05T14:37:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に新規フィードバックなし（last_read 以降唯一のコメントは run #50 自身の返信のエコー）。ops-health-report (14:00:04Z) は run #50 から変化なし（coder/immich/vaultwarden は T-0067 未完了のため Degraded のまま、他7アプリは Synced/Healthy）。backlog の todo は T-0101 のみで、immich の pvc-usage-reporter が18:05 UTCの次回実行を迎えるまで確認不可のため、CHARTER §3 に従い調査。subagent 2件（発見 → リリースノート精査）を投入し、ci.yml の azure/setup-helm `version:` 入力（helm バイナリ本体）が T-0090（run #43）で監視対象化されて以降一度も上流確認されておらず v3.16.4 のまま5 minor 分遅れていたと判明。v3.17.0〜v3.21.3 の全25リリースノートを原文確認し破壊的変更が無いことを確認した上で T-0102 として完遂（#200, low risk, auto-merge → merge 済み）",
+      "prs": [
+        200
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

run #51 の運用記録更新（コード変更なし）。

- `ops/backlog.json`: T-0102（helm バイナリ v3.16.4→v3.21.3、#200）を done に、`next_id` を進める
- `ops/journal/2026-08.md`: run #51 の記録を追記
- `ops/state.json`: `runs` に run #51 を追記、`feedback.last_read` を更新（issue #56 に新規フィードバックなし）
- `ops/dashboard/prs.json`: `mcp__github__list_pull_requests` で最新化（open 0件、merged 直近60件）

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 生成成功

## ロールバック手順

revert すれば記録のみ元に戻る。クラスタ・データへの影響なし。

## backlog task id

（記録更新のみ、個別 task 無し。T-0102 は #200 で対応済み）


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q95oKAF7gN2xLmNWhxfUkB)_