### PR TITLE
feat: 一度きりの Job で restic backup を即時検証する (T-0104)

### DIFF
--- a/apps/coder/kustomization.yaml
+++ b/apps/coder/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - pvc-usage-cronjob.yaml
   - restic-external-secret.yaml
   - restic-backup-cronjob.yaml
+  - restic-backup-verify-job.yaml

--- a/apps/coder/restic-backup-verify-job.yaml
+++ b/apps/coder/restic-backup-verify-job.yaml
@@ -1,0 +1,102 @@
+# T-0104: 一度きりの検証用 Job。coder-restic-backup CronJob（次回実行 03:10 UTC、明朝）を
+# 待たず、T-0103（remoteRef のキー名不一致修正）が実際に反映されて restic backup が成功するかを
+# 今すぐ確認するため、restic-backup-cronjob.yaml の jobTemplate と同じ内容を一度だけ走らせる
+# （issue #56, 2026-08-05 15:49:52 構築セッションの提案）。
+#
+# 確認が取れ次第、この Job は削除する PR を出す（restic-backup-cronjob.yaml 側は変更しない、
+# CronJob の schedule は引き続き 03:10 UTC のまま）。
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: coder-restic-backup-verify
+  namespace: coder
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
+  template:
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      initContainers:
+        - name: pg-dump
+          image: postgres:17.10
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              PGPASSWORD="$POSTGRES_PASSWORD" pg_dump \
+                -h coder-postgres -U coder -d coder \
+                -Fc -f /staging/coder-postgres.dump
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: coder-postgres-credentials
+                  key: password
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+            runAsGroup: 999
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 20m
+              memory: 64Mi
+            limits:
+              cpu: 300m
+          volumeMounts:
+            - name: staging
+              mountPath: /staging
+      containers:
+        - name: restic-backup
+          image: restic/restic:0.19.1
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              restic snapshots >/dev/null 2>&1 || restic init
+              restic backup /staging/coder-postgres.dump
+          env:
+            - name: RESTIC_B2_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: coder-restic-credentials
+                  key: RESTIC_B2_BUCKET
+            - name: RESTIC_REPOSITORY
+              value: "b2:$(RESTIC_B2_BUCKET):coder-postgres"
+            - name: RESTIC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: coder-restic-credentials
+                  key: RESTIC_PASSWORD
+            - name: B2_ACCOUNT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: coder-restic-credentials
+                  key: B2_ACCOUNT_ID
+            - name: B2_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: coder-restic-credentials
+                  key: B2_ACCOUNT_KEY
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+          volumeMounts:
+            - name: staging
+              mountPath: /staging
+              readOnly: true
+      volumes:
+        - name: staging
+          emptyDir: {}

--- a/apps/immich/kustomization.yaml
+++ b/apps/immich/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - pvc-usage-cronjob.yaml
   - restic-external-secret.yaml
   - restic-backup-cronjob.yaml
+  - restic-backup-verify-job.yaml

--- a/apps/immich/restic-backup-verify-job.yaml
+++ b/apps/immich/restic-backup-verify-job.yaml
@@ -1,0 +1,75 @@
+# T-0104: 一度きりの検証用 Job。immich-restic-backup CronJob（次回実行 02:45 UTC、明朝）を
+# 待たず、T-0103（remoteRef のキー名不一致修正）が実際に反映されて restic backup が成功するかを
+# 今すぐ確認するため、restic-backup-cronjob.yaml の jobTemplate と同じ内容を一度だけ走らせる
+# （issue #56, 2026-08-05 15:49:52 構築セッションの提案）。immich 自身の内蔵日次DBダンプ
+# （毎日02:00 UTC）の完了は待たないため、backups/ 配下は前日分のままの可能性がある
+# （ライブラリ本体の restic backup 成否の確認が目的で、DB ダンプの世代確認は T-0101 が担う）。
+#
+# 確認が取れ次第、この Job は削除する PR を出す（restic-backup-cronjob.yaml 側は変更しない、
+# CronJob の schedule は引き続き 02:45 UTC のまま）。
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: immich-restic-backup-verify
+  namespace: immich
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 3600
+  template:
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      containers:
+        - name: restic-backup
+          image: restic/restic:0.19.1
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              restic snapshots >/dev/null 2>&1 || restic init
+              restic backup /mnt/immich-library
+          env:
+            - name: RESTIC_B2_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: immich-restic-credentials
+                  key: RESTIC_B2_BUCKET
+            - name: RESTIC_REPOSITORY
+              value: "b2:$(RESTIC_B2_BUCKET):immich"
+            - name: RESTIC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: immich-restic-credentials
+                  key: RESTIC_PASSWORD
+            - name: B2_ACCOUNT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: immich-restic-credentials
+                  key: B2_ACCOUNT_ID
+            - name: B2_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: immich-restic-credentials
+                  key: B2_ACCOUNT_KEY
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+              add: ["DAC_READ_SEARCH"]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+          volumeMounts:
+            - name: immich-library
+              mountPath: /mnt/immich-library
+              readOnly: true
+      volumes:
+        - name: immich-library
+          persistentVolumeClaim:
+            claimName: immich-library
+            readOnly: true

--- a/apps/vaultwarden/kustomization.yaml
+++ b/apps/vaultwarden/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - pvc-usage-cronjob.yaml
   - restic-external-secret.yaml
   - restic-backup-cronjob.yaml
+  - restic-backup-verify-job.yaml

--- a/apps/vaultwarden/restic-backup-verify-job.yaml
+++ b/apps/vaultwarden/restic-backup-verify-job.yaml
@@ -1,0 +1,116 @@
+# T-0104: 一度きりの検証用 Job。vaultwarden-restic-backup CronJob（次回実行 03:40 UTC、
+# 明朝）を待たず、T-0103（remoteRef のキー名不一致修正）が実際に反映されて restic backup
+# が成功するかを今すぐ確認するため、restic-backup-cronjob.yaml の jobTemplate と同じ内容を
+# 一度だけ走らせる（issue #56, 2026-08-05 15:49:52 構築セッションの提案）。
+#
+# 確認が取れ次第、この Job は削除する PR を出す（restic-backup-cronjob.yaml 側は変更しない、
+# CronJob の schedule は引き続き 03:40 UTC のまま）。
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: vaultwarden-restic-backup-verify
+  namespace: vaultwarden
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1800
+  template:
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      initContainers:
+        - name: sqlite-snapshot
+          image: python:3.12-alpine
+          command: ["python", "/scripts/sqlite_backup.py"]
+          env:
+            - name: SRC_DB
+              value: /mnt/vaultwarden-data/db.sqlite3
+            - name: DST_DB
+              value: /staging/db.sqlite3
+            - name: PYTHONDONTWRITEBYTECODE
+              value: "1"
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+              add: ["DAC_READ_SEARCH"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 300m
+              memory: 256Mi
+          volumeMounts:
+            - name: script
+              mountPath: /scripts
+              readOnly: true
+            - name: vaultwarden-data
+              mountPath: /mnt/vaultwarden-data
+              readOnly: true
+            - name: staging
+              mountPath: /staging
+      containers:
+        - name: restic-backup
+          image: restic/restic:0.19.1
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              restic snapshots >/dev/null 2>&1 || restic init
+              restic backup /mnt/vaultwarden-data /staging/db.sqlite3 \
+                --exclude db.sqlite3 --exclude db.sqlite3-wal --exclude db.sqlite3-shm \
+                --exclude icon_cache
+          env:
+            - name: RESTIC_B2_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: vaultwarden-restic-credentials
+                  key: RESTIC_B2_BUCKET
+            - name: RESTIC_REPOSITORY
+              value: "b2:$(RESTIC_B2_BUCKET):vaultwarden"
+            - name: RESTIC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: vaultwarden-restic-credentials
+                  key: RESTIC_PASSWORD
+            - name: B2_ACCOUNT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: vaultwarden-restic-credentials
+                  key: B2_ACCOUNT_ID
+            - name: B2_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: vaultwarden-restic-credentials
+                  key: B2_ACCOUNT_KEY
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+              add: ["DAC_READ_SEARCH"]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+          volumeMounts:
+            - name: vaultwarden-data
+              mountPath: /mnt/vaultwarden-data
+              readOnly: true
+            - name: staging
+              mountPath: /staging
+              readOnly: true
+      volumes:
+        - name: script
+          configMap:
+            name: vaultwarden-restic-sqlite-backup-script
+        - name: vaultwarden-data
+          persistentVolumeClaim:
+            claimName: vaultwarden-data
+            readOnly: true
+        - name: staging
+          emptyDir: {}

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 104,
+  "next_id": 105,
   "updated": "2026-08-05T16:19:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
@@ -1322,13 +1322,13 @@
       "why": "issue #56 (2026-08-05 04:40:59) の人間の新方針。『試したことのないバックアップは、バックアップではありません』。T-0068〜T-0070 で作った CronJob が実際に復元可能なデータを作れているかを、別 namespace か使い捨て環境に実際に復元して確認する。T-0023/T-0027/T-0029（データを失いうるメジャー更新）はこれが通るまで着手できない（T-0034 dropped に伴い、これらの blocked_by をここに張り替え済み）",
       "dod": "immich / vaultwarden / coder-postgres それぞれについて、restic のバックアップから使い捨て環境（別 namespace 等）に実際に復元し、データが読めることを確認する。**復元にかかった時間を実測して記録する**（PBS 退役判断の材料になる、人間の依頼どおり）。結果を docs/backup.md に記録する",
       "needs_human_reason": "復元試験にはクラスタへの到達（別 namespace の作成、restic restore コマンドの実行）が要る。autopilot のクラウドサンドボックスは到達できない（CHARTER §5.2）。ただし実装（CronJob の manifest、restic restore の手順書）自体はブロックされずに進められるため blocked のままにし、needs-human への切り替えは T-0068〜T-0070 が終わってから判断する",
-      "blocked_by": "T-0067（restic/B2 credential 登録。T-0068〜T-0070 の実装自体は完了済みだが、実際にバックアップが成功していないと復元試験もできない）",
+      "blocked_by": "T-0104（一度きりの検証 Job で restic backup 自体が成功することを先に確認する。T-0067 は完了済み）",
       "refs": [
         "docs/backup.md"
       ],
       "created": "2026-08-05",
       "pr": null,
-      "notes": " | run #50: issue #56 (12:48:16) の指摘で、immich がまだほとんど使われていない（332MiB）今のうちに復元試験まで通しておくべきと助言された。T-0068〜T-0070 の実装は完了済みのため blocked_by を T-0067 のみに絞った。T-0067 が片付き次第、最優先で着手する。"
+      "notes": " | run #50: issue #56 (12:48:16) の指摘で、immich がまだほとんど使われていない（332MiB）今のうちに復元試験まで通しておくべきと助言された。T-0068〜T-0070 の実装は完了済みのため blocked_by を T-0067 のみに絞った。T-0067 が片付き次第、最優先で着手する。 | run #53: T-0067 done。ただし T-0103（remoteRef タイポ）修正直後のため、まだ一度も backup が成功した実績が無い。T-0104（検証 Job）の結果を待ってから着手する。復元試験自体（別 namespace の作成、restic restore の実行）は write 権限が要るため、構築セッションの現状（`agent-reader`、view 相当）では足りない可能性がある点に注意"
     },
     {
       "id": "T-0072",
@@ -1802,7 +1802,7 @@
       "priority": 41,
       "why": "T-0069 (#191) は manifest 実装のみで、実際に restic push が成功するかは T-0067 の credential 登録が終わるまで検証できない（このクラウドサンドボックスは k8s Job のログを見られない）。CHARTER §4『PR 本文に残った不確実性を書いたら同じ PR で backlog にも軽量な確認待ちタスクとして起票する』に従い分離",
       "dod": "T-0067 の Doppler 登録後、次回以降の起動で ops-health-report の pod_issues に `vaultwarden-restic-backup`/`vaultwarden-restic-retention` の CronJob の Job が Failed で出ていないかを確認する。問題なければ docs/backup.md に成功日時を記録して done にする。継続的に失敗するなら症状を記録し、原因調査を新規タスクとして起票する",
-      "blocked_by": "T-0067（credential 登録。登録完了後の確認作業自体は autopilot が行う）",
+      "blocked_by": "T-0104（一度きりの検証 Job の実行結果。T-0067 は完了済み）",
       "refs": [
         "apps/vaultwarden/restic-backup-cronjob.yaml",
         "docs/backup.md"
@@ -1841,7 +1841,7 @@
       "priority": 41,
       "why": "T-0068 は manifest 実装のみで、実際に restic push が成功するかは T-0067 の credential 登録が終わるまで検証できない（このクラウドサンドボックスは k8s Job のログを見られない）。T-0097（vaultwarden 版）/T-0099（coder-postgres 版）と同型",
       "dod": "T-0067 の Doppler 登録後、次回以降の起動で ops-health-report の pod_issues に `immich-restic-backup`/`immich-restic-retention` の CronJob の Job が Failed で出ていないかを確認する。あわせて `immich-restic-backup` が想定どおり immich 自身の日次DBダンプ完了後（02:45 UTC）に走っていることも確認する。問題なければ docs/backup.md に成功日時を記録して done にする。継続的に失敗するなら症状を記録し、原因調査を新規タスクとして起票する",
-      "blocked_by": "T-0067（credential 登録。登録完了後の確認作業自体は autopilot が行う）",
+      "blocked_by": "T-0104（一度きりの検証 Job の実行結果。T-0067 は完了済み）",
       "refs": [
         "apps/immich/restic-backup-cronjob.yaml",
         "docs/backup.md"
@@ -1877,7 +1877,7 @@
       "priority": 41,
       "why": "T-0070 は manifest 実装のみで、実際に restic push が成功するかは T-0067 の credential 登録が終わるまで検証できない（このクラウドサンドボックスは k8s Job のログを見られない）。T-0097（vaultwarden 版）と同型",
       "dod": "T-0067 の Doppler 登録後、次回以降の起動で ops-health-report の pod_issues に `coder-restic-backup`/`coder-restic-retention` の CronJob の Job が Failed で出ていないかを確認する。問題なければ docs/backup.md に成功日時を記録して done にする。継続的に失敗するなら症状を記録し、原因調査を新規タスクとして起票する",
-      "blocked_by": "T-0067（credential 登録。登録完了後の確認作業自体は autopilot が行う）",
+      "blocked_by": "T-0104（一度きりの検証 Job の実行結果。T-0067 は完了済み）",
       "refs": [
         "apps/coder/restic-backup-cronjob.yaml",
         "docs/backup.md"
@@ -1922,6 +1922,25 @@
       "created": "2026-08-05",
       "pr": 205,
       "notes": "run #53: issue #56 の指摘（T-0067 完了報告）を反映する過程で、依頼した2工程（Doppler 登録キー名の確定と、manifest 側のキー名）を実際に突き合わせて初めて発見した。CHARTER §4『縛る変更には実測か裏付けが要る』の逆パターンとして、『裏付けを取ったつもりが実装側の転記ミスを見落とす』ケースが起きうると分かった。secretKey（k8s Secret 内のキー名、コンテナ側の環境変数名と一致させる用）と remoteRef.key（Doppler 側のキー名）を混同しやすい構造で、コメントヘッダーの記述と実際の remoteRef.key がズレていても CI（kustomize build）はこれを検出できない（構文的には正しい YAML なので）。CI で検出できない領域だったため実測（今回は構築セッションによる Doppler API 直接確認）が唯一の発見経路だった。CI green（6件success）を確認し即マージした（#205）"
+    },
+    {
+      "id": "T-0104",
+      "domain": "homelab",
+      "title": "一度きりの検証用 Job で vaultwarden/coder-postgres/immich の restic backup を即時検証する",
+      "kind": "investigate",
+      "risk": "medium",
+      "status": "todo",
+      "priority": 5,
+      "why": "issue #56（構築セッション、2026-08-05 15:49:52）の提案。T-0069/T-0070/T-0068 の CronJob は次回実行が明朝（vaultwarden 03:40 / coder-postgres 03:10 / immich 02:45 UTC）で、T-0103 の修正が実際に反映されて restic backup が成功するかをそれまで確認できない。CronJob の jobTemplate と同じ内容の一度きりの Job を追加すれば ArgoCD sync 直後に1回だけ走り、待たずに確認できる。人間の方針（『試したことのないバックアップは、バックアップではありません』）に沿って T-0071（復元試験）へできるだけ早く進むための前段",
+      "dod": "apps/{vaultwarden,coder,immich}/restic-backup-verify-job.yaml が ArgoCD で同期され、3つの Job が Complete になる。restic のリポジトリ初期化（`restic init`）が成功し B2 にオブジェクトが作られたことを、次回以降の起動で ops-health-report の pod_issues（Job が Failed で出ていないか）と、可能なら構築セッションに issue #56 経由でログ確認を依頼して確認する。成功が確認できたら T-0097/T-0099/T-0100 を done にし、この Job 3つを削除する PR を出す（CronJob 自体は変更しない、以後は schedule どおりに動く）",
+      "refs": [
+        "apps/vaultwarden/restic-backup-verify-job.yaml",
+        "apps/coder/restic-backup-verify-job.yaml",
+        "apps/immich/restic-backup-verify-job.yaml"
+      ],
+      "created": "2026-08-05",
+      "pr": null,
+      "notes": "run #53: risk を medium とした理由: 実データを外部（B2）へ初めて書き込む操作だが、ソース側（PVC/DB）には読み取り専用でしか触れず（restic backup は非破壊）、Job はいつでも削除できる。CronJob の jobTemplate をそのままコピーしただけで新しいロジックは無いため『縛る変更』（CHARTER §4）には該当しない。ロールバック手順: Job 3つを削除する PR を出せば良い。B2 側に作られたオブジェクトは残るが、追加コストは実質ゼロ（無料枠 10GB 以内）で害はない"
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`apps/{vaultwarden,coder,immich}/restic-backup-verify-job.yaml` を追加。既存の
`restic-backup-cronjob.yaml` の `jobTemplate`（backup 側のみ、retention は含まない）と
全く同じ内容を、一度だけ走る `Job` として複製した。CronJob 自体（schedule 含む）は変更していない。

## 背景

T-0103（#205）で ExternalSecret の remoteRef タイポを修正したが、各 CronJob の次回実行は
明朝（vaultwarden 03:40 / coder-postgres 03:10 / immich 02:45 UTC）で、それまで修正が実際に
効いて restic backup が成功するかを確認できない。issue #56（構築セッション、2026-08-05
15:49:52）の提案どおり、一度きりの `Job` を追加して待たずに検証する。

## 検証したこと

- 3ファイルとも該当 CronJob の `jobTemplate.spec.template.spec` をそのまま複製しただけで、
  新しいロジック・新しい image tag・新しい RBAC は追加していない
- `python3 ops/validate.py` → 0 error
- kustomization.yaml 3ファイルに新しい resource を追加。CI（kustomize build / manifest-diff）
  で構文とレンダリング結果を検証する

## リスクと安全性

- ソース側（PVC・DB）には既存の CronJob と同じ read-only の触り方しかしない（restic backup は
  非破壊）。書き込み先は B2（外部）のみで、成功しても失敗してもクラスタ内のデータには影響しない
- 初めて実際に credential を使って書き込みを行う操作だが、CronJob が明朝行うのと全く同じ操作を
  数時間早めるだけ

## ロールバック手順

このコミットを revert すれば Job 3つが消えるだけ（DB・PVC のデータには一切触れていないため
巻き戻すべきスキーマ変更等は無い）。B2 側に作られたオブジェクトは残るが、無料枠（10GB）以内の
微小なデータで実害は無い。確認が取れ次第、別 PR でこの Job 3つを削除する（CHARTER のとおり
「使い切ったら消す」）。

## backlog task id

T-0104。あわせて T-0071/T-0097/T-0099/T-0100 の `blocked_by` を T-0067（完了済み）から
T-0104 の実行結果待ちに更新した。


---
_Generated by [Claude Code](https://claude.ai/code/session_01AvUXWZj5HVXTd6ZEMNYDyC)_