### PR TITLE
fix(vaultwarden): restic verify Job の ArgoCD 再作成が失敗していたのを修正 (T-0108)

### DIFF
--- a/apps/vaultwarden/restic-backup-verify-job.yaml
+++ b/apps/vaultwarden/restic-backup-verify-job.yaml
@@ -15,14 +15,19 @@
 #
 # T-0108: この Job オブジェクトは既に Failed 状態でクラスタに存在しており、
 # Job.spec.template は不変フィールドのため通常の patch では更新できない。
-# argocd.argoproj.io/sync-options: Replace=true で ArgoCD に delete+recreate させる。
+# Replace=true 単体（kubectl replace 相当）では spec.selector 等の immutable フィールドを
+# 含む置き換えは失敗する（PUT でも immutable 制約はサーバー側で強制される）。実際に #223
+# merge 後、ArgoCD の operationState が "field is immutable" で SyncFailed を繰り返していた
+# （2026-08-05 18:43 UTC 時点で4回リトライ済み、kubectl で直接確認）。Force=true を足すと
+# kubectl replace --force 相当になり、失敗時に delete → create で入れ直すため、この Job には
+# Replace 単体ではなく Replace=true,Force=true が必要。
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: vaultwarden-restic-backup-verify
   namespace: vaultwarden
   annotations:
-    argocd.argoproj.io/sync-options: Replace=true
+    argocd.argoproj.io/sync-options: Replace=true,Force=true
 spec:
   backoffLimit: 1
   # T-0108: 診断目的で短く戻す（延ばす方向ではなく、早く失敗させて --verbose の途中経過を見る）

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 110,
+  "next_id": 111,
   "updated": "2026-08-06",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
@@ -2045,7 +2045,28 @@
       ],
       "created": "2026-08-06",
       "pr": 223,
-      "notes": "T-0097 が『T-0108 で activeDeadlineSeconds を緩和したうえで再実行を待つ』として forward-reference していたが実体が起票されていなかった（T-0107 と同じ経緯）。#214 で timeout 緩和は既に着手済みだが、構築セッションの後続指摘（unlock 自動化・verbose 診断・timeout短縮での切り分け）はまだ manifest に反映されていない。次回以降で実装する。 | run #58: manifest 変更を実装した。apps/vaultwarden/restic-backup-verify-job.yaml に restic unlock・--verbose・RESTIC_PROGRESS_FPS=1 を追加し、診断のため activeDeadlineSeconds を 3600→300 に短縮（延ばす方向ではなく早く失敗させて途中経過を見る）。この Job は既にクラスタ上に Failed 状態で存在し Job.spec.template は不変フィールドのため、argocd.argoproj.io/sync-options: Replace=true を追加して ArgoCD が delete+recreate できるようにした。apps/vaultwarden/restic-backup-cronjob.yaml（本番）にも restic unlock のみを追加（timeout は変更しない）。ttlSecondsAfterFinished は元々未設定でログ保持の要件は満たしている。マージ後の実行結果（Complete/Failed）は autopilot が kubectl で自分で追える（Job/Pod の get/list は許可されている）が、--verbose の出力は Pod ログの読み取り権限が無いため見られない。失敗が続く場合は issue #56 で構築セッションにログ確認を依頼する。"
+      "notes": "T-0097 が『T-0108 で activeDeadlineSeconds を緩和したうえで再実行を待つ』として forward-reference していたが実体が起票されていなかった（T-0107 と同じ経緯）。#214 で timeout 緩和は既に着手済みだが、構築セッションの後続指摘（unlock 自動化・verbose 診断・timeout短縮での切り分け）はまだ manifest に反映されていない。次回以降で実装する。 | run #58: manifest 変更を実装した。apps/vaultwarden/restic-backup-verify-job.yaml に restic unlock・--verbose・RESTIC_PROGRESS_FPS=1 を追加し、診断のため activeDeadlineSeconds を 3600→300 に短縮（延ばす方向ではなく早く失敗させて途中経過を見る）。この Job は既にクラスタ上に Failed 状態で存在し Job.spec.template は不変フィールドのため、argocd.argoproj.io/sync-options: Replace=true を追加して ArgoCD が delete+recreate できるようにした。apps/vaultwarden/restic-backup-cronjob.yaml（本番）にも restic unlock のみを追加（timeout は変更しない）。ttlSecondsAfterFinished は元々未設定でログ保持の要件は満たしている。マージ後の実行結果（Complete/Failed）は autopilot が kubectl で自分で追える（Job/Pod の get/list は許可されている）が、--verbose の出力は Pod ログの読み取り権限が無いため見られない。失敗が続く場合は issue #56 で構築セッションにログ確認を依頼する。 | run #59: PR #223 merge 後、ArgoCD の operationState を kubectl で確認したところ Replace=true 単体では Job.spec.selector 等の immutable フィールドを含む置き換えが 'field is immutable' で SyncFailed し、4回リトライしても解消していなかった（2026-08-05 18:43 UTC 確認）。原因は Replace=true が kubectl replace 相当で PUT でも immutable 制約はサーバー側で強制されるため。Force=true を追加し Replace=true,Force=true（kubectl replace --force 相当、delete→create）に変更した。"
+    },
+    {
+      "id": "T-0110",
+      "domain": "homelab",
+      "title": "ops-health-reporter に autopilot 自身（namespace autopilot）の健全性を追加する",
+      "kind": "feature",
+      "risk": "low",
+      "status": "todo",
+      "priority": 15,
+      "why": "常駐化（run #57、CHARTER §5.5）で autopilot は自分自身が CrashLoopBackOff やハングに陥っても報告できない。ops-health-reporter は他コンポーネントの sync/health を見ているが autopilot 自身は対象外。人間から具体的な提案があった（issue #56, 2026-08-05T18:34:45Z）: 'crash より静かな失敗のほうが厄介'。",
+      "dod": "ops-health-reporter（apps/ops-health-reporter/）が ops/health/latest.json に次を含める: (1) autopilot namespace の Deployment の readyReplicas/restartCount、(2) 直近イテレーションの終了コード・終了時刻（可能なら Pod ログから `iteration #N end exit=` を拾う。ops-health-reporter 自身の RBAC で pods/log が読めるか要確認、読めなければ代替指標を検討する）、(3) 最後にイテレーションが完了してからの経過時間。CHARTER §2 に、次の起動が起動直後にこれを見て『前回の自分は正常に終わったか』を確認する手順を追記する。ダッシュボードにも表示する。",
+      "blocked_by": null,
+      "refs": [
+        "apps/ops-health-reporter/",
+        "apps/autopilot/",
+        "ops/CHARTER.md",
+        "ops/dashboard/build.py"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "ops-health-reporter の ServiceAccount の権限（pods/log を含むか）を実装前に確認する必要がある。含まないなら CHARTER §5.5 と同様にログ以外の指標（Deployment restartCount, 最終 successfulJob 的なもの）で代替する。"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 224,
+      "title": "ops: run #58 の記録更新（T-0028/T-0071 前提訂正）",
+      "url": "https://github.com/hikuohiku/homelab/pull/224",
+      "mergedAt": "2026-08-05T18:41:20Z",
+      "headRefName": "autopilot/run58-wrapup"
+    },
+    {
       "number": 223,
       "title": "fix(vaultwarden): restic backup verify Job のハング切り分け診断を追加 (T-0108)",
       "url": "https://github.com/hikuohiku/homelab/pull/223",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/157",
       "mergedAt": "2026-08-05T05:34:05Z",
       "headRefName": "autopilot/T-0065-iac-completeness"
-    },
-    {
-      "number": 156,
-      "title": "run #30: issue #56 のフィードバック2件を反映（cooldown/直列化の規則衝突、#153 レビュー）",
-      "url": "https://github.com/hikuohiku/homelab/pull/156",
-      "mergedAt": "2026-08-05T05:27:17Z",
-      "headRefName": "autopilot/run30-feedback"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1743,3 +1743,28 @@
 - 次の起動へ: PR #223 の効果（vaultwarden-restic-backup-verify Job が Complete になるか）を
   kubectl で確認すること。成功していれば T-0097/T-0104/T-0108 を done にし、T-0071 の
   blocked_by を解除して着手する。失敗が続くなら T-0108 の DoD に沿ってさらに切り分ける
+
+## 2026-08-06 03:52 JST — run #59
+
+- 前回の中断確認: オープン PR 0 件、`autopilot/*` ブランチも無し
+- 読んだフィードバック: issue #56 の未読1件（2026-08-05T18:34:45Z「autopilot 自身を誰も見ていない」）。
+  もう1件（18:39:07）は run #58 自身の返信だった。「やってほしいこと」として T-0110 を起票
+  （ops-health-reporter に autopilot namespace の健全性を追加する）。issue に3行で返信し
+  last_read を更新
+- やったこと: T-0108 のフォローアップ。PR #223 merge 後の効果を kubectl + ArgoCD Application
+  リソース（`kubectl -n argocd get application vaultwarden`）で確認したところ、
+  `vaultwarden-restic-backup-verify` Job の再作成が `operationState.message: "field is
+  immutable"` で SyncFailed を繰り返していた（18:43 UTC 時点で4回リトライ済み）。原因は
+  `argocd.argoproj.io/sync-options: Replace=true` 単体は `kubectl replace` 相当で、PUT でも
+  `spec.selector` 等の immutable フィールドを含む置き換えはサーバー側で拒否されるため。
+  `Replace=true,Force=true`（`kubectl replace --force` 相当、delete→create）に修正した
+  （apps/vaultwarden/restic-backup-verify-job.yaml）。risk は low（診断用 Job のみ、本番
+  CronJob は対象外）
+- 見つけたこと: 本番の `vaultwarden-restic-backup` CronJob 自体は直近実行が Complete（16秒、
+  5分前）していて、restic unlock 追加（#223）は本番側で効いている。詰まっているのは検証用
+  Job の ArgoCD 再作成だけ
+- 次の起動へ: この PR が merge されたら ArgoCD の次回 sync で Job が delete→create されるはず
+  なので、kubectl で `vaultwarden-restic-backup-verify` の Complete/Failed を確認する。
+  Complete なら T-0097/T-0104/T-0108 を done にし、3つの検証用 Job を削除する PR を出す。
+  --verbose の Pod ログは autopilot からは読めないので、Failed が続くなら issue #56 で
+  構築セッションにログ確認を依頼する。T-0110（autopilot 自身の健全性監視）は着手前の todo

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-05T18:14:03Z",
+  "updated": "2026-08-05T18:52:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-05T18:32:03Z"
+    "last_read": "2026-08-05T18:39:07Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -652,6 +652,14 @@
       "prs": [
         223
       ]
+    },
+    {
+      "n": 59,
+      "at": "2026-08-05T18:52:00Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "issue #56 のフィードバック(autopilot 自身の健全性監視提案)を T-0110 として起票。T-0108 のフォローアップ: ArgoCD が vaultwarden-restic-backup-verify Job の再作成を 'field is immutable' で SyncFailed し続けているのを kubectl で発見し、sync-options を Replace=true,Force=true に修正",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`vaultwarden-restic-backup-verify` Job（T-0104 の診断用 Job）の ArgoCD 再作成が失敗し続けていたのを修正しました。

- 直前の PR #223（T-0108）で Job に `restic unlock` / `--verbose` を追加し、`argocd.argoproj.io/sync-options: Replace=true` を付けたが、merge 後 kubectl + ArgoCD の Application リソースで確認したところ `operationState.message` が `"field is immutable"` で SyncFailed を4回リトライしていた
- 原因: `Replace=true` 単体は `kubectl replace` 相当で、PUT でも `spec.selector` 等の immutable フィールドを含む置き換えはサーバー側で拒否される
- `argocd.argoproj.io/sync-options: Replace=true,Force=true`（`kubectl replace --force` 相当、失敗時に delete→create）に修正
- あわせて issue #56 のフィードバック（autopilot 自身の健全性監視の提案）を backlog に T-0110 として起票、journal / state.json / dashboard PR キャッシュを更新（`ops/` の運用記録の相乗り、CHARTER §4）

## 検証したこと

- `kubectl -n argocd get application vaultwarden -o json` で `operationState.message` に `"field is immutable"` が繰り返し出ていることを直接確認（2026-08-05 18:43 UTC 時点で4回目のリトライ）
- 本番の `vaultwarden-restic-backup` CronJob（別リソース、このJobとは無関係）は直近実行が Complete 済みで、restic unlock 追加は本番側では既に効いている
- `python3 ops/validate.py` 0 error
- `python3 ops/dashboard/build.py` 正常終了

## ロールバック手順

`argocd.argoproj.io/sync-options` を `Replace=true` に戻せば元の状態（SyncFailed を繰り返す）に戻ります。この Job は診断用の一度きりの検証 Job（本番 CronJob ではない）なので、ロールバックしてもデータへの影響はありません。

## backlog task id

T-0108（継続）