### PR TITLE
ops: run #55 の記録更新（重複 PR #210 の close、PRキャッシュ更新）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 209,
+      "title": "ops: run #54 の記録更新（immich restic backup 検証確認、T-0105/T-0106 起票）",
+      "url": "https://github.com/hikuohiku/homelab/pull/209",
+      "mergedAt": "2026-08-05T16:26:22Z",
+      "headRefName": "autopilot/run54-record"
+    },
+    {
       "number": 208,
       "title": "ops: run #53 の記録更新（T-0103 修正確認、journal・state・PRキャッシュ、ダッシュボード再公開）",
       "url": "https://github.com/hikuohiku/homelab/pull/208",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/143",
       "mergedAt": "2026-08-05T04:05:35Z",
       "headRefName": "autopilot/dashboard-streams-gantt"
-    },
-    {
-      "number": 142,
-      "title": "ops: run #25 の PR 番号一覧・キャッシュを確定させる",
-      "url": "https://github.com/hikuohiku/homelab/pull/142",
-      "mergedAt": "2026-08-05T04:00:22Z",
-      "headRefName": "autopilot/run25-wrapup-final"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1592,3 +1592,18 @@
   確認する（immich は確認済み）。3つとも確認が取れたら T-0097/T-0099/T-0100 を done にし、
   検証用 Job 3つ（apps/{vaultwarden,coder,immich}/restic-backup-verify-job.yaml）を削除する
   PR を出すこと
+
+## 2026-08-06 01:40 JST — run #55
+
+- 前回の中断確認: オープン PR・autopilot ブランチとも無し
+- 読んだフィードバック: なし（last_read 以降新規コメントなし。issue #56 の run #54 分は前起動で処理済み）
+- やったこと: 前起動（run #54）が issue #56 のフィードバック5件を反映する PR #210 を作ったが、
+  ほぼ同時刻に別セッションが同一内容（T-0068/T-0100/T-0101 done、T-0105/T-0106 起票）の
+  PR #209 を先に merge していたと判明（push 後に気づいた）。#210 は base 乖離で dirty になって
+  おり、merge すると backlog.json に同じ task id の重複エントリを作る危険があったため、
+  内容重複と確認したうえで #210 を close した（ブランチ削除は 403 のため孤児のまま残る、既知の
+  制約）。#209 の内容は #210 と実質同一で、かつ T-0068/T-0101 の done 化まで含めておりこちら
+  の方が広い。origin/main の backlog.json・journal は #209 の内容で十分なため追加の反映は無し。
+  PR キャッシュ（ops/dashboard/prs.json）に #209 を追加し、ダッシュボードを再生成した
+- 次の起動へ: T-0104 の vaultwarden/coder-postgres 分の検証 Job 結果はまだ構築セッションから
+  報告が無いため、issue #56 で改めて確認する（immich 分は確認済み）

--- a/ops/state.json
+++ b/ops/state.json
@@ -609,6 +609,16 @@
       "kind": "scheduled",
       "by": "cloud routine",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 の未読4件（構築セッション経由）を反映。#205 close 依頼は run #53 の merge と時刻が交錯していたが、直後のコメントで両修正が噛み合い3 namespace とも SecretSynced に復帰したと確認できたためやり直し不要と判断。immich の restic backup 検証（T-0104, #207由来）が実際に成功した報告（82 files/332.200 MiB, snapshot c57eb36c、内蔵DBダンプ14世代も同梱確認）を受け T-0068/T-0100/T-0101 を done に。Doppler の重複 credential 削除を T-0105（needs-human）、B2 credential の append-only 鍵分離を T-0106（blocked_by: T-0071）として起票。vaultwarden/coder-postgres 分の検証 Job 結果はまだ未報告のため issue #56 で追加確認を依頼した",
+      "prs": [
+        209
+      ]
+    },
+    {
+      "n": 55,
+      "at": "2026-08-05T16:40:00Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "同じ cron から並行して起動していた別セッション（run #54 として先に #209 を merge）と、issue #56 の同じフィードバックを同時に処理してしまい、内容が完全重複した PR #210 を作成・push 後に発覚。#210 は base 乖離で dirty になっており、merge すると backlog.json に T-0100/T-0105/T-0106 の重複エントリを作る危険があったため merge せず close した（run #13/#44/#46 と同型の重複）。#209 の方が T-0068/T-0101 の done 化まで含み内容が広いため、origin/main への追加反映は不要と判断。PR キャッシュ（ops/dashboard/prs.json）に #209 を追加し、run #54 の記録に漏れていた pr 番号（#209）も補完した",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

- `ops/state.json`: run #54 の記録に漏れていた PR 番号（#209）を補完し、run #55 を追記
- `ops/journal/2026-08.md`: run #55 の記録を追記
- `ops/dashboard/prs.json`: merge 済み PR キャッシュに #209 を追加
- コード・manifest の変更は無し（記録のみ）

## 背景

同じ cron から並行して起動していた別セッションが issue #56 の同じフィードバック（T-0100 done、
T-0105/T-0106 起票）を先に PR #209 として merge していた。こちらも同時に同じ内容の PR #210 を
作成・push してしまい、push 後に重複と判明したため #210 は merge せず close した（run #13/#44/#46
と同型の重複。ブランチ削除は 403 のため孤児のまま残る）。

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 例外なく生成成功、同じ Artifact URL に再公開予定

## ロールバック手順

`ops/` 配下の記録ファイルのみの変更。revert すれば元に戻る。

## backlog task id

なし（記録のみ、タスクの新規起票・状態変更は無し）

---
_Generated by [Claude Code](https://claude.ai/code/session_017KJWvCNMrDcFkzE8jAsiRi)_