### PR TITLE
ops: run #56 の記録更新（journal・state・PRキャッシュ、ダッシュボード再公開）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,41 @@
   "open": [],
   "merged": [
     {
+      "number": 215,
+      "title": "security(dex,argocd): OIDC client secret を Doppler 経由の ExternalSecret に切り替える",
+      "url": "https://github.com/hikuohiku/homelab/pull/215",
+      "mergedAt": "2026-08-05T17:28:31Z",
+      "headRefName": "autopilot/T-0060-dex-argocd-oidc-secret"
+    },
+    {
+      "number": 214,
+      "title": "fix(vaultwarden): restic backup の activeDeadlineSeconds を 1800→3600 に緩和",
+      "url": "https://github.com/hikuohiku/homelab/pull/214",
+      "mergedAt": "2026-08-05T17:25:31Z",
+      "headRefName": "autopilot/T-0097-vaultwarden-backup-deadline"
+    },
+    {
+      "number": 213,
+      "title": "ops: issue #56 のフィードバック5件を backlog/CHARTER に反映",
+      "url": "https://github.com/hikuohiku/homelab/pull/213",
+      "mergedAt": "2026-08-05T17:24:01Z",
+      "headRefName": "autopilot/T-0107-run56-feedback-records"
+    },
+    {
+      "number": 212,
+      "title": "feat(ops): ダッシュボードに「いま動いているもの」を追加し鮮度を可視化する",
+      "url": "https://github.com/hikuohiku/homelab/pull/212",
+      "mergedAt": "2026-08-05T17:20:08Z",
+      "headRefName": "autopilot/dashboard-live"
+    },
+    {
+      "number": 211,
+      "title": "ops: run #55 の記録更新（重複 PR #210 の close、PRキャッシュ更新）",
+      "url": "https://github.com/hikuohiku/homelab/pull/211",
+      "mergedAt": "2026-08-05T16:32:00Z",
+      "headRefName": "autopilot/run55-record"
+    },
+    {
       "number": 209,
       "title": "ops: run #54 の記録更新（immich restic backup 検証確認、T-0105/T-0106 起票）",
       "url": "https://github.com/hikuohiku/homelab/pull/209",
@@ -336,90 +371,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/156",
       "mergedAt": "2026-08-05T05:27:17Z",
       "headRefName": "autopilot/run30-feedback"
-    },
-    {
-      "number": 152,
-      "title": "docs: terraform plan の CI 化を調査する (T-0073)",
-      "url": "https://github.com/hikuohiku/homelab/pull/152",
-      "mergedAt": "2026-08-05T05:23:45Z",
-      "headRefName": "autopilot/T-0073-terraform-plan-ci-feasibility"
-    },
-    {
-      "number": 153,
-      "title": "T-0015: ArgoCD/k8s の健全性を homelab から repo へ書き戻す CronJob を追加",
-      "url": "https://github.com/hikuohiku/homelab/pull/153",
-      "mergedAt": "2026-08-05T05:21:50Z",
-      "headRefName": "autopilot/T-0015-ops-health-reporter"
-    },
-    {
-      "number": 154,
-      "title": "ops: run #29 の記録をまとめ、ダッシュボードを再生成する",
-      "url": "https://github.com/hikuohiku/homelab/pull/154",
-      "mergedAt": "2026-08-05T05:16:19Z",
-      "headRefName": "autopilot/run29-wrapup"
-    },
-    {
-      "number": 151,
-      "title": "T-0011: vaultwarden ADMIN_TOKEN の Argon2 PHC 化を完了扱いにする",
-      "url": "https://github.com/hikuohiku/homelab/pull/151",
-      "mergedAt": "2026-08-05T05:06:53Z",
-      "headRefName": "autopilot/T-0011-vaultwarden-admin-token-done"
-    },
-    {
-      "number": 150,
-      "title": "ops: run #28 の記録をまとめる（T-0064 merge、backup 方針転換の反映）",
-      "url": "https://github.com/hikuohiku/homelab/pull/150",
-      "mergedAt": "2026-08-05T04:59:11Z",
-      "headRefName": "autopilot/run28-wrapup"
-    },
-    {
-      "number": 149,
-      "title": "T-0064: proxmox_virtual_environment_download_file を proxmox_download_file に改名",
-      "url": "https://github.com/hikuohiku/homelab/pull/149",
-      "mergedAt": "2026-08-05T04:52:53Z",
-      "headRefName": "autopilot/T-0064-terraform-download-file-rename"
-    },
-    {
-      "number": 148,
-      "title": "T-0062: k3s 1.34→1.35の非推奨API影響確認、および人間merge分の記録同期",
-      "url": "https://github.com/hikuohiku/homelab/pull/148",
-      "mergedAt": "2026-08-05T04:35:42Z",
-      "headRefName": "autopilot/T-0062-k3s-1.35-deprecation-check"
-    },
-    {
-      "number": 147,
-      "title": "T-0061: 時刻表示のJST化と、残った不確実性のbacklog追跡",
-      "url": "https://github.com/hikuohiku/homelab/pull/147",
-      "mergedAt": "2026-08-05T04:25:47Z",
-      "headRefName": "autopilot/T-0061-jst-time-and-uncertainty-tracking"
-    },
-    {
-      "number": 146,
-      "title": "chore(nix): flake.lock を更新する（nixpkgs 2025-12-08 → 2026-08-04）",
-      "url": "https://github.com/hikuohiku/homelab/pull/146",
-      "mergedAt": "2026-08-05T04:24:50Z",
-      "headRefName": "autopilot/T-0049-nix-flake-update"
-    },
-    {
-      "number": 145,
-      "title": "chore(terraform): bpg/proxmox provider を 0.89.1 → 0.111.1 に上げる",
-      "url": "https://github.com/hikuohiku/homelab/pull/145",
-      "mergedAt": "2026-08-05T04:22:12Z",
-      "headRefName": "autopilot/T-0030-tf-provider-0.111.1"
-    },
-    {
-      "number": 144,
-      "title": "ops: run #26 の記録をまとめ、T-0060 を起票する",
-      "url": "https://github.com/hikuohiku/homelab/pull/144",
-      "mergedAt": "2026-08-05T04:14:29Z",
-      "headRefName": "autopilot/T-0060-dex-argocd-secret-plaintext"
-    },
-    {
-      "number": 143,
-      "title": "feat(ops): ダッシュボードにストリーム分類とガントを追加する",
-      "url": "https://github.com/hikuohiku/homelab/pull/143",
-      "mergedAt": "2026-08-05T04:05:35Z",
-      "headRefName": "autopilot/dashboard-streams-gantt"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1607,3 +1607,44 @@
   PR キャッシュ（ops/dashboard/prs.json）に #209 を追加し、ダッシュボードを再生成した
 - 次の起動へ: T-0104 の vaultwarden/coder-postgres 分の検証 Job 結果はまだ構築セッションから
   報告が無いため、issue #56 で改めて確認する（immich 分は確認済み）
+
+## 2026-08-06 02:28 JST — run #56
+
+- 前回の中断確認: オープン PR・autopilot ブランチとも無し
+- 読んだフィードバック: issue #56 の未読7件（うち2件は自分自身の返信のエコーでスキップ）、
+  構築セッション経由の5件を反映
+  1. **T-0105**（Doppler の重複 B2 credential）を構築セッション自身が削除済みとの報告 → done
+  2. **T-0060**（Dex↔ArgoCD OIDC secret）の Doppler 登録（`DEX_ARGOCD_CLIENT_SECRET`）完了の
+     報告 → needs-human から todo に戻し、この起動で実装まで完了（後述）
+  3. **T-0074 の前提訂正**: HCP Terraform は Remote ではなく **Local 実行モード**で、構築セッションが
+     Coder ワークスペースから `terraform plan` を実際に成功させた。ただし
+     `proxmox_download_file.nixos_image` に `1 to add` が出て、`replace_triggered_by` 経由で
+     **node01 VM が再作成されうる**危険な差分が見つかった。判定は Proxmox 証明書の SAN 不一致
+     による TLS 検証エラーの最中に出たもので本物か誤検知か未確定。**T-0107 として最優先
+     （priority 2）の needs-human タスクを新規起票**し、対応が終わるまで `terraform apply`/
+     `just apply` を実行しないよう明記（#213）。T-0074 は方式を CI ではなくクラスタ内 Job に
+     書き換え、T-0107 の解消待ちにした
+  4. **構築セッションの能力アップデート**: Doppler 読み書き削除・kubectl 読み取り（Secret/nodes/
+     ArgoCD Application 以外）・restic/B2 操作・node01 のファイルシステム確認ができるように
+     なったとの報告を受け、CHARTER §4「人間に渡してよいもの」を改訂し確認先として明記（#213）
+  5. **重複起動の heartbeat 提案**（構築セッションの手動起動と cron が3回重なった件、実害は
+     検知して close 済みで軽微）: 2 案のうち「専用ブランチにタイムスタンプだけ push」を採用と
+     判断し T-0108（todo, 低優先度）として起票。実装は次回以降（#213）
+- やったこと（続き）:
+  - **T-0099**（coder-postgres backup 検証）を構築セッションの実測報告（Job Complete）で done
+  - **T-0097**（vaultwarden backup 検証）は Job が `DeadlineExceeded` で失敗との報告を受け、
+    `activeDeadlineSeconds` を 1800→3600 に緩和（immich 側の既存実績値に揃えた。#214）。
+    根本原因は未確定のまま失敗解消の緩和として先に反映。構築セッションに再実行を依頼した
+  - **T-0060 実装**: apps/dex の envFrom Secret に `DEX_ARGOCD_CLIENT_SECRET` を追加し
+    staticClients を `secretEnv` 参照に、apps/argocd に新規 ExternalSecret
+    （`app.kubernetes.io/part-of: argocd` ラベル付き）を追加し `oidc.config.clientSecret` を
+    `$argocd-dex-client-secret:secret` 参照に変更（#215）。両ファイルの平文重複が解消した。
+    Dex は到達性の根幹のため、PR 本文に復旧手順（revert で旧設定に戻る、Pod が起動しなくなった
+    場合は自分では直せない旨）を明記したうえで CI green を確認し自分で merge した
+- ops-health-report（17:00:04Z、#213/#214/#215 merge 前の観測）: ArgoCD 9/10 アプリ
+  Synced/Healthy、vaultwarden のみ Degraded（restic-backup-verify Job の DeadlineExceeded
+  失敗が原因と推定、#214 で解消見込み）。pod restarts はいずれも既知の値で新規異常なし
+- 次の起動へ: T-0107（Proxmox 証明書の SAN 不一致）は人間の対応待ち、対応が終わるまで
+  `terraform apply` を実行しないこと最優先で伝える。T-0097/T-0104 は vaultwarden の再実行結果
+  （構築セッションからの報告）待ち。T-0060 の実ログイン確認は次回以降 ops-health-report で
+  argocd アプリの健全性を見て判断する。backlog の todo は T-0104 のみ

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-05T16:20:00Z",
+  "updated": "2026-08-05T17:28:54Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-05T16:12:29Z"
+    "last_read": "2026-08-05T17:14:24Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -620,6 +620,18 @@
       "by": "cloud routine",
       "summary": "同じ cron から並行して起動していた別セッション（run #54 として先に #209 を merge）と、issue #56 の同じフィードバックを同時に処理してしまい、内容が完全重複した PR #210 を作成・push 後に発覚。#210 は base 乖離で dirty になっており、merge すると backlog.json に T-0100/T-0105/T-0106 の重複エントリを作る危険があったため merge せず close した（run #13/#44/#46 と同型の重複）。#209 の方が T-0068/T-0101 の done 化まで含み内容が広いため、origin/main への追加反映は不要と判断。PR キャッシュ（ops/dashboard/prs.json）に #209 を追加し、run #54 の記録に漏れていた pr 番号（#209）も補完した",
       "prs": []
+    },
+    {
+      "n": 56,
+      "at": "2026-08-05T17:19:51Z",
+      "kind": "scheduled",
+      "by": "cloud routine",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 の未読7件（自分の返信2件を除く5件）を反映: T-0105 done（構築セッションが重複 credential を自ら削除）、T-0060 needs-human→todo（Doppler 登録完了）でこの起動で実装まで完遂（apps/dex・apps/argocd の OIDC client secret を Doppler 経由の ExternalSecret に切り替え、#215）。T-0099 done（coder-postgres backup 検証 Job Complete）。T-0074 は HCP Terraform がLocal 実行モードだったという前提訂正を反映し方式変更。構築セッションが初めて terraform plan を実行した結果、proxmox_download_file.nixos_image に 1 to add が出て node01 VM が再作成されうる危険な差分を発見（Proxmox 証明書の SAN 不一致で本物か誤検知か未確定）、T-0107 として最優先の needs-human タスクを新規起票し apply 前の警告を明記（#213）。vaultwarden の restic backup 検証 Job が DeadlineExceeded で失敗したとの報告を受け activeDeadlineSeconds を 1800→3600 に緩和（#214）。重複起動検知の heartbeat 案を採用と判断し T-0108 として起票（実装は次回以降）。",
+      "prs": [
+        213,
+        214,
+        215
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

run #56 の記録をまとめて更新する。

- `ops/journal/2026-08.md`: run #56 のまとめを追記
- `ops/state.json`: `runs` に run #56 を追記、`feedback.last_read` を更新
- `ops/dashboard/prs.json`: PR キャッシュを最新化（#213/#214/#215 merge 分を反映）
- ダッシュボードを同じ Artifact URL に再公開

この起動で行った実質的な変更は #213（issue #56 フィードバック5件を backlog/CHARTER に反映）、#214（vaultwarden backup timeout 緩和）、#215（T-0060: Dex/ArgoCD OIDC secret 実装）の3PRで、いずれも merge 済み。本 PR は記録のみ。

## 検証したこと

`python3 ops/validate.py` → 0 error。

## ロールバック手順

記録ファイルのみの変更。revert すれば元に戻る。

## backlog task id

なし（記録のみ）

---
_Generated by [Claude Code](https://claude.ai/code/session_018ehE4UgMhgEPFoqqotni6W)_