### PR TITLE
fix(vaultwarden): restic backup verify Job のハング切り分け診断を追加 (T-0108)

### DIFF
--- a/apps/vaultwarden/restic-backup-cronjob.yaml
+++ b/apps/vaultwarden/restic-backup-cronjob.yaml
@@ -64,6 +64,10 @@ spec:
       # 使っており実績があるため、その値に揃える。根本原因（なぜ vaultwarden だけ時間がかかったか）
       # は未確定のまま、失敗を解消する方向の緩和として先に反映する（CHARTER §4、縛る変更のcooldownは
       # 失敗を緩める変更には適用しない）
+      #
+      # T-0108: DeadlineExceeded で restic のロックが残ったまま次回以降も失敗し続ける状態になって
+      # いた（構築セッションが restic unlock --remove-all で解消した実例あり）。1回の失敗が
+      # 恒久的な失敗にならないよう、backup 実行前に stale lock だけを外す restic unlock を先頭に入れる
       activeDeadlineSeconds: 3600
       template:
         spec:
@@ -117,6 +121,7 @@ spec:
                 - |
                   set -eu
                   restic snapshots >/dev/null 2>&1 || restic init
+                  restic unlock
                   restic backup /mnt/vaultwarden-data /staging/db.sqlite3 \
                     --exclude db.sqlite3 --exclude db.sqlite3-wal --exclude db.sqlite3-shm \
                     --exclude icon_cache

--- a/apps/vaultwarden/restic-backup-verify-job.yaml
+++ b/apps/vaultwarden/restic-backup-verify-job.yaml
@@ -5,16 +5,28 @@
 #
 # 確認が取れ次第、この Job は削除する PR を出す（restic-backup-cronjob.yaml 側は変更しない、
 # CronJob の schedule は引き続き 03:40 UTC のまま）。
+#
+# T-0108: T-0097 で 1800s→3600s（#214）に緩和しても DeadlineExceeded は解消していない
+# （このジョブが実際に 3600s まで走った実績はまだ無く、緩和前の 1800s 失敗記録がそのまま
+# 残っていただけだった）。原因不明のまま timeout を延ばし続けるのではなく、診断のため
+# 意図的に短く戻し、restic unlock（stale lock 除去）と --verbose / RESTIC_PROGRESS_FPS で
+# 途中経過をログに残す。Pod のログは autopilot からは読めない（§5.5）ため、構築セッションに
+# issue #56 で確認を依頼する。
+#
+# T-0108: この Job オブジェクトは既に Failed 状態でクラスタに存在しており、
+# Job.spec.template は不変フィールドのため通常の patch では更新できない。
+# argocd.argoproj.io/sync-options: Replace=true で ArgoCD に delete+recreate させる。
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: vaultwarden-restic-backup-verify
   namespace: vaultwarden
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
 spec:
   backoffLimit: 1
-  # T-0097: 初回実行が DeadlineExceeded で失敗したため、restic-backup-cronjob.yaml と同じ理由で
-  # 3600s に揃える（immich 側の既存の実績値）
-  activeDeadlineSeconds: 3600
+  # T-0108: 診断目的で短く戻す（延ばす方向ではなく、早く失敗させて --verbose の途中経過を見る）
+  activeDeadlineSeconds: 300
   template:
     spec:
       automountServiceAccountToken: false
@@ -61,10 +73,14 @@ spec:
             - |
               set -eu
               restic snapshots >/dev/null 2>&1 || restic init
+              restic unlock
               restic backup /mnt/vaultwarden-data /staging/db.sqlite3 \
                 --exclude db.sqlite3 --exclude db.sqlite3-wal --exclude db.sqlite3-shm \
-                --exclude icon_cache
+                --exclude icon_cache \
+                --verbose
           env:
+            - name: RESTIC_PROGRESS_FPS
+              value: "1"
             - name: RESTIC_B2_BUCKET
               valueFrom:
                 secretKeyRef:

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2044,7 +2044,7 @@
         "apps/vaultwarden/restic-backup-cronjob.yaml"
       ],
       "created": "2026-08-06",
-      "pr": null,
+      "pr": 223,
       "notes": "T-0097 が『T-0108 で activeDeadlineSeconds を緩和したうえで再実行を待つ』として forward-reference していたが実体が起票されていなかった（T-0107 と同じ経緯）。#214 で timeout 緩和は既に着手済みだが、構築セッションの後続指摘（unlock 自動化・verbose 診断・timeout短縮での切り分け）はまだ manifest に反映されていない。次回以降で実装する。 | run #58: manifest 変更を実装した。apps/vaultwarden/restic-backup-verify-job.yaml に restic unlock・--verbose・RESTIC_PROGRESS_FPS=1 を追加し、診断のため activeDeadlineSeconds を 3600→300 に短縮（延ばす方向ではなく早く失敗させて途中経過を見る）。この Job は既にクラスタ上に Failed 状態で存在し Job.spec.template は不変フィールドのため、argocd.argoproj.io/sync-options: Replace=true を追加して ArgoCD が delete+recreate できるようにした。apps/vaultwarden/restic-backup-cronjob.yaml（本番）にも restic unlock のみを追加（timeout は変更しない）。ttlSecondsAfterFinished は元々未設定でログ保持の要件は満たしている。マージ後の実行結果（Complete/Failed）は autopilot が kubectl で自分で追える（Job/Pod の get/list は許可されている）が、--verbose の出力は Pod ログの読み取り権限が無いため見られない。失敗が続く場合は issue #56 で構築セッションにログ確認を依頼する。"
     }
   ]

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 110,
-  "updated": "2026-08-05",
+  "updated": "2026-08-06",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2045,7 +2045,7 @@
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "T-0097 が『T-0108 で activeDeadlineSeconds を緩和したうえで再実行を待つ』として forward-reference していたが実体が起票されていなかった（T-0107 と同じ経緯）。#214 で timeout 緩和は既に着手済みだが、構築セッションの後続指摘（unlock 自動化・verbose 診断・timeout短縮での切り分け）はまだ manifest に反映されていない。次回以降で実装する。"
+      "notes": "T-0097 が『T-0108 で activeDeadlineSeconds を緩和したうえで再実行を待つ』として forward-reference していたが実体が起票されていなかった（T-0107 と同じ経緯）。#214 で timeout 緩和は既に着手済みだが、構築セッションの後続指摘（unlock 自動化・verbose 診断・timeout短縮での切り分け）はまだ manifest に反映されていない。次回以降で実装する。 | run #58: manifest 変更を実装した。apps/vaultwarden/restic-backup-verify-job.yaml に restic unlock・--verbose・RESTIC_PROGRESS_FPS=1 を追加し、診断のため activeDeadlineSeconds を 3600→300 に短縮（延ばす方向ではなく早く失敗させて途中経過を見る）。この Job は既にクラスタ上に Failed 状態で存在し Job.spec.template は不変フィールドのため、argocd.argoproj.io/sync-options: Replace=true を追加して ArgoCD が delete+recreate できるようにした。apps/vaultwarden/restic-backup-cronjob.yaml（本番）にも restic unlock のみを追加（timeout は変更しない）。ttlSecondsAfterFinished は元々未設定でログ保持の要件は満たしている。マージ後の実行結果（Complete/Failed）は autopilot が kubectl で自分で追える（Job/Pod の get/list は許可されている）が、--verbose の出力は Pod ログの読み取り権限が無いため見られない。失敗が続く場合は issue #56 で構築セッションにログ確認を依頼する。"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1690,3 +1690,25 @@
   manifest 変更）が backlog の todo として残っている。auto-merge の GraphQL mutation
   （`enablePullRequestAutoMerge`）はまだ未検証、次に auto-merge が必要な low risk PR が出たときに
   試す。クラウド routine の頻度を下げる件（人間の依頼、まだ未着手）も backlog に載せる価値がある
+
+## 2026-08-06 05:20 JST — run #58
+
+- 前回の中断確認: オープン PR 0 件、`autopilot/*` ブランチも無し（クリーンな状態から開始）
+- 読んだフィードバック: issue #56 に last_read（2026-08-05T17:46:27Z）以降の新規コメント無し
+- やったこと: T-0108（vaultwarden restic backup verify Job のハング切り分け）に着手。
+  kubectl（autopilot-reader、この substrate で get/list 可、§5.5）で3つの検証 Job の実状態を
+  自分で確認できた: immich/coder-postgres は Complete（journal 既知の内容と一致）、vaultwarden は
+  Failed（DeadlineExceeded）。ただし失敗記録の startTime/lastTransitionTime を計算すると実際には
+  1800s で失敗しており、#214 で 3600s に緩和した後の再実行はまだ一度も無かった（緩和前の失敗記録が
+  spec だけ後から 3600 に上書きされて残っていただけ）と判明。DoD どおり
+  apps/vaultwarden/restic-backup-verify-job.yaml に restic unlock・--verbose・
+  RESTIC_PROGRESS_FPS=1 を追加し、診断のため activeDeadlineSeconds を 300 に短縮した。この
+  Job は既に Failed 状態でクラスタに存在し Job.spec.template が不変フィールドのため、
+  argocd.argoproj.io/sync-options: Replace=true を追加（無いと ArgoCD の patch がこの
+  変更を適用できない）。本番 CronJob（restic-backup-cronjob.yaml）にも restic unlock のみ追加
+  （timeout は変更しない）。risk は low のまま（診断用 Job の一時的な変更、本番側は失敗を減らす
+  方向の安全な追加のみ）
+- 次の起動へ: PR マージ後、ArgoCD sync で verify Job が再実行されるはずなので、次回起動で
+  kubectl の Job status を確認する。Complete なら T-0097/T-0104 を done にして3つの検証用
+  Job を削除する PR を出す。再度 Failed/ハングするなら --verbose の Pod ログは autopilot からは
+  読めない（pods/log 権限なし）ため issue #56 で構築セッションにログ確認を依頼する


### PR DESCRIPTION
## 変更点

vaultwarden の restic backup 検証用 Job (T-0104) が `DeadlineExceeded` で失敗し続けている
問題（T-0108）の切り分けのため、以下を変更した。

- `apps/vaultwarden/restic-backup-verify-job.yaml`（検証用 Job、one-off）
  - `restic backup` の前に `restic unlock`（stale lock だけを外す。既存の有効なロックには影響しない）を追加
  - `restic backup` に `--verbose` を追加し、`RESTIC_PROGRESS_FPS=1` を設定して途中経過をログに残す
  - `activeDeadlineSeconds` を 3600 → 300 に短縮（timeout を延ばして様子を見るのではなく、早く失敗させて
    `--verbose` の途中経過から原因を切り分けるための診断目的の変更）
  - この Job は既にクラスタ上に `Failed` 状態で存在しており、Kubernetes の `Job.spec.template` は
    作成後は不変フィールドのため、`argocd.argoproj.io/sync-options: Replace=true` を追加して
    ArgoCD が delete+recreate できるようにした
- `apps/vaultwarden/restic-backup-cronjob.yaml`（本番 CronJob）
  - `restic backup` の前に `restic unlock` のみ追加（timeout は変更しない）。1回の `DeadlineExceeded`
    で lock が残ったまま次回以降も失敗し続ける事態を防ぐための安全側の追加

## 検証したこと

- kubectl（in-cluster ServiceAccount `autopilot`、get/list のみ）で3つの検証 Job の実状態を確認:
  immich/coder-postgres は `Complete`、vaultwarden は `Failed`（`DeadlineExceeded`）。ただし失敗の
  タイムスタンプを計算すると実際には旧 1800s の deadline で失敗しており、`#214` で 3600s に緩和した
  後の再実行はまだ一度も行われていなかった（緩和後の spec が Failed 状態の Job オブジェクトに
  後から上書きされて残っていただけ）
- `python3 -c "import yaml; yaml.safe_load_all(...)"` で両ファイルの YAML 構文を確認
- `python3 ops/validate.py` で 0 error（既存の warning のみ、本 PR とは無関係）

## ロールバック手順

`git revert` で元に戻せば ArgoCD が旧マニフェストへ self-heal する。検証用 Job は本番のバックアップ
経路とは独立（`apps/vaultwarden/restic-backup-cronjob.yaml` の schedule は変更していない）で、
いつでも削除してよい one-off Job。restic 側は `restic unlock`（stale lock のみ除去、非破壊）のみの
追加で、実データ（B2 上の既存 snapshot）には影響しない。

## backlog task id

T-0108