### PR TITLE
fix(vaultwarden): restic backup の activeDeadlineSeconds を 1800→3600 に緩和

### DIFF
--- a/apps/vaultwarden/restic-backup-cronjob.yaml
+++ b/apps/vaultwarden/restic-backup-cronjob.yaml
@@ -58,7 +58,13 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 1
-      activeDeadlineSeconds: 1800
+      # T-0097: 初回実行が restic backup 実行中に 1800s の deadline に到達し DeadlineExceeded で
+      # 失敗した（sqlite の一貫コピー・restic リポジトリ作成までは成功していた）。同じ restic
+      # backup CronJob である immich 側 (apps/immich/restic-backup-cronjob.yaml) が既に 3600s を
+      # 使っており実績があるため、その値に揃える。根本原因（なぜ vaultwarden だけ時間がかかったか）
+      # は未確定のまま、失敗を解消する方向の緩和として先に反映する（CHARTER §4、縛る変更のcooldownは
+      # 失敗を緩める変更には適用しない）
+      activeDeadlineSeconds: 3600
       template:
         spec:
           automountServiceAccountToken: false

--- a/apps/vaultwarden/restic-backup-verify-job.yaml
+++ b/apps/vaultwarden/restic-backup-verify-job.yaml
@@ -12,7 +12,9 @@ metadata:
   namespace: vaultwarden
 spec:
   backoffLimit: 1
-  activeDeadlineSeconds: 1800
+  # T-0097: 初回実行が DeadlineExceeded で失敗したため、restic-backup-cronjob.yaml と同じ理由で
+  # 3600s に揃える（immich 側の既存の実績値）
+  activeDeadlineSeconds: 3600
   template:
     spec:
       automountServiceAccountToken: false

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 109,
-  "updated": "2026-08-05T17:19:51Z",
+  "updated": "2026-08-05T17:35:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -1805,7 +1805,7 @@
       ],
       "created": "2026-08-05",
       "pr": 191,
-      "notes": " | run #56: issue #56 (17:14:24, 構築セッション経由) の実測報告で vaultwarden-restic-backup-verify Job が DeadlineExceeded で Failed と判明（sqlite バックアップ・restic リポジトリ作成までは成功していたが、その後の restic backup 実行中に activeDeadlineSeconds=1800 に到達）。immich (12秒) は成功しているためデータ量の問題ではなさそう。T-0108 で activeDeadlineSeconds を緩和したうえで再実行を待つ。blocked_by は T-0104 のまま（3つとも Complete になるまで T-0104 は完了しない）。"
+      "notes": " | run #56: issue #56 (17:14:24, 構築セッション経由) の実測報告で vaultwarden-restic-backup-verify Job が DeadlineExceeded で Failed と判明（sqlite バックアップ・restic リポジトリ作成までは成功していたが、その後の restic backup 実行中に activeDeadlineSeconds=1800 に到達）。immich (12秒) は成功しているためデータ量の問題ではなさそう。T-0108 で activeDeadlineSeconds を緩和したうえで再実行を待つ。blocked_by は T-0104 のまま（3つとも Complete になるまで T-0104 は完了しない）。 | run #56 続き: activeDeadlineSeconds を 1800→3600 に緩和（immich 側の既存値に揃えた）。構築セッションに再実行を依頼済み。成功が確認できたら T-0104/T-0097 を done にする。"
     },
     {
       "id": "T-0098",


### PR DESCRIPTION
## 変更点

vaultwarden の restic backup（CronJob 本体 + T-0104 の一度きりの検証 Job）の `activeDeadlineSeconds` を 1800 → 3600 に緩和した。

## 検証したこと

初回実行の実測（issue #56, 2026-08-05 17:14:24、構築セッション経由）で、sqlite の一貫コピー・restic リポジトリ作成までは成功していたが、その後の `restic backup` 実行中に 1800s の deadline に到達し `DeadlineExceeded` で失敗したことを確認済み。同じ restic backup CronJob である immich 側（`apps/immich/restic-backup-cronjob.yaml`）は既に 3600s を使い実績があるため、その値に揃えた。

根本原因（vaultwarden だけなぜ時間がかかったか）は未確定。データ量は immich（332 MiB）よりむしろ小さい（vaultwarden 4.6 MiB）ため、単純なデータ量の問題ではなさそう。B2 リポジトリの初回作成コストや一時的なネットワーク要因の可能性がある。

CHARTER §4 の「縛る変更には実測の裏付けが要る」は値を厳しくする方向の変更が対象で、今回は既に失敗を引き起こしている値を緩める方向のため cooldown 対象外として即マージする。

## ロールバック手順

`activeDeadlineSeconds` の値を戻すだけ。ステートを持たないパラメータ変更のため、revert すればそのまま元に戻る。データ整合性への影響なし。

## backlog task id

T-0097

---
_Generated by [Claude Code](https://claude.ai/code/session_018ehE4UgMhgEPFoqqotni6W)_