### PR TITLE
ops: run #53 の記録更新（T-0103 修正確認、journal・state・PRキャッシュ、ダッシュボード再公開）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 105,
-  "updated": "2026-08-05T16:19:00Z",
+  "updated": "2026-08-05T16:20:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -1939,8 +1939,8 @@
         "apps/immich/restic-backup-verify-job.yaml"
       ],
       "created": "2026-08-05",
-      "pr": null,
-      "notes": "run #53: risk を medium とした理由: 実データを外部（B2）へ初めて書き込む操作だが、ソース側（PVC/DB）には読み取り専用でしか触れず（restic backup は非破壊）、Job はいつでも削除できる。CronJob の jobTemplate をそのままコピーしただけで新しいロジックは無いため『縛る変更』（CHARTER §4）には該当しない。ロールバック手順: Job 3つを削除する PR を出せば良い。B2 側に作られたオブジェクトは残るが、追加コストは実質ゼロ（無料枠 10GB 以内）で害はない"
+      "pr": 207,
+      "notes": "run #53: risk を medium とした理由: 実データを外部（B2）へ初めて書き込む操作だが、ソース側（PVC/DB）には読み取り専用でしか触れず（restic backup は非破壊）、Job はいつでも削除できる。CronJob の jobTemplate をそのままコピーしただけで新しいロジックは無いため『縛る変更』（CHARTER §4）には該当しない。ロールバック手順: Job 3つを削除する PR を出せば良い。B2 側に作られたオブジェクトは残るが、追加コストは実質ゼロ（無料枠 10GB 以内）で害はない。CI green を確認し即マージした（#207）。副次的な確認: T-0103 (#205) merge 直後（16:00:04Z）の ops-health-report で vaultwarden/coder/immich が既に Synced/Healthy に戻っていることを確認した——ExternalSecret の同期自体は Job の実行を待たずに直った（remoteRef 修正だけで解決する話だったため、これは想定どおり）。Job 自体（初回の実際の B2 書き込み）が成功したかどうかは、この Job が #207 merge 後に ArgoCD で同期されるのを待つ必要があり、この run の時点ではまだ反映前のため確認できていない。次回以降の起動で ops-health-report の pod_issues を確認すること"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,59 +1,425 @@
 {
   "open": [],
   "merged": [
-    {"number": 202, "title": "feat(ops): ダッシュボードを作り直す — 主役を「何をすればいいか」にする", "url": "https://github.com/hikuohiku/homelab/pull/202", "mergedAt": "2026-08-05T15:10:23Z", "headRefName": "autopilot/dashboard-redesign"},
-    {"number": 201, "title": "ops: run #51 の記録更新（T-0102 完遂・journal・state・PRキャッシュ）", "url": "https://github.com/hikuohiku/homelab/pull/201", "mergedAt": "2026-08-05T14:42:43Z", "headRefName": "autopilot/run51-record"},
-    {"number": 200, "title": "ci: helm バイナリを v3.16.4 → v3.21.3 に更新 (T-0102)", "url": "https://github.com/hikuohiku/homelab/pull/200", "mergedAt": "2026-08-05T14:38:46Z", "headRefName": "autopilot/T-0102-helm-binary-3.21.3"},
-    {"number": 199, "title": "ドキュメントが案内する just recipe の実在を CI で検証する (T-0096)", "url": "https://github.com/hikuohiku/homelab/pull/199", "mergedAt": "2026-08-05T13:41:09Z", "headRefName": "autopilot/T-0096-doc-just-recipe-check"},
-    {"number": 198, "title": "immich 内蔵バックアップの実在検証を pvc-usage-reporter に追加 (T-0068 follow-up)", "url": "https://github.com/hikuohiku/homelab/pull/198", "mergedAt": "2026-08-05T12:49:06Z", "headRefName": "autopilot/T-0068-followup-verify-immich-backup-dump"},
-    {"number": 197, "title": "restic/restic イメージタグの重複を check_version_sync.py の監視対象に追加 (T-0098)", "url": "https://github.com/hikuohiku/homelab/pull/197", "mergedAt": "2026-08-05T12:41:04Z", "headRefName": "autopilot/T-0098-restic-image-tag-ci"},
-    {"number": 196, "title": "immich-library 用 restic backup CronJob を追加 (T-0068)", "url": "https://github.com/hikuohiku/homelab/pull/196", "mergedAt": "2026-08-05T12:37:04Z", "headRefName": "autopilot/T-0068-immich-restic-backup"},
-    {"number": 195, "title": "coder-postgres 用 restic backup CronJob を追加 (T-0070)", "url": "https://github.com/hikuohiku/homelab/pull/195", "mergedAt": "2026-08-05T12:28:53Z", "headRefName": "autopilot/T-0070-coder-postgres-restic-backup"},
-    {"number": 194, "title": "ops: run #48 の記録更新（journal・state・PRキャッシュ、T-0095 id重複の再発防止）", "url": "https://github.com/hikuohiku/homelab/pull/194", "mergedAt": "2026-08-05T12:03:09Z", "headRefName": "autopilot/run48-record"},
-    {"number": 189, "title": "docs: apps/README.md の使われていない旧ブートストラップ手順を削除する (T-0095)", "url": "https://github.com/hikuohiku/homelab/pull/189", "mergedAt": "2026-08-05T11:55:33Z", "headRefName": "autopilot/T-0095-apps-readme-dead-bootstrap"},
-    {"number": 192, "title": "fix: vaultwarden backupのsqlite-snapshotをapk依存からpython標準ライブラリへ (T-0069 follow-up)", "url": "https://github.com/hikuohiku/homelab/pull/192", "mergedAt": "2026-08-05T11:54:12Z", "headRefName": "autopilot/T-0069-followup-drop-apk-dep"},
-    {"number": 191, "title": "feat: vaultwarden用restic backup CronJobを追加 (T-0069)", "url": "https://github.com/hikuohiku/homelab/pull/191", "mergedAt": "2026-08-05T11:41:15Z", "headRefName": "autopilot/T-0069-vaultwarden-restic-backup"},
-    {"number": 190, "title": "CHARTER: blocked/needs-humanをタスク全体でなく部分で見る (T-0095)", "url": "https://github.com/hikuohiku/homelab/pull/190", "mergedAt": "2026-08-05T11:32:44Z", "headRefName": "autopilot/T-0095-blocked-granularity"},
-    {"number": 188, "title": "ops: run #47 の記録更新（PR番号反映・journal・state・PRキャッシュ）", "url": "https://github.com/hikuohiku/homelab/pull/188", "mergedAt": "2026-08-05T11:23:58Z", "headRefName": "autopilot/run47-record"},
-    {"number": 187, "title": "docs: apps/README.md の ArgoCD Application 出力例を実態に合わせる (T-0094)", "url": "https://github.com/hikuohiku/homelab/pull/187", "mergedAt": "2026-08-05T10:29:02Z", "headRefName": "autopilot/T-0094-apps-readme-app-list"},
-    {"number": 186, "title": "docs: CLAUDE.md の autopilot 定期実行間隔記述を実態に合わせる (T-0093)", "url": "https://github.com/hikuohiku/homelab/pull/186", "mergedAt": "2026-08-05T09:29:57Z", "headRefName": "autopilot/T-0093-claude-md-schedule-interval"},
-    {"number": 183, "title": "docs: README.md の insecure 手順を実態に合わせる (T-0092)", "url": "https://github.com/hikuohiku/homelab/pull/183", "mergedAt": "2026-08-05T09:25:25Z", "headRefName": "autopilot/T-0092-readme-insecure-fix"},
-    {"number": 182, "title": "ops: T-0091 の PR 番号反映、PR キャッシュ最新化 (run #43)", "url": "https://github.com/hikuohiku/homelab/pull/182", "mergedAt": "2026-08-05T09:04:43Z", "headRefName": "autopilot/run43-pr-numbers"},
-    {"number": 180, "title": "ci: terraform_version を 1.15.0 → 1.15.8 に更新 (T-0091)", "url": "https://github.com/hikuohiku/homelab/pull/180", "mergedAt": "2026-08-05T09:01:37Z", "headRefName": "autopilot/T-0091-terraform-binary-version"},
-    {"number": 178, "title": "ci: kustomize/helm バイナリ版を version_sync の監視対象に追加 (T-0090)", "url": "https://github.com/hikuohiku/homelab/pull/178", "mergedAt": "2026-08-05T08:53:29Z", "headRefName": "autopilot/T-0090-ci-binary-version-tracking"},
-    {"number": 177, "title": "ops: run #42 のラップアップ（PR #175/#176 反映）", "url": "https://github.com/hikuohiku/homelab/pull/177", "mergedAt": "2026-08-05T08:48:16Z", "headRefName": "autopilot/run42-wrapup"},
-    {"number": 176, "title": "docs: CLAUDE.md の Apps/ディレクトリ構造を実態に合わせる (T-0089)", "url": "https://github.com/hikuohiku/homelab/pull/176", "mergedAt": "2026-08-05T08:46:20Z", "headRefName": "autopilot/T-0089-claude-md-apps"},
-    {"number": 175, "title": "ops: T-0087/T-0088 完遂の記録、T-0090 起票 (run #42)", "url": "https://github.com/hikuohiku/homelab/pull/175", "mergedAt": "2026-08-05T08:44:20Z", "headRefName": "autopilot/T-0087-record"},
-    {"number": 174, "title": "ops: tailscale-operator/k8s-nameserver の v1.102.2 更新調査結果を記録 (run #41)", "url": "https://github.com/hikuohiku/homelab/pull/174", "mergedAt": "2026-08-05T08:37:19Z", "headRefName": "autopilot/tailscale-v1102-investigation"},
-    {"number": 173, "title": "ops: run #40 の記録漏れ(state.json/last_read)を埋め合わせ、PRキャッシュ更新", "url": "https://github.com/hikuohiku/homelab/pull/173", "mergedAt": "2026-08-05T08:30:59Z", "headRefName": "autopilot/records-run40-catchup"},
-    {"number": 172, "title": "issue #56 のフィードバックを反映: DB コンポーネントのロールバック手順にスキーマの扱いを明記する規則を追加", "url": "https://github.com/hikuohiku/homelab/pull/172", "mergedAt": "2026-08-05T08:23:29Z", "headRefName": "autopilot/T-0086-rollback-wording"},
-    {"number": 171, "title": "immich server/machine-learning を v2.6.3 → v2.7.5 に更新 (T-0086)", "url": "https://github.com/hikuohiku/homelab/pull/171", "mergedAt": "2026-08-05T08:16:43Z", "headRefName": "autopilot/T-0086-immich-v2.7.5"},
-    {"number": 170, "title": "ops: T-0085 の PR番号(#169)を記録に反映", "url": "https://github.com/hikuohiku/homelab/pull/170", "mergedAt": "2026-08-05T07:50:37Z", "headRefName": "autopilot/T-0085-pr-record"},
-    {"number": 169, "title": "T-0085: pvc_usage 404 の想定内/異常の区別基準を CHARTER に明記", "url": "https://github.com/hikuohiku/homelab/pull/169", "mergedAt": "2026-08-05T07:48:58Z", "headRefName": "autopilot/T-0085-pvc-usage-404-criterion"},
-    {"number": 168, "title": "T-0083: ops-health-reporter に履歴（history/YYYY-MM-DD.jsonl）を追加", "url": "https://github.com/hikuohiku/homelab/pull/168", "mergedAt": "2026-08-05T07:43:01Z", "headRefName": "autopilot/T-0083-health-report-history"},
-    {"number": 167, "title": "T-0082: pvc-usage-reporter の python イメージを inventory 監視対象に追加", "url": "https://github.com/hikuohiku/homelab/pull/167", "mergedAt": "2026-08-05T07:26:09Z", "headRefName": "autopilot/T-0082-pvc-usage-reporter-image-inventory"},
-    {"number": 166, "title": "ci: pvc-usage-reporter の埋め込みスクリプト3ファイルの一致を検証する (T-0081)", "url": "https://github.com/hikuohiku/homelab/pull/166", "mergedAt": "2026-08-05T07:09:53Z", "headRefName": "autopilot/T-0081-pvc-usage-script-sync"},
-    {"number": 165, "title": "run #35: T-0080 完遂の記録更新", "url": "https://github.com/hikuohiku/homelab/pull/165", "mergedAt": "2026-08-05T07:03:37Z", "headRefName": "autopilot/T-0080-records-2"},
-    {"number": 163, "title": "PVC の実使用量を計測する namespace 別 CronJob を追加 (T-0080)", "url": "https://github.com/hikuohiku/homelab/pull/163", "mergedAt": "2026-08-05T06:59:02Z", "headRefName": "autopilot/T-0080-pvc-usage"},
-    {"number": 164, "title": "run #34: T-0080 の並行セッション調整反映、記録更新", "url": "https://github.com/hikuohiku/homelab/pull/164", "mergedAt": "2026-08-05T06:37:26Z", "headRefName": "autopilot/T-0080-records"},
-    {"number": 162, "title": "ops: T-0080 に fsGroup 再帰 chown リスクを追記 (run #33)", "url": "https://github.com/hikuohiku/homelab/pull/162", "mergedAt": "2026-08-05T06:33:03Z", "headRefName": "autopilot/T-0080-fsgroup-risk-note"},
-    {"number": 161, "title": "ops-health-reporter に metrics-server 経由のコンテナ実メモリ/CPU 収集を追加", "url": "https://github.com/hikuohiku/homelab/pull/161", "mergedAt": "2026-08-05T06:27:26Z", "headRefName": "autopilot/T-0077-metrics-collect"},
-    {"number": 160, "title": "ops: node01 実ディスク容量の食い違いを起票、PR作り直し時の規則を追記 (T-0079)", "url": "https://github.com/hikuohiku/homelab/pull/160", "mergedAt": "2026-08-05T06:05:50Z", "headRefName": "autopilot/T-0079-node01-disk-discrepancy"},
-    {"number": 159, "title": "ops: 取り残された cooldown/直列化の衝突対策を CHARTER に戻す", "url": "https://github.com/hikuohiku/homelab/pull/159", "mergedAt": "2026-08-05T05:56:52Z", "headRefName": "autopilot/recover-charter-cooldown-rule"},
-    {"number": 158, "title": "T-0015/T-0075: ops-health-reporter の動作確認、run #30 のラップアップ", "url": "https://github.com/hikuohiku/homelab/pull/158", "mergedAt": "2026-08-05T05:39:41Z", "headRefName": "autopilot/T-0075-health-reporter-confirmed"},
-    {"number": 157, "title": "T-0065: IaC 完全性の棚卸し — node01 揮発時の未カバー領域を確認", "url": "https://github.com/hikuohiku/homelab/pull/157", "mergedAt": "2026-08-05T05:34:05Z", "headRefName": "autopilot/T-0065-iac-completeness"},
-    {"number": 156, "title": "run #30: issue #56 のフィードバック2件を反映（cooldown/直列化の規則衝突、#153 レビュー）", "url": "https://github.com/hikuohiku/homelab/pull/156", "mergedAt": "2026-08-05T05:27:17Z", "headRefName": "autopilot/run30-feedback"},
-    {"number": 152, "title": "docs: terraform plan の CI 化を調査する (T-0073)", "url": "https://github.com/hikuohiku/homelab/pull/152", "mergedAt": "2026-08-05T05:23:45Z", "headRefName": "autopilot/T-0073-terraform-plan-ci-feasibility"},
-    {"number": 153, "title": "T-0015: ArgoCD/k8s の健全性を homelab から repo へ書き戻す CronJob を追加", "url": "https://github.com/hikuohiku/homelab/pull/153", "mergedAt": "2026-08-05T05:21:50Z", "headRefName": "autopilot/T-0015-ops-health-reporter"},
-    {"number": 154, "title": "ops: run #29 の記録をまとめ、ダッシュボードを再生成する", "url": "https://github.com/hikuohiku/homelab/pull/154", "mergedAt": "2026-08-05T05:16:19Z", "headRefName": "autopilot/run29-wrapup"},
-    {"number": 151, "title": "T-0011: vaultwarden ADMIN_TOKEN の Argon2 PHC 化を完了扱いにする", "url": "https://github.com/hikuohiku/homelab/pull/151", "mergedAt": "2026-08-05T05:06:53Z", "headRefName": "autopilot/T-0011-vaultwarden-admin-token-done"},
-    {"number": 150, "title": "ops: run #28 の記録をまとめる（T-0064 merge、backup 方針転換の反映）", "url": "https://github.com/hikuohiku/homelab/pull/150", "mergedAt": "2026-08-05T04:59:11Z", "headRefName": "autopilot/run28-wrapup"},
-    {"number": 149, "title": "T-0064: proxmox_virtual_environment_download_file を proxmox_download_file に改名", "url": "https://github.com/hikuohiku/homelab/pull/149", "mergedAt": "2026-08-05T04:52:53Z", "headRefName": "autopilot/T-0064-terraform-download-file-rename"},
-    {"number": 148, "title": "T-0062: k3s 1.34→1.35の非推奨API影響確認、および人間merge分の記録同期", "url": "https://github.com/hikuohiku/homelab/pull/148", "mergedAt": "2026-08-05T04:35:42Z", "headRefName": "autopilot/T-0062-k3s-1.35-deprecation-check"},
-    {"number": 147, "title": "T-0061: 時刻表示のJST化と、残った不確実性のbacklog追跡", "url": "https://github.com/hikuohiku/homelab/pull/147", "mergedAt": "2026-08-05T04:25:47Z", "headRefName": "autopilot/T-0061-jst-time-and-uncertainty-tracking"},
-    {"number": 146, "title": "chore(nix): flake.lock を更新する（nixpkgs 2025-12-08 → 2026-08-04）", "url": "https://github.com/hikuohiku/homelab/pull/146", "mergedAt": "2026-08-05T04:24:50Z", "headRefName": "autopilot/T-0049-nix-flake-update"},
-    {"number": 145, "title": "chore(terraform): bpg/proxmox provider を 0.89.1 → 0.111.1 に上げる", "url": "https://github.com/hikuohiku/homelab/pull/145", "mergedAt": "2026-08-05T04:22:12Z", "headRefName": "autopilot/T-0030-tf-provider-0.111.1"},
-    {"number": 144, "title": "ops: run #26 の記録をまとめ、T-0060 を起票する", "url": "https://github.com/hikuohiku/homelab/pull/144", "mergedAt": "2026-08-05T04:14:29Z", "headRefName": "autopilot/T-0060-dex-argocd-secret-plaintext"},
-    {"number": 143, "title": "feat(ops): ダッシュボードにストリーム分類とガントを追加する", "url": "https://github.com/hikuohiku/homelab/pull/143", "mergedAt": "2026-08-05T04:05:35Z", "headRefName": "autopilot/dashboard-streams-gantt"}
+    {
+      "number": 207,
+      "title": "feat: 一度きりの Job で restic backup を即時検証する (T-0104)",
+      "url": "https://github.com/hikuohiku/homelab/pull/207",
+      "mergedAt": "2026-08-05T16:09:10Z",
+      "headRefName": "autopilot/T-0104-restic-backup-verify-once"
+    },
+    {
+      "number": 206,
+      "title": "ops: issue #56 フィードバック反映 (T-0063 done, T-0079 dropped, T-0067 done)",
+      "url": "https://github.com/hikuohiku/homelab/pull/206",
+      "mergedAt": "2026-08-05T16:02:15Z",
+      "headRefName": "autopilot/run53-feedback-and-records"
+    },
+    {
+      "number": 205,
+      "title": "fix: restic ExternalSecret の remoteRef を実際の Doppler キー名に合わせる (T-0103)",
+      "url": "https://github.com/hikuohiku/homelab/pull/205",
+      "mergedAt": "2026-08-05T15:54:48Z",
+      "headRefName": "autopilot/T-0103-restic-doppler-key-mismatch"
+    },
+    {
+      "number": 203,
+      "title": "ops: run #52 の記録更新（issue #56 フィードバック反映・PRキャッシュ・ダッシュボード再公開）",
+      "url": "https://github.com/hikuohiku/homelab/pull/203",
+      "mergedAt": "2026-08-05T15:33:35Z",
+      "headRefName": "autopilot/run52-record"
+    },
+    {
+      "number": 202,
+      "title": "feat(ops): ダッシュボードを作り直す — 主役を「何をすればいいか」にする",
+      "url": "https://github.com/hikuohiku/homelab/pull/202",
+      "mergedAt": "2026-08-05T15:10:23Z",
+      "headRefName": "autopilot/dashboard-redesign"
+    },
+    {
+      "number": 201,
+      "title": "ops: run #51 の記録更新（T-0102 完遂・journal・state・PRキャッシュ）",
+      "url": "https://github.com/hikuohiku/homelab/pull/201",
+      "mergedAt": "2026-08-05T14:42:43Z",
+      "headRefName": "autopilot/run51-record"
+    },
+    {
+      "number": 200,
+      "title": "ci: helm バイナリを v3.16.4 → v3.21.3 に更新 (T-0102)",
+      "url": "https://github.com/hikuohiku/homelab/pull/200",
+      "mergedAt": "2026-08-05T14:38:46Z",
+      "headRefName": "autopilot/T-0102-helm-binary-3.21.3"
+    },
+    {
+      "number": 199,
+      "title": "ドキュメントが案内する just recipe の実在を CI で検証する (T-0096)",
+      "url": "https://github.com/hikuohiku/homelab/pull/199",
+      "mergedAt": "2026-08-05T13:41:09Z",
+      "headRefName": "autopilot/T-0096-doc-just-recipe-check"
+    },
+    {
+      "number": 198,
+      "title": "immich 内蔵バックアップの実在検証を pvc-usage-reporter に追加 (T-0068 follow-up)",
+      "url": "https://github.com/hikuohiku/homelab/pull/198",
+      "mergedAt": "2026-08-05T12:49:06Z",
+      "headRefName": "autopilot/T-0068-followup-verify-immich-backup-dump"
+    },
+    {
+      "number": 197,
+      "title": "restic/restic イメージタグの重複を check_version_sync.py の監視対象に追加 (T-0098)",
+      "url": "https://github.com/hikuohiku/homelab/pull/197",
+      "mergedAt": "2026-08-05T12:41:04Z",
+      "headRefName": "autopilot/T-0098-restic-image-tag-ci"
+    },
+    {
+      "number": 196,
+      "title": "immich-library 用 restic backup CronJob を追加 (T-0068)",
+      "url": "https://github.com/hikuohiku/homelab/pull/196",
+      "mergedAt": "2026-08-05T12:37:04Z",
+      "headRefName": "autopilot/T-0068-immich-restic-backup"
+    },
+    {
+      "number": 195,
+      "title": "coder-postgres 用 restic backup CronJob を追加 (T-0070)",
+      "url": "https://github.com/hikuohiku/homelab/pull/195",
+      "mergedAt": "2026-08-05T12:28:53Z",
+      "headRefName": "autopilot/T-0070-coder-postgres-restic-backup"
+    },
+    {
+      "number": 194,
+      "title": "ops: run #48 の記録更新（journal・state・PRキャッシュ、T-0095 id重複の再発防止）",
+      "url": "https://github.com/hikuohiku/homelab/pull/194",
+      "mergedAt": "2026-08-05T12:03:09Z",
+      "headRefName": "autopilot/run48-record"
+    },
+    {
+      "number": 189,
+      "title": "docs: apps/README.md の使われていない旧ブートストラップ手順を削除する (T-0095)",
+      "url": "https://github.com/hikuohiku/homelab/pull/189",
+      "mergedAt": "2026-08-05T11:55:33Z",
+      "headRefName": "autopilot/T-0095-apps-readme-dead-bootstrap"
+    },
+    {
+      "number": 192,
+      "title": "fix: vaultwarden backupのsqlite-snapshotをapk依存からpython標準ライブラリへ (T-0069 follow-up)",
+      "url": "https://github.com/hikuohiku/homelab/pull/192",
+      "mergedAt": "2026-08-05T11:54:12Z",
+      "headRefName": "autopilot/T-0069-followup-drop-apk-dep"
+    },
+    {
+      "number": 191,
+      "title": "feat: vaultwarden用restic backup CronJobを追加 (T-0069)",
+      "url": "https://github.com/hikuohiku/homelab/pull/191",
+      "mergedAt": "2026-08-05T11:41:15Z",
+      "headRefName": "autopilot/T-0069-vaultwarden-restic-backup"
+    },
+    {
+      "number": 190,
+      "title": "CHARTER: blocked/needs-humanをタスク全体でなく部分で見る (T-0095)",
+      "url": "https://github.com/hikuohiku/homelab/pull/190",
+      "mergedAt": "2026-08-05T11:32:44Z",
+      "headRefName": "autopilot/T-0095-blocked-granularity"
+    },
+    {
+      "number": 188,
+      "title": "ops: run #47 の記録更新（PR番号反映・journal・state・PRキャッシュ）",
+      "url": "https://github.com/hikuohiku/homelab/pull/188",
+      "mergedAt": "2026-08-05T11:23:58Z",
+      "headRefName": "autopilot/run47-record"
+    },
+    {
+      "number": 187,
+      "title": "docs: apps/README.md の ArgoCD Application 出力例を実態に合わせる (T-0094)",
+      "url": "https://github.com/hikuohiku/homelab/pull/187",
+      "mergedAt": "2026-08-05T10:29:02Z",
+      "headRefName": "autopilot/T-0094-apps-readme-app-list"
+    },
+    {
+      "number": 186,
+      "title": "docs: CLAUDE.md の autopilot 定期実行間隔記述を実態に合わせる (T-0093)",
+      "url": "https://github.com/hikuohiku/homelab/pull/186",
+      "mergedAt": "2026-08-05T09:29:57Z",
+      "headRefName": "autopilot/T-0093-claude-md-schedule-interval"
+    },
+    {
+      "number": 183,
+      "title": "docs: README.md の insecure 手順を実態に合わせる (T-0092)",
+      "url": "https://github.com/hikuohiku/homelab/pull/183",
+      "mergedAt": "2026-08-05T09:25:25Z",
+      "headRefName": "autopilot/T-0092-readme-insecure-fix"
+    },
+    {
+      "number": 182,
+      "title": "ops: T-0091 の PR 番号反映、PR キャッシュ最新化 (run #43)",
+      "url": "https://github.com/hikuohiku/homelab/pull/182",
+      "mergedAt": "2026-08-05T09:04:43Z",
+      "headRefName": "autopilot/run43-pr-numbers"
+    },
+    {
+      "number": 180,
+      "title": "ci: terraform_version を 1.15.0 → 1.15.8 に更新 (T-0091)",
+      "url": "https://github.com/hikuohiku/homelab/pull/180",
+      "mergedAt": "2026-08-05T09:01:37Z",
+      "headRefName": "autopilot/T-0091-terraform-binary-version"
+    },
+    {
+      "number": 178,
+      "title": "ci: kustomize/helm バイナリ版を version_sync の監視対象に追加 (T-0090)",
+      "url": "https://github.com/hikuohiku/homelab/pull/178",
+      "mergedAt": "2026-08-05T08:53:29Z",
+      "headRefName": "autopilot/T-0090-ci-binary-version-tracking"
+    },
+    {
+      "number": 177,
+      "title": "ops: run #42 のラップアップ（PR #175/#176 反映）",
+      "url": "https://github.com/hikuohiku/homelab/pull/177",
+      "mergedAt": "2026-08-05T08:48:16Z",
+      "headRefName": "autopilot/run42-wrapup"
+    },
+    {
+      "number": 176,
+      "title": "docs: CLAUDE.md の Apps/ディレクトリ構造を実態に合わせる (T-0089)",
+      "url": "https://github.com/hikuohiku/homelab/pull/176",
+      "mergedAt": "2026-08-05T08:46:20Z",
+      "headRefName": "autopilot/T-0089-claude-md-apps"
+    },
+    {
+      "number": 175,
+      "title": "ops: T-0087/T-0088 完遂の記録、T-0090 起票 (run #42)",
+      "url": "https://github.com/hikuohiku/homelab/pull/175",
+      "mergedAt": "2026-08-05T08:44:20Z",
+      "headRefName": "autopilot/T-0087-record"
+    },
+    {
+      "number": 174,
+      "title": "ops: tailscale-operator/k8s-nameserver の v1.102.2 更新調査結果を記録 (run #41)",
+      "url": "https://github.com/hikuohiku/homelab/pull/174",
+      "mergedAt": "2026-08-05T08:37:19Z",
+      "headRefName": "autopilot/tailscale-v1102-investigation"
+    },
+    {
+      "number": 173,
+      "title": "ops: run #40 の記録漏れ(state.json/last_read)を埋め合わせ、PRキャッシュ更新",
+      "url": "https://github.com/hikuohiku/homelab/pull/173",
+      "mergedAt": "2026-08-05T08:30:59Z",
+      "headRefName": "autopilot/records-run40-catchup"
+    },
+    {
+      "number": 172,
+      "title": "issue #56 のフィードバックを反映: DB コンポーネントのロールバック手順にスキーマの扱いを明記する規則を追加",
+      "url": "https://github.com/hikuohiku/homelab/pull/172",
+      "mergedAt": "2026-08-05T08:23:29Z",
+      "headRefName": "autopilot/T-0086-rollback-wording"
+    },
+    {
+      "number": 171,
+      "title": "immich server/machine-learning を v2.6.3 → v2.7.5 に更新 (T-0086)",
+      "url": "https://github.com/hikuohiku/homelab/pull/171",
+      "mergedAt": "2026-08-05T08:16:43Z",
+      "headRefName": "autopilot/T-0086-immich-v2.7.5"
+    },
+    {
+      "number": 170,
+      "title": "ops: T-0085 の PR番号(#169)を記録に反映",
+      "url": "https://github.com/hikuohiku/homelab/pull/170",
+      "mergedAt": "2026-08-05T07:50:37Z",
+      "headRefName": "autopilot/T-0085-pr-record"
+    },
+    {
+      "number": 169,
+      "title": "T-0085: pvc_usage 404 の想定内/異常の区別基準を CHARTER に明記",
+      "url": "https://github.com/hikuohiku/homelab/pull/169",
+      "mergedAt": "2026-08-05T07:48:58Z",
+      "headRefName": "autopilot/T-0085-pvc-usage-404-criterion"
+    },
+    {
+      "number": 168,
+      "title": "T-0083: ops-health-reporter に履歴（history/YYYY-MM-DD.jsonl）を追加",
+      "url": "https://github.com/hikuohiku/homelab/pull/168",
+      "mergedAt": "2026-08-05T07:43:01Z",
+      "headRefName": "autopilot/T-0083-health-report-history"
+    },
+    {
+      "number": 167,
+      "title": "T-0082: pvc-usage-reporter の python イメージを inventory 監視対象に追加",
+      "url": "https://github.com/hikuohiku/homelab/pull/167",
+      "mergedAt": "2026-08-05T07:26:09Z",
+      "headRefName": "autopilot/T-0082-pvc-usage-reporter-image-inventory"
+    },
+    {
+      "number": 166,
+      "title": "ci: pvc-usage-reporter の埋め込みスクリプト3ファイルの一致を検証する (T-0081)",
+      "url": "https://github.com/hikuohiku/homelab/pull/166",
+      "mergedAt": "2026-08-05T07:09:53Z",
+      "headRefName": "autopilot/T-0081-pvc-usage-script-sync"
+    },
+    {
+      "number": 165,
+      "title": "run #35: T-0080 完遂の記録更新",
+      "url": "https://github.com/hikuohiku/homelab/pull/165",
+      "mergedAt": "2026-08-05T07:03:37Z",
+      "headRefName": "autopilot/T-0080-records-2"
+    },
+    {
+      "number": 163,
+      "title": "PVC の実使用量を計測する namespace 別 CronJob を追加 (T-0080)",
+      "url": "https://github.com/hikuohiku/homelab/pull/163",
+      "mergedAt": "2026-08-05T06:59:02Z",
+      "headRefName": "autopilot/T-0080-pvc-usage"
+    },
+    {
+      "number": 164,
+      "title": "run #34: T-0080 の並行セッション調整反映、記録更新",
+      "url": "https://github.com/hikuohiku/homelab/pull/164",
+      "mergedAt": "2026-08-05T06:37:26Z",
+      "headRefName": "autopilot/T-0080-records"
+    },
+    {
+      "number": 162,
+      "title": "ops: T-0080 に fsGroup 再帰 chown リスクを追記 (run #33)",
+      "url": "https://github.com/hikuohiku/homelab/pull/162",
+      "mergedAt": "2026-08-05T06:33:03Z",
+      "headRefName": "autopilot/T-0080-fsgroup-risk-note"
+    },
+    {
+      "number": 161,
+      "title": "ops-health-reporter に metrics-server 経由のコンテナ実メモリ/CPU 収集を追加",
+      "url": "https://github.com/hikuohiku/homelab/pull/161",
+      "mergedAt": "2026-08-05T06:27:26Z",
+      "headRefName": "autopilot/T-0077-metrics-collect"
+    },
+    {
+      "number": 160,
+      "title": "ops: node01 実ディスク容量の食い違いを起票、PR作り直し時の規則を追記 (T-0079)",
+      "url": "https://github.com/hikuohiku/homelab/pull/160",
+      "mergedAt": "2026-08-05T06:05:50Z",
+      "headRefName": "autopilot/T-0079-node01-disk-discrepancy"
+    },
+    {
+      "number": 159,
+      "title": "ops: 取り残された cooldown/直列化の衝突対策を CHARTER に戻す",
+      "url": "https://github.com/hikuohiku/homelab/pull/159",
+      "mergedAt": "2026-08-05T05:56:52Z",
+      "headRefName": "autopilot/recover-charter-cooldown-rule"
+    },
+    {
+      "number": 158,
+      "title": "T-0015/T-0075: ops-health-reporter の動作確認、run #30 のラップアップ",
+      "url": "https://github.com/hikuohiku/homelab/pull/158",
+      "mergedAt": "2026-08-05T05:39:41Z",
+      "headRefName": "autopilot/T-0075-health-reporter-confirmed"
+    },
+    {
+      "number": 157,
+      "title": "T-0065: IaC 完全性の棚卸し — node01 揮発時の未カバー領域を確認",
+      "url": "https://github.com/hikuohiku/homelab/pull/157",
+      "mergedAt": "2026-08-05T05:34:05Z",
+      "headRefName": "autopilot/T-0065-iac-completeness"
+    },
+    {
+      "number": 156,
+      "title": "run #30: issue #56 のフィードバック2件を反映（cooldown/直列化の規則衝突、#153 レビュー）",
+      "url": "https://github.com/hikuohiku/homelab/pull/156",
+      "mergedAt": "2026-08-05T05:27:17Z",
+      "headRefName": "autopilot/run30-feedback"
+    },
+    {
+      "number": 152,
+      "title": "docs: terraform plan の CI 化を調査する (T-0073)",
+      "url": "https://github.com/hikuohiku/homelab/pull/152",
+      "mergedAt": "2026-08-05T05:23:45Z",
+      "headRefName": "autopilot/T-0073-terraform-plan-ci-feasibility"
+    },
+    {
+      "number": 153,
+      "title": "T-0015: ArgoCD/k8s の健全性を homelab から repo へ書き戻す CronJob を追加",
+      "url": "https://github.com/hikuohiku/homelab/pull/153",
+      "mergedAt": "2026-08-05T05:21:50Z",
+      "headRefName": "autopilot/T-0015-ops-health-reporter"
+    },
+    {
+      "number": 154,
+      "title": "ops: run #29 の記録をまとめ、ダッシュボードを再生成する",
+      "url": "https://github.com/hikuohiku/homelab/pull/154",
+      "mergedAt": "2026-08-05T05:16:19Z",
+      "headRefName": "autopilot/run29-wrapup"
+    },
+    {
+      "number": 151,
+      "title": "T-0011: vaultwarden ADMIN_TOKEN の Argon2 PHC 化を完了扱いにする",
+      "url": "https://github.com/hikuohiku/homelab/pull/151",
+      "mergedAt": "2026-08-05T05:06:53Z",
+      "headRefName": "autopilot/T-0011-vaultwarden-admin-token-done"
+    },
+    {
+      "number": 150,
+      "title": "ops: run #28 の記録をまとめる（T-0064 merge、backup 方針転換の反映）",
+      "url": "https://github.com/hikuohiku/homelab/pull/150",
+      "mergedAt": "2026-08-05T04:59:11Z",
+      "headRefName": "autopilot/run28-wrapup"
+    },
+    {
+      "number": 149,
+      "title": "T-0064: proxmox_virtual_environment_download_file を proxmox_download_file に改名",
+      "url": "https://github.com/hikuohiku/homelab/pull/149",
+      "mergedAt": "2026-08-05T04:52:53Z",
+      "headRefName": "autopilot/T-0064-terraform-download-file-rename"
+    },
+    {
+      "number": 148,
+      "title": "T-0062: k3s 1.34→1.35の非推奨API影響確認、および人間merge分の記録同期",
+      "url": "https://github.com/hikuohiku/homelab/pull/148",
+      "mergedAt": "2026-08-05T04:35:42Z",
+      "headRefName": "autopilot/T-0062-k3s-1.35-deprecation-check"
+    },
+    {
+      "number": 147,
+      "title": "T-0061: 時刻表示のJST化と、残った不確実性のbacklog追跡",
+      "url": "https://github.com/hikuohiku/homelab/pull/147",
+      "mergedAt": "2026-08-05T04:25:47Z",
+      "headRefName": "autopilot/T-0061-jst-time-and-uncertainty-tracking"
+    },
+    {
+      "number": 146,
+      "title": "chore(nix): flake.lock を更新する（nixpkgs 2025-12-08 → 2026-08-04）",
+      "url": "https://github.com/hikuohiku/homelab/pull/146",
+      "mergedAt": "2026-08-05T04:24:50Z",
+      "headRefName": "autopilot/T-0049-nix-flake-update"
+    },
+    {
+      "number": 145,
+      "title": "chore(terraform): bpg/proxmox provider を 0.89.1 → 0.111.1 に上げる",
+      "url": "https://github.com/hikuohiku/homelab/pull/145",
+      "mergedAt": "2026-08-05T04:22:12Z",
+      "headRefName": "autopilot/T-0030-tf-provider-0.111.1"
+    },
+    {
+      "number": 144,
+      "title": "ops: run #26 の記録をまとめ、T-0060 を起票する",
+      "url": "https://github.com/hikuohiku/homelab/pull/144",
+      "mergedAt": "2026-08-05T04:14:29Z",
+      "headRefName": "autopilot/T-0060-dex-argocd-secret-plaintext"
+    },
+    {
+      "number": 143,
+      "title": "feat(ops): ダッシュボードにストリーム分類とガントを追加する",
+      "url": "https://github.com/hikuohiku/homelab/pull/143",
+      "mergedAt": "2026-08-05T04:05:35Z",
+      "headRefName": "autopilot/dashboard-streams-gantt"
+    },
+    {
+      "number": 142,
+      "title": "ops: run #25 の PR 番号一覧・キャッシュを確定させる",
+      "url": "https://github.com/hikuohiku/homelab/pull/142",
+      "mergedAt": "2026-08-05T04:00:22Z",
+      "headRefName": "autopilot/run25-wrapup-final"
+    },
+    {
+      "number": 141,
+      "title": "ops: run #25 の記録をまとめ、ダッシュボードを再生成する",
+      "url": "https://github.com/hikuohiku/homelab/pull/141",
+      "mergedAt": "2026-08-05T03:58:37Z",
+      "headRefName": "autopilot/run25-wrapup"
+    }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1533,3 +1533,33 @@
 - T-0101（immich backup_listing 確認）は pvc-usage-reporter の immich 分の次回実行が 18:05 UTC の
   ため、この起動では DoD を満たせず todo のまま持ち越し
 - backlog に他の todo が無いため新規タスクは起票せず、記録のみで起動を終える
+
+## 2026-08-06 01:19 JST — run #53
+
+- 前回の中断確認: オープン PR・autopilot ブランチとも無し
+- 読んだフィードバック: issue #56 の未読3件（構築セッション経由、15:45:04/15:47:44/15:49:52）。
+  人間の指示で構築セッションが Coder ワークスペース（node01 上の Pod）から `agent-reader`
+  （view 相当）で kubectl を使えるようになったと報告
+- やったこと:
+  1. T-0063 done（cgroup v2 確認済み）、T-0079 dropped（node01 のディスクは実際 252GiB あり、
+     ドキュメント記載どおり正しかった。以前の懸念は構築セッションが `ephemeral-storage`
+     という kubelet のメトリクス名をルート FS 容量と読み違えたことによる誤り）
+  2. T-0067 done の報告を確認する過程で、Doppler の実キー名（`B2_ACCOUNT_ID`/`B2_ACCOUNT_KEY`）
+     と `apps/{vaultwarden,coder,immich}/restic-external-secret.yaml` の `remoteRef.key`
+     （誤って `RESTIC_` プレフィックス付きだった）が不一致と発見。**これが vaultwarden/coder/
+     immich の Degraded の真因**だった（run #50 の「T-0067 未完了が原因」という推測は誤りで、
+     たまたま時系列が一致していただけ）。T-0103 として3ファイルを修正（#205, CI green 確認後
+     merge）。merge 直後の ops-health-report (16:00:04Z) で3アプリとも Synced/Healthy に復帰した
+     ことを確認した
+  3. T-0063/T-0079/T-0067 の backlog 更新、ops-health-reporter への ephemeral-storage 注記追加、
+     CHARTER §3 への追記（needs-human に落とす前に構築セッションで確認できないか考える）を
+     #206 で反映
+  4. 構築セッションの提案（CronJob の次回実行=明朝を待たず一度きりの Job で即検証すべき）を
+     受け、T-0104 として vaultwarden/coder/immich 3つに `restic-backup-verify-job.yaml` を
+     追加（#207, CI green 確認後 merge）。T-0071/T-0097/T-0099/T-0100 の `blocked_by` を
+     T-0067（完了済み）から T-0104 の実行結果待ちに更新
+  5. issue #56 に対応内容を返信（last_read 更新済み）
+- 次の起動へ: T-0104 の Job 3つが #207 merge 後に ArgoCD で同期されるので、次回以降の
+  ops-health-report の pod_issues で成否を確認すること（Failed が出ていないか、成功していれば
+  T-0097/T-0099/T-0100 を done にし Job を削除する PR を出す）。T-0101（immich backup_listing
+  確認）は pvc-usage-reporter の次回実行（18:05 UTC）待ちのため todo のまま持ち越し

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-05T14:40:00Z",
+  "updated": "2026-08-05T16:20:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-05T15:31:59Z"
+    "last_read": "2026-08-05T15:49:52Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -590,6 +590,18 @@
       "by": "cloud routine",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし（孤児ブランチ6件は main との内容重複を確認済みで回収不要、既知）。issue #56 の未読1件（15:11:28、構築セッション経由）を反映: ダッシュボード再設計（#202、既に別セッションが完遂・merge済み）に伴う新しい規約2点を確認。(1) needs-human タスクへの human_action 必須化 → 現行5件（T-0060/T-0063/T-0067/T-0074/T-0079）は全て run #48 で書き込み済みと確認、追加対応なし。(2) 件数をダッシュボードのみで数える → 了解し以後徹底する旨を返信。build.py の新版で prs.json キャッシュを最新化し再ビルド、同じ Artifact URL に再公開した。ops-health-report (15:00:04Z) は coder/immich/vaultwarden が引き続き Degraded（T-0067 未完了による ExternalSecret 未同期、既知・実害なし）で変化なし。T-0101（immich backup_listing 確認）は pvc-usage-reporter の次回実行（18:05 UTC）待ちのため todo のまま持ち越し。backlog に他の todo が無いため新規タスクは起票せず、記録のみで終える",
       "prs": []
+    },
+    {
+      "n": 53,
+      "at": "2026-08-05T16:19:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 の未読3件（構築セッション経由、15:45:04/15:47:44/15:49:52）を反映。(1) T-0063 done（cgroup v2 確認済み）、T-0079 dropped（node01 は実際256GiB系統で正しく、ephemeral-storage を root FS 容量と読み違えていたのは構築セッション自身の誤り。report.py の notes に誤読防止の注記を追加）。(2) T-0067 done の報告を反映する過程で、Doppler 登録キー名（B2_ACCOUNT_ID/B2_ACCOUNT_KEY）と apps/{vaultwarden,coder,immich}/restic-external-secret.yaml の remoteRef.key（誤って RESTIC_ プレフィックス付き）が不一致だったと発見。**これが vaultwarden/coder/immich の Degraded の真因**だった（T-0067 未完了が原因という run #50 の推測は誤りだった）。T-0103 として3ファイルとも即修正（#205, CI green 確認後に自分で merge）。merge 直後の ops-health-report (16:00:04Z) で3アプリとも Synced/Healthy に復帰したことを確認した。(3) T-0063/T-0079/T-0067 の backlog 更新と CHARTER §3 への追記（needs-human に落とす前に構築セッションで確認できないか考える）を #206 で反映。(4) 構築セッションの提案（CronJob の次回実行=明朝を待たず一度きりの Job で即検証すべき）を受け、T-0104 として vaultwarden/coder/immich 3つに restic-backup-verify-job.yaml を追加（#207, CI green 確認後 merge）。T-0071/T-0097/T-0099/T-0100 の blocked_by を T-0067（完了済み）から T-0104 の実行結果待ちに更新。issue #56 に対応内容を返信した。3つの PR（#205/#206/#207）はいずれも直列に処理し CI green を確認して自分で merge した",
+      "prs": [
+        205,
+        206,
+        207
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

run #53 の運用記録更新（`ops/` の副産物のみ、論点は無し）。

- `ops/backlog.json`: T-0104 の `pr` を反映し、T-0103 (#205) が実際に vaultwarden/coder/immich の Degraded を解消したことを notes に記録
- `ops/state.json`: run #53 のエントリを追記、`feedback.last_read` を更新
- `ops/journal/2026-08.md`: run #53 の記録を追記
- `ops/dashboard/prs.json`: `mcp__github__list_pull_requests` でキャッシュを最新化
- ダッシュボードを再ビルドし、既存の Artifact URL に再公開済み

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 例外なく完了

## ロールバック手順

記録ファイルのみの変更。revert しても実インフラ・データには影響しない。

## backlog task id

なし（運用記録の更新のみ）


---
_Generated by [Claude Code](https://claude.ai/code/session_01AvUXWZj5HVXTd6ZEMNYDyC)_