### PR TITLE
feat(autopilot): クラスタ内常駐 autopilot のイメージとビルド経路を追加する

### DIFF
--- a/.github/workflows/build-autopilot-image.yml
+++ b/.github/workflows/build-autopilot-image.yml
@@ -1,0 +1,66 @@
+name: Build autopilot image
+
+# クラスタ内常駐 autopilot のコンテナイメージを ghcr.io へ publish する。
+#
+# このリポジトリのワークスペースには docker デーモンが無く、クラスタ内でイメージを
+# ビルドする権限も無いため、ビルドは GitHub Actions で行う。
+#
+# images/autopilot/ を変更した PR では build のみ（push しない）。
+# main に入った時点で ghcr.io へ push する。手動実行もできる。
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "images/autopilot/**"
+      - ".github/workflows/build-autopilot-image.yml"
+  pull_request:
+    paths:
+      - "images/autopilot/**"
+      - ".github/workflows/build-autopilot-image.yml"
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/homelab-autopilot
+
+jobs:
+  build:
+    name: build and push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # ghcr.io への push に必要。GITHUB_TOKEN に付与される。
+      packages: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v3
+
+      # PR では push しないので login も不要だが、条件分岐を増やさないため常に行う。
+      # GITHUB_TOKEN は同一オーナーの ghcr.io に対してのみ有効。
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build (and push on main)
+        uses: docker/build-push-action@v6
+        with:
+          context: images/autopilot
+          push: ${{ github.event_name != 'pull_request' }}
+          # sha タグを必ず付ける。manifest 側は sha で pin し、いつでも戻せるようにする。
+          # latest は「最新を追いたいとき」用で、manifest からは参照しない。
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # 次に manifest を書き換える人（人間でも autopilot でも）が、
+      # どのタグを指せばよいか分かるようにログへ出す。
+      - name: Show image reference
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "::notice title=autopilot image::${{ env.IMAGE }}:${{ github.sha }}"

--- a/images/autopilot/Dockerfile
+++ b/images/autopilot/Dockerfile
@@ -1,0 +1,41 @@
+# クラスタ内で常駐する autopilot のイメージ。
+#
+# クラウドのサンドボックス（claude.ai の定期実行）は homelab に到達できず、起動のたびに
+# プロビジョニングのオーバーヘッドがかかり、実行中かどうかも外から分からなかった。
+# このイメージはクラスタ内で動くので、k8s / Proxmox / B2 に直接届く。
+#
+# 入れる道具は「agent が homelab を操作するのに実際に要るもの」だけに絞る。
+# 増やすときは、なぜ要るかをコメントに書くこと。
+FROM node:22-alpine
+
+# git         : リポジトリの取得と push
+# openssh-client / ca-certificates : TLS と一部の git 操作
+# python3 / py3-yaml : ops/validate.py・ops/dashboard/build.py の実行に必須（標準ライブラリのみで動く方針）
+# curl        : 外部 API の疎通確認
+# bash        : ループスクリプト
+# restic      : バックアップの検証（クラスタ内からしかできない）
+# tzdata      : ログの時刻を読める形にする
+RUN apk add --no-cache \
+      git openssh-client ca-certificates python3 py3-yaml curl bash restic tzdata \
+ && npm install -g @anthropic-ai/claude-code \
+ && npm cache clean --force
+
+# kubectl は apk に無いので公式バイナリを取る。バージョンは k3s 側（1.35 系）に合わせる。
+ARG KUBECTL_VERSION=v1.35.0
+RUN ARCH="$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')" \
+ && curl -fsSLo /usr/local/bin/kubectl \
+      "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" \
+ && chmod +x /usr/local/bin/kubectl \
+ && kubectl version --client=true
+
+# 非 root で動かす。npm と git がホームに書ける必要があるので HOME を用意する。
+RUN adduser -D -u 10001 -h /home/autopilot autopilot \
+ && mkdir -p /work && chown -R 10001:10001 /work /home/autopilot
+
+USER 10001
+ENV HOME=/home/autopilot
+WORKDIR /work
+
+# 実際の起動コマンドは k8s 側の ConfigMap（ループスクリプト）が渡す。
+# イメージに振る舞いを焼き込まないことで、挙動の変更を Git だけで完結させる。
+CMD ["/bin/bash", "-c", "echo 'autopilot image: no command given'; sleep 3600"]


### PR DESCRIPTION
**VISION 段階 3（常駐基盤を自前に持つ）の第一歩**です。人間の指示で優先度を上げました。

## なぜ移すか

いまの autopilot は claude.ai のクラウド定期実行で動いていますが、

- **homelab に到達できません**（今日の詰まりの大半がこれ）
- 起動のたびにサンドボックスのプロビジョニングが走ります
- **実行中かどうかが外から分かりません**（重複起動を 3 回起こしました）
- cron の下限が 1 時間です

クラスタ内で動けば全部解決します。

## この PR の範囲

**イメージとビルド経路だけ**です。デプロイはまだしません。

- `images/autopilot/Dockerfile` — `claude` CLI に加え、agent が homelab を操作するのに実際に要る道具（git / python3 / kubectl / restic）
- **振る舞いはイメージに焼き込みません。** 起動コマンドは k8s 側の ConfigMap が渡すので、挙動の変更が Git だけで完結します
- `.github/workflows/build-autopilot-image.yml` — ghcr.io へ publish。PR では build のみ、main で push

## 段階的に進めます

1. **この PR**（イメージ）
2. クラスタ内 Job で `claude -p` が動くことだけ確認
3. GitHub に PR を 1 本出せることを確認
4. Deployment 化して常駐
5. **クラウド routine を保険に降格**（消しません。クラスタが死んだときの唯一の生存経路です）

## 検証

- ワークスペースで `claude -p` のヘッドレス実行が動くことを確認済み（`HEADLESS_OK`）
- workflow YAML は `yaml.safe_load_all` でパース確認済み