### PR TITLE
fix(autopilot): repo の権限設定を効かせ、ログを逐次出す

### DIFF
--- a/apps/autopilot/deployment.yaml
+++ b/apps/autopilot/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           # タグはイメージのビルド経路が固まった時点で差し替えるプレースホルダ。
           # ghcr の package が private の場合は imagePullSecrets が別途要る
           image: ghcr.io/hikuohiku/homelab-autopilot@sha256:1ef41f711651af72fea996ba95c0e0a6e9171f4e6f5579325f54fed1605938a8
-          command: ["sh", "/config/loop.sh"]
+          command: ["bash", "/config/loop.sh"]
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/apps/autopilot/kustomization.yaml
+++ b/apps/autopilot/kustomization.yaml
@@ -13,6 +13,7 @@ configMapGenerator:
     files:
       - loop.sh
       - prompt.md
+      - render.py
 
 generatorOptions:
   # 名前にハッシュを付けない（ops-health-reporter と同じ）。ハッシュを付けると

--- a/apps/autopilot/loop.sh
+++ b/apps/autopilot/loop.sh
@@ -39,6 +39,27 @@ log() {
 # PR / autopilot-* ブランチ経由なので、途中で落ちても次の Pod が拾える
 trap 'log "received SIGTERM, stopping after current step"; exit 0' TERM INT
 
+trust_workspace() {
+  # claude は未 trust のワークスペースでは repo 側 .claude/settings.json の
+  # permissions.allow を無視する（起動直後のログで実際に 18 件が無視された）。
+  # Pod には trust dialog に答える人間がいないので、受理済みとして書いておく。
+  mkdir -p "${HOME}"
+  CLAUDE_JSON="${HOME}/.claude.json" REPO="${REPO_DIR}" python3 - <<'EOF'
+import json
+import os
+
+path = os.environ["CLAUDE_JSON"]
+try:
+    with open(path) as f:
+        cfg = json.load(f)
+except (OSError, ValueError):
+    cfg = {}
+cfg.setdefault("projects", {}).setdefault(os.environ["REPO"], {})["hasTrustDialogAccepted"] = True
+with open(path, "w") as f:
+    json.dump(cfg, f)
+EOF
+}
+
 setup_git() {
   # トークンを remote URL に埋め込むと .git/config に平文で残り、`git remote -v` や
   # エラーメッセージに載りうる。credential helper 経由なら環境変数のまま渡せる
@@ -72,8 +93,14 @@ iterate() {
   # headless では既定で権限確認が要る。Pod は read-only RBAC の非 root コンテナで、
   # 確認に応じられる人間もいないので bypass する（CHARTER §5.1 の「止まるくらいなら
   # 最初から確認を出さない」と同じ理由）。
+  set -o pipefail
   timeout -k 30 "${ITERATION_TIMEOUT_SECONDS}" \
-    claude -p --permission-mode bypassPermissions "${PROMPT}"
+    claude -p --permission-mode bypassPermissions \
+      --output-format stream-json --verbose "${PROMPT}" \
+    | python3 /config/render.py
+  rc=$?
+  set +o pipefail
+  return "${rc}"
 }
 
 main() {
@@ -81,6 +108,7 @@ main() {
   # ホームに書けるよう、先に実体を作っておく
   mkdir -p "${WORKDIR}" "${HOME}"
   setup_git
+  trust_workspace
 
   log "started (interval=${INTERVAL_SECONDS}s timeout=${ITERATION_TIMEOUT_SECONDS}s repo=${REPO_URL})"
 

--- a/apps/autopilot/render.py
+++ b/apps/autopilot/render.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""claude -p --output-format stream-json の出力を 1 行ログに畳む。
+
+-p は既定だと完了までなにも出さないので、最大 1 時間 Pod のログが無音になる。
+何をしているのかを外から追えるようにするためだけの部品で、判断は一切しない。
+壊れても本体を巻き込まないよう、解釈できない行はそのまま捨てる。
+"""
+import json
+import sys
+
+
+def emit(text):
+    print(f"[claude] {text}", flush=True)
+
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        ev = json.loads(line)
+    except ValueError:
+        continue
+    kind = ev.get("type")
+    if kind == "assistant":
+        for block in ev.get("message", {}).get("content", []):
+            if block.get("type") == "tool_use":
+                name = block.get("name", "?")
+                inp = block.get("input", {})
+                hint = inp.get("command") or inp.get("file_path") or inp.get("pattern") or ""
+                emit(f"{name} {str(hint)[:160]}")
+            elif block.get("type") == "text":
+                text = block.get("text", "").strip()
+                if text:
+                    emit(text[:400])
+    elif kind == "result":
+        emit(
+            "result subtype={} turns={} cost_usd={}".format(
+                ev.get("subtype"), ev.get("num_turns"), ev.get("total_cost_usd")
+            )
+        )


### PR DESCRIPTION
クラスタ内 autopilot を起動して最初のイテレーションを観察して見つかった 2 点。

## repo の権限設定が無視されていた

起動直後のログ:

> Ignoring 18 permissions.allow entries from .claude/settings.json: this workspace has not been trusted.

Pod には trust dialog に答える人間がいないので、起動時に受理済みとして書く。

## ログが最大 1 時間無音だった

`claude -p` は完了までなにも出さない。`stream-json` を 1 行ログに畳み、使ったツールと結果・コストが `kubectl logs` で追えるようにする。

```
[claude] Bash echo RENDER_TEST
[claude] `echo RENDER_TEST` を実行し、`RENDER_TEST` が出力されました。
[claude] result subtype=success turns=2 cost_usd=0.14176850000000002
```

`pipefail` で `claude` 側の終了コードを取るため `sh` → `bash` に変える（イメージに同梱済み）。

レンダラは実際の `stream-json` 出力で動作確認済み。解釈できない行は捨てるので、本体を巻き込まない。