### PR TITLE
ops: run #58 の記録更新（T-0028/T-0071 前提訂正）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -539,7 +539,7 @@
       "priority": 19,
       "why": "T-0005 の調査 (run #6) で判明。9→10 で server.additionalApplications/additionalProjects が別 chart (argocd-apps) に分離、redis-ha の selector-label immutability により手動 Pod 削除が必要になる場合があるなど breaking change を含む。ArgoCD 自身なので壊れると全アプリのデプロイ経路が止まる（ops/inventory.json の policy=manual の理由そのもの）",
       "dod": "9.1.6 から 10.2.3 までの全リリースノートを原文で読む。apps/argocd/kustomization.yaml と nix/images/proxmox-cloud/k3s-manifests.nix（T-0002 の二重管理、ops/check_version_sync.py が同時更新を検証する）の両方を同時に更新。CHARTER §4『到達性を失いうる変更（ArgoCD 自身）』の手順に従い、壊れたときの復旧手順を PR に明記する。policy=manual のため実装は用意できても最終判断は人間に委ねる必要があるか、この時点で再検討する",
-      "blocked_by": "ArgoCD 自身の破壊的更新。失敗すると revert を適用する経路（ArgoCD）ごと失われ、復旧にクラスタへの直接操作が要る。autopilot のクラウドサンドボックスは Tailscale 経由でクラスタに到達できないため、人間が起きていて Tailscale 経由でクラスタに触れる時間帯にのみ着手すべき（issue #56, 2026-08-04 22:42:36）。autopilot はその時間帯かどうかを判定する手段を持たないため、当面 blocked のままにし、着手可否の判断自体を人間からのフィードバックか、到達性確認の仕組み（T-0015）が整うのを待つ",
+      "blocked_by": "ArgoCD 自身の破壊的更新。失敗すると revert を適用する経路（ArgoCD）ごと失われる。run #57 の substrate 移行（issue #56, 2026-08-05 18:32:03 の棚卸し依頼）で前提を訂正: autopilot は現在クラスタ内 Pod として常駐しており『到達できない』は成り立たない。ただし autopilot の ClusterRole (`autopilot-reader`) は get/list のみで書き込み動詞が無く、構築セッションの kubectl も同じく読み取りのみ（§5.5）。ArgoCD が壊れると git revert しても ArgoCD 自身の self-heal に頼るしかなく、それが機能しない場合の直接復旧（kubectl apply/rollback）はどちらの主体にも書き込み権限が無く実行できない。加えて autopilot 自身も ArgoCD 経由でデプロイされているため、ArgoCD が壊れると自分自身を巻き込みうる（issue #56 指摘）。復旧経路を持てるのは Tailscale 経由で書き込み可能な kubeconfig を持つ人間だけであり、この点は substrate 移行後も変わらない。着手するには (a) 緊急復旧専用の書き込み権限を新設する設計を先に固める、(b) 人間が Tailscale 経由で対応できる時間帯の判断を委ねる、のいずれかが要る。当面 blocked のまま",
       "refs": [
         "apps/argocd/kustomization.yaml",
         "nix/images/proxmox-cloud/k3s-manifests.nix",
@@ -1320,14 +1320,14 @@
       "priority": 41,
       "why": "issue #56 (2026-08-05 04:40:59) の人間の新方針。『試したことのないバックアップは、バックアップではありません』。T-0068〜T-0070 で作った CronJob が実際に復元可能なデータを作れているかを、別 namespace か使い捨て環境に実際に復元して確認する。T-0023/T-0027/T-0029（データを失いうるメジャー更新）はこれが通るまで着手できない（T-0034 dropped に伴い、これらの blocked_by をここに張り替え済み）",
       "dod": "immich / vaultwarden / coder-postgres それぞれについて、restic のバックアップから使い捨て環境（別 namespace 等）に実際に復元し、データが読めることを確認する。**復元にかかった時間を実測して記録する**（PBS 退役判断の材料になる、人間の依頼どおり）。結果を docs/backup.md に記録する",
-      "needs_human_reason": "復元試験にはクラスタへの到達（別 namespace の作成、restic restore コマンドの実行）が要る。autopilot のクラウドサンドボックスは到達できない（CHARTER §5.2）。ただし実装（CronJob の manifest、restic restore の手順書）自体はブロックされずに進められるため blocked のままにし、needs-human への切り替えは T-0068〜T-0070 が終わってから判断する",
+      "needs_human_reason": "run #57 の substrate 移行（issue #56, 2026-08-05 18:32:03 の棚卸し依頼）で前提を訂正: 『クラスタへの到達』を理由に needs-human 化する必要は無い。T-0104 が示した手法（restore-verify Job を manifest として git に宣言し ArgoCD に apply させ、autopilot は kubectl get job の Complete/Failed だけを read-only で確認する）がそのまま restic restore にも使える——別 namespace の作成も restic restore コマンドの実行も、autopilot 自身の kubectl 書き込み権限は不要で、Git 経由の ArgoCD 適用で完結する。データの整合性確認（ファイル数・チェックサム等）も Job 内のスクリプトに埋め込んで exit code で判定させれば、autopilot に無い pods/log 権限も不要。したがって T-0104 完了後は autopilot 自身が実装から完了確認まで完結でき、人間の手作業は不要と見込まれる。念のため復元にかかった時間の実測（DoD）が Job のログでしか取れない場合のみ、構築セッション（restic/B2 直接操作が可能、§5.5）に issue #56 経由で確認を頼む",
       "blocked_by": "T-0104（一度きりの検証 Job で restic backup 自体が成功することを先に確認する。T-0067 は完了済み）",
       "refs": [
         "docs/backup.md"
       ],
       "created": "2026-08-05",
       "pr": null,
-      "notes": " | run #50: issue #56 (12:48:16) の指摘で、immich がまだほとんど使われていない（332MiB）今のうちに復元試験まで通しておくべきと助言された。T-0068〜T-0070 の実装は完了済みのため blocked_by を T-0067 のみに絞った。T-0067 が片付き次第、最優先で着手する。 | run #53: T-0067 done。ただし T-0103（remoteRef タイポ）修正直後のため、まだ一度も backup が成功した実績が無い。T-0104（検証 Job）の結果を待ってから着手する。復元試験自体（別 namespace の作成、restic restore の実行）は write 権限が要るため、構築セッションの現状（`agent-reader`、view 相当）では足りない可能性がある点に注意"
+      "notes": " | run #50: issue #56 (12:48:16) の指摘で、immich がまだほとんど使われていない（332MiB）今のうちに復元試験まで通しておくべきと助言された。T-0068〜T-0070 の実装は完了済みのため blocked_by を T-0067 のみに絞った。T-0067 が片付き次第、最優先で着手する。 | run #53: T-0067 done。ただし T-0103（remoteRef タイポ）修正直後のため、まだ一度も backup が成功した実績が無い。T-0104（検証 Job）の結果を待ってから着手する。 | run #57 (2巡目): substrate が in-cluster 常駐に変わったため『write 権限が要るため実行できない可能性』という懸念は解消（T-0104 と同じ Git→ArgoCD 経路で書き込み不要のまま実行できる）"
     },
     {
       "id": "T-0072",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,23 +1,27 @@
 {
-  "open": [
-    {
-      "number": 216,
-      "title": "ops: T-0107/T-0108 の起票漏れを埋め、run #56 の記録を追加",
-      "url": "https://github.com/hikuohiku/homelab/pull/216",
-      "isDraft": false,
-      "createdAt": "2026-08-05T17:29:46Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "SUCCESS"
-        }
-      ],
-      "headRefName": "autopilot/T-0107-T-0108-node01-tls-and-vaultwarden-deadline",
-      "autoMergeRequest": {
-        "enabledAt": "true"
-      }
-    }
-  ],
+  "open": [],
   "merged": [
+    {
+      "number": 223,
+      "title": "fix(vaultwarden): restic backup verify Job のハング切り分け診断を追加 (T-0108)",
+      "url": "https://github.com/hikuohiku/homelab/pull/223",
+      "mergedAt": "2026-08-05T18:36:27Z",
+      "headRefName": "autopilot/T-0108-vaultwarden-restic-diagnostics"
+    },
+    {
+      "number": 222,
+      "title": "fix(autopilot): repo の権限設定を効かせ、ログを逐次出す",
+      "url": "https://github.com/hikuohiku/homelab/pull/222",
+      "mergedAt": "2026-08-05T18:18:37Z",
+      "headRefName": "autopilot/loop-visibility"
+    },
+    {
+      "number": 221,
+      "title": "ops: クラスタ内 substrate の事実を CHARTER に記録し、T-0107/T-0108 起票漏れを埋める",
+      "url": "https://github.com/hikuohiku/homelab/pull/221",
+      "mergedAt": "2026-08-05T18:18:27Z",
+      "headRefName": "autopilot/T-0107-T-0108-substrate-charter-update"
+    },
     {
       "number": 220,
       "title": "feat(autopilot): クラスタ内 autopilot を起動する",
@@ -416,27 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/156",
       "mergedAt": "2026-08-05T05:27:17Z",
       "headRefName": "autopilot/run30-feedback"
-    },
-    {
-      "number": 152,
-      "title": "docs: terraform plan の CI 化を調査する (T-0073)",
-      "url": "https://github.com/hikuohiku/homelab/pull/152",
-      "mergedAt": "2026-08-05T05:23:45Z",
-      "headRefName": "autopilot/T-0073-terraform-plan-ci-feasibility"
-    },
-    {
-      "number": 153,
-      "title": "T-0015: ArgoCD/k8s の健全性を homelab から repo へ書き戻す CronJob を追加",
-      "url": "https://github.com/hikuohiku/homelab/pull/153",
-      "mergedAt": "2026-08-05T05:21:50Z",
-      "headRefName": "autopilot/T-0015-ops-health-reporter"
-    },
-    {
-      "number": 154,
-      "title": "ops: run #29 の記録をまとめ、ダッシュボードを再生成する",
-      "url": "https://github.com/hikuohiku/homelab/pull/154",
-      "mergedAt": "2026-08-05T05:16:19Z",
-      "headRefName": "autopilot/run29-wrapup"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1712,3 +1712,34 @@
   kubectl の Job status を確認する。Complete なら T-0097/T-0104 を done にして3つの検証用
   Job を削除する PR を出す。再度 Failed/ハングするなら --verbose の Pod ログは autopilot からは
   読めない（pods/log 権限なし）ため issue #56 で構築セッションにログ確認を依頼する
+
+## 2026-08-06 03:38 JST — run #58
+
+- 前回の中断確認: PR #223（T-0108, vaultwarden restic backup verify Job のハング診断）が open のまま
+  残っていたので拾った。CI green・issue #223 に新規コメント無し・`mergeable_state: clean` を確認して
+  merge した。ArgoCD の次回ポーリングまで反映されないため、修正後の Job 成否確認はまだできていない
+  （kubectl で確認したところ vaultwarden-restic-backup-verify は旧 Failed のまま、ArgoCD の
+  `status.sync.revision` も merge 前のコミットのまま——想定どおり、次回起動で再確認する）
+- 読んだフィードバック: issue #56 の未読1件（18:32:03、substrate 移行に伴う棚卸し依頼）。
+  「クラスタに到達できない」を理由に blocked/needs-human にしていたタスクの前提が substrate 移行
+  （run #57、in-cluster 常駐）で崩れていないか確認した
+  - **T-0028**（ArgoCD メジャー更新）: `blocked_by` を訂正。「到達できない」は誤りで、実際の制約は
+    autopilot・構築セッションとも kubectl が read-only（書き込み動詞なし）で、ArgoCD が壊れると
+    self-heal に頼れず直接復旧できないこと、autopilot 自身も ArgoCD 経由デプロイのため巻き込まれ
+    うること。判断（blocked のまま）は変えていない
+  - **T-0071**（restic 復元試験）: `needs_human_reason` を訂正。T-0104 で確立した手法（restore-verify
+    Job を git に宣言 → ArgoCD が適用 → autopilot は read-only kubectl で Complete/Failed を確認）が
+    restic restore にもそのまま使え、書き込み権限もログ閲覧権限も不要と判断した。T-0104 完了後は
+    人間の手作業無しで autopilot 自身が進められる見込み
+  - **T-0074**: 対象外（T-0107 待ちのまま変更なし、人間の指摘どおり）
+  - issue #56 に3行程度で返信し、last_read を 2026-08-05T18:32:03Z に更新
+- kubectl（in-cluster read-only）で vaultwarden/coder/immich の restic-backup-verify Job・
+  本番 CronJob の実行状況を直接確認: coder/immich は Complete（本番 CronJob も直近実行が Complete）、
+  vaultwarden は PR #223 反映前のため旧 Failed のまま
+- ダッシュボード PR キャッシュ（ops/dashboard/prs.json）を REST API で最新化（open 0件、merged 60件）、
+  `python3 ops/validate.py` は 0 error（既存 warning のみ）、`ops/dashboard/build.py` で index.html
+  再生成。Artifact ツールがこの substrate に無いため再公開はできず（既知、CHARTER §7.1 の対応どおり
+  journal に一行だけ残す）
+- 次の起動へ: PR #223 の効果（vaultwarden-restic-backup-verify Job が Complete になるか）を
+  kubectl で確認すること。成功していれば T-0097/T-0104/T-0108 を done にし、T-0071 の
+  blocked_by を解除して着手する。失敗が続くなら T-0108 の DoD に沿ってさらに切り分ける

--- a/ops/state.json
+++ b/ops/state.json
@@ -6,7 +6,7 @@
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-05T17:46:27Z"
+    "last_read": "2026-08-05T18:32:03Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -641,6 +641,16 @@
       "summary": "substrate がクラウド毎時cronからクラスタ内常駐Deploymentに変わった最初のイテレーション。CHARTER §5.5を新設し、この環境で実際に使えるもの（curl+GitHub REST APIがAUTOPILOT_GITHUB_TOKENで直接使える、旧サンドボックスと違いapi.github.comへの到達が403にならない、kubectlが専用ClusterRoleで実際に動く、restic CLIはあるがB2 credentialは無い）を実測して記録した。issue #56の未読9件を確認し、積み残し2点（vaultwarden resticのハング切り分けが未解決、T-0107/T-0108の起票漏れ）に対応: T-0107（needs-human、Proxmox証明書SAN不一致、terraform apply禁止）・T-0108（todo、restic unlock自動化/verbose診断/timeout短縮）をbacklogに起票し、PR #216（stale化していた同内容のPR）をcloseした。T-0109（autopilotのクラスタ内常駐移行）はkubectlでreplicas=1を確認しdoneにした。",
       "prs": [
         221
+      ]
+    },
+    {
+      "n": 58,
+      "at": "2026-08-05T18:38:50Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot (apps/autopilot/)",
+      "summary": "前回の中断: run #57 が open のまま残していた PR #223（T-0108, vaultwarden restic backup verify Job のハング診断: restic unlock 追加・--verbose 診断・activeDeadlineSeconds 3600→300 短縮）を CI green・新規異議なしを確認して merge した。ArgoCD の次回ポーリングまで未反映のため、修正後の Job 成否は次回起動で確認する。issue #56 の未読1件（18:32:03、substrate 移行に伴う棚卸し依頼）を反映: 「クラスタに到達できない」を理由に blocked/needs-human にしていたタスクを洗い出し、T-0028（blocked_by の文面を『到達不可』→『書き込み権限が無い・ArgoCD 自壊時の自己復旧不可・autopilot 自身も巻き込まれうる』に訂正、判断=blockedは維持）、T-0071（needs_human_reason を訂正。T-0104 と同型の Git 宣言 Job + read-only kubectl 確認で復元試験も autopilot 自身が完結できると判断、人間の手作業は不要見込み）を backlog に反映。T-0074 は対象外（T-0107 待ちのまま変更なし）と確認。kubectl で vaultwarden/coder/immich の restic-backup-verify Job・CronJob 実行状況を直接確認（coder/immich は Complete、vaultwarden は旧 Failed のまま——PR #223 未反映のため想定どおり）。ダッシュボード PR キャッシュを REST API で最新化（open 0件、merged 60件）、Artifact ツールがこの substrate に無いため再公開はできず（既知、CHARTER §7.1 どおり）。",
+      "prs": [
+        223
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

run #58 の記録更新のみ（`ops/` の運用記録、CHARTER §4 の相乗り例外に該当する回のみの記録PR）。

- `ops/backlog.json`: T-0028 / T-0071 の `blocked_by` / `needs_human_reason` を訂正。
  issue #56（2026-08-05 18:32:03）の棚卸し依頼を受け、「クラスタに到達できない」を理由にしていた
  文面を substrate 移行後の実態（in-cluster 常駐・kubectl は read-only）に合わせた。
  判断（両タスクとも blocked のまま）自体は変えていない。
- `ops/state.json`: run #58 の記録、`feedback.last_read` を更新。
- `ops/journal/2026-08.md`: run #58 の引き継ぎ記録。
- `ops/dashboard/prs.json`: PR 一覧キャッシュを最新化（open 0件、merged 60件）。

前段として、前回起動（run #57）が open のまま残していた PR #223（T-0108, vaultwarden restic
backup verify Job のハング診断）は本 PR とは別に、CI green・新規異議なしを確認済みの上で
既に merge 済み。

## 検証したこと

- `python3 ops/validate.py` → 0 error（既存 warning のみ、本 PR とは無関係）
- `python3 ops/dashboard/build.py` → 例外なく完走

## ロールバック手順

`git revert` で元に戻せば良い。記録データのみで実インフラには影響しない。

## backlog task id

なし（記録のみ）