### PR TITLE
feat(ops-health-reporter): autopilot 自身の健全性を latest.json に追加する (T-0110)

### DIFF
--- a/apps/ops-health-reporter/rbac.yaml
+++ b/apps/ops-health-reporter/rbac.yaml
@@ -24,6 +24,9 @@ rules:
     resources: ["configmaps"]
     resourceNames: ["pvc-usage-report"]
     verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -33,6 +36,34 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: ops-health-reporter-reader
+subjects:
+  - kind: ServiceAccount
+    name: ops-health-reporter
+    namespace: ops-health-reporter
+---
+# autopilot 自身のハートビート（iteration の開始/終了ログ）を読むための追加権限。
+# pods/log は他 namespace のワークロード（vaultwarden/immich/coder 等）のログを
+# 読む経路を一切新設したくないので、cluster-wide の ClusterRole ではなく
+# autopilot namespace に閉じた Role にする（T-0110）。
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ops-health-reporter-autopilot-log-reader
+  namespace: autopilot
+rules:
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ops-health-reporter-autopilot-log-reader
+  namespace: autopilot
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ops-health-reporter-autopilot-log-reader
 subjects:
   - kind: ServiceAccount
     name: ops-health-reporter

--- a/apps/ops-health-reporter/report.py
+++ b/apps/ops-health-reporter/report.py
@@ -9,6 +9,7 @@ import base64
 import datetime
 import json
 import os
+import re
 import ssl
 import urllib.error
 import urllib.request
@@ -29,6 +30,15 @@ def k8s_get(path):
     )
     with urllib.request.urlopen(req, context=SSL_CTX, timeout=15) as resp:
         return json.load(resp)
+
+
+def k8s_get_text(path):
+    # /log エンドポイントはプレーンテキストを返す（JSON ではない）
+    req = urllib.request.Request(
+        K8S_BASE + path, headers={"Authorization": "Bearer " + SA_TOKEN}
+    )
+    with urllib.request.urlopen(req, context=SSL_CTX, timeout=15) as resp:
+        return resp.read().decode("utf-8", errors="replace")
 
 
 def collect(fn):
@@ -178,6 +188,100 @@ def collect_nodes():
     return out
 
 
+# loop.sh (apps/autopilot/loop.sh) の log() が書く心拍行だけを抜き出す正規表現。
+# ここにマッチした行から取り出した値（timestamp/iteration/exit_code/elapsed_seconds）
+# だけを report に載せる。生ログはこの関数の外に一切出さない — claude の出力を
+# git 管理のブランチにそのまま持ち出す経路を作らないため（T-0110）。
+# exit=124 (timeout) の行は "exit=124 (timed out after Ns) elapsed=Ns" と exit code の後に
+# 括弧書きが挟まるので、その部分を任意にして両方の形式を通す
+HEARTBEAT_RE = re.compile(
+    r"^\[autopilot\] (\S+) iteration #(\d+) (?:start|end exit=(-?\d+)(?: \([^)]*\))? elapsed=(\d+)s)"
+)
+
+
+def parse_heartbeat(raw_log):
+    last_start = None
+    last_end = None
+    for line in raw_log.splitlines():
+        m = HEARTBEAT_RE.match(line.strip())
+        if not m:
+            continue
+        ts, iteration, exit_code, elapsed = m.groups()
+        if exit_code is None:
+            last_start = {"timestamp": ts, "iteration": int(iteration)}
+        else:
+            last_end = {
+                "timestamp": ts,
+                "iteration": int(iteration),
+                "exit_code": int(exit_code),
+                "elapsed_seconds": int(elapsed),
+            }
+    return {"last_start": last_start, "last_end": last_end}
+
+
+AUTOPILOT_NAMESPACE = "autopilot"
+
+
+def collect_autopilot_health():
+    result = {}
+
+    try:
+        dep = k8s_get(
+            "/apis/apps/v1/namespaces/{}/deployments/autopilot".format(AUTOPILOT_NAMESPACE)
+        )
+        status = dep.get("status", {})
+        result["deployment"] = {
+            "replicas": status.get("replicas", 0),
+            "readyReplicas": status.get("readyReplicas", 0),
+            "unavailableReplicas": status.get("unavailableReplicas", 0),
+        }
+    except Exception as e:  # noqa: BLE001
+        result["deployment"] = {"error": "{}: {}".format(type(e).__name__, e)}
+
+    pod_name = None
+    try:
+        pods = k8s_get(
+            "/api/v1/namespaces/{}/pods?labelSelector=app%3Dautopilot".format(
+                AUTOPILOT_NAMESPACE
+            )
+        )
+        items = pods.get("items", [])
+        pod_list = []
+        for item in items:
+            meta = item.get("metadata", {})
+            pstatus = item.get("status", {})
+            cs = (pstatus.get("containerStatuses") or [{}])[0]
+            pod_list.append(
+                {
+                    "name": meta.get("name"),
+                    "phase": pstatus.get("phase"),
+                    "restartCount": cs.get("restartCount"),
+                }
+            )
+        result["pods"] = pod_list
+        running = [i for i in items if i.get("status", {}).get("phase") == "Running"]
+        pick = running[0] if running else (items[0] if items else None)
+        if pick:
+            pod_name = pick.get("metadata", {}).get("name")
+    except Exception as e:  # noqa: BLE001
+        result["pods"] = {"error": "{}: {}".format(type(e).__name__, e)}
+
+    if pod_name:
+        try:
+            raw = k8s_get_text(
+                "/api/v1/namespaces/{}/pods/{}/log?tailLines=200".format(
+                    AUTOPILOT_NAMESPACE, pod_name
+                )
+            )
+            result["heartbeat"] = parse_heartbeat(raw)
+        except Exception as e:  # noqa: BLE001
+            result["heartbeat"] = {"error": "{}: {}".format(type(e).__name__, e)}
+    else:
+        result["heartbeat"] = {"error": "app=autopilot の pod が見つからない"}
+
+    return result
+
+
 def github_request(method, path, token, body=None):
     url = "https://api.github.com" + path
     data = json.dumps(body).encode() if body is not None else None
@@ -302,6 +406,7 @@ def main():
         "pod_metrics": collect(collect_pod_metrics),
         "node_metrics": collect(collect_node_metrics),
         "pvc_usage": collect(collect_pvc_usage),
+        "autopilot": collect(collect_autopilot_health),
         "notes": (
             "コンテナ/ノードの実メモリ・CPU 使用量は metrics-server (metrics.k8s.io) から取得 "
             "(pod_metrics/node_metrics)。PVC の実ディスク使用量は namespace ごとの pvc-usage-reporter "
@@ -313,6 +418,10 @@ def main():
             "監視用に計算する値であり、ルートファイルシステムの全体サイズとは別物（node01 の root "
             "ファイルシステムは実際には約252GiBあるが、この値は約48.9GiBしか出ない）。ディスク容量の "
             "確認にこの値を使わないこと（T-0079, issue #56 2026-08-05 15:45:04 参照）。"
+            " autopilot キーは autopilot 自身（namespace autopilot）の健全性。"
+            "heartbeat.last_end が無い/古い、または exit_code が非 0 なら前回のイテレーションが"
+            "異常終了またはハング中の疑い（T-0110）。pods/log は autopilot namespace に閉じた"
+            "Role でのみ許可し、心拍行だけを正規表現で抽出している。生ログはここに含まれない。"
         ),
     }
 

--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -57,6 +57,16 @@ PVC 実使用量・コンテナ/ノードの実メモリ・CPU 使用量は `pvc
 `ops/health/history/YYYY-MM-DD.jsonl`（1行1回分、T-0083）を辿る。値の妥当性は単点観測では判断できない
 （issue #56, 2026-08-05 07:25:18 の指摘。アイドル時の数字だけで memory limits 等を決めない）。
 
+**起動直後に「前回の自分は正常に終わったか」も同じ `latest.json` の `autopilot` キーで確認する**（T-0110）。
+常駐化（§5.5）以降、autopilot は自分自身が CrashLoopBackOff や、クラッシュせずにハングしているだけの
+静かな失敗に陥っても自分では気づけない。`autopilot.deployment.readyReplicas` が 1 未満、
+`autopilot.heartbeat.last_end.exit_code` が非 0、または `last_start`（実行中のイテレーション開始）から
+`ITERATION_TIMEOUT_SECONDS`（現行 3600s）を大きく超えて `last_end` が来ていなければ、直前の起動が
+異常終了またはハング中の疑いがある。異常が見えたら新規タスクより先に原因を調べる（§9 と同じ扱い）。
+`heartbeat` は loop.sh の `[autopilot] <timestamp> iteration #N start/end exit=... elapsed=...` 行を
+`ops-health-reporter` が正規表現で抜き出したものだけで、生ログそのものはここに含まれない
+（pods/log の読み取り権限は autopilot namespace に閉じた Role のみ、他 namespace には及ばない）。
+
 **バックアップ CronJob 自身が「取れているはず」と主張しているだけでは足りない**（issue #56,
 2026-08-05 12:35:47 の指摘。T-0068 は immich 内蔵の日次 DB ダンプが `UPLOAD_LOCATION/backups/`
 に落ちている前提だったが、これはソースコードで確認しただけで実機で見ていなかった。前提が崩れて

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2052,7 +2052,7 @@
       "title": "ops-health-reporter に autopilot 自身（namespace autopilot）の健全性を追加する",
       "kind": "feature",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 15,
       "why": "常駐化（run #57、CHARTER §5.5）で autopilot は自分自身が CrashLoopBackOff やハングに陥っても報告できない。ops-health-reporter は他コンポーネントの sync/health を見ているが autopilot 自身は対象外。人間から具体的な提案があった（issue #56, 2026-08-05T18:34:45Z）: 'crash より静かな失敗のほうが厄介'。",
       "dod": "ops-health-reporter（apps/ops-health-reporter/）が ops/health/latest.json に次を含める: (1) autopilot namespace の Deployment の readyReplicas/restartCount、(2) 直近イテレーションの終了コード・終了時刻（可能なら Pod ログから `iteration #N end exit=` を拾う。ops-health-reporter 自身の RBAC で pods/log が読めるか要確認、読めなければ代替指標を検討する）、(3) 最後にイテレーションが完了してからの経過時間。CHARTER §2 に、次の起動が起動直後にこれを見て『前回の自分は正常に終わったか』を確認する手順を追記する。ダッシュボードにも表示する。",
@@ -2065,7 +2065,7 @@
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "ops-health-reporter の ServiceAccount の権限（pods/log を含むか）を実装前に確認する必要がある。含まないなら CHARTER §5.5 と同様にログ以外の指標（Deployment restartCount, 最終 successfulJob 的なもの）で代替する。"
+      "notes": "ops-health-reporter の ServiceAccount の権限（pods/log を含むか）を実装前に確認する必要がある。含まないなら CHARTER §5.5 と同様にログ以外の指標（Deployment restartCount, 最終 successfulJob 的なもの）で代替する。 | run #60: 実装した。report.py に collect_autopilot_health() を追加し、ops/health/latest.json の autopilot キーに (1) Deployment の readyReplicas/replicas/unavailableReplicas、(2) namespace autopilot の pod restartCount/phase、(3) 直近イテレーションの心拍（loop.sh の \"iteration #N start/end exit=... elapsed=...\" 行を正規表現で抽出、生ログは含めない）を追加した。pods/log の読み取りは ops-health-reporter-reader のような cluster-wide ClusterRole ではなく、autopilot namespace に閉じた新規 Role/RoleBinding のみに絞った（他 namespace のログを読む経路を新設しないため）。CHARTER §2 に、次の起動がこの autopilot キーで前回の自分の終了状態を確認する手順を追記した。ダッシュボード (render_autopilot_self) にも反映した。ops-health-reporter Application の destination.namespace（ops-health-reporter）と異なる namespace（autopilot）へ namespaced resource を作る構成のため、既定の AppProject（default、customize無し）の permissive destinations に依存している——次回起動で Application の sync/health を kubectl で確認すること。"
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2064,7 +2064,7 @@
         "ops/dashboard/build.py"
       ],
       "created": "2026-08-06",
-      "pr": null,
+      "pr": 227,
       "notes": "ops-health-reporter の ServiceAccount の権限（pods/log を含むか）を実装前に確認する必要がある。含まないなら CHARTER §5.5 と同様にログ以外の指標（Deployment restartCount, 最終 successfulJob 的なもの）で代替する。 | run #60: 実装した。report.py に collect_autopilot_health() を追加し、ops/health/latest.json の autopilot キーに (1) Deployment の readyReplicas/replicas/unavailableReplicas、(2) namespace autopilot の pod restartCount/phase、(3) 直近イテレーションの心拍（loop.sh の \"iteration #N start/end exit=... elapsed=...\" 行を正規表現で抽出、生ログは含めない）を追加した。pods/log の読み取りは ops-health-reporter-reader のような cluster-wide ClusterRole ではなく、autopilot namespace に閉じた新規 Role/RoleBinding のみに絞った（他 namespace のログを読む経路を新設しないため）。CHARTER §2 に、次の起動がこの autopilot キーで前回の自分の終了状態を確認する手順を追記した。ダッシュボード (render_autopilot_self) にも反映した。ops-health-reporter Application の destination.namespace（ops-health-reporter）と異なる namespace（autopilot）へ namespaced resource を作る構成のため、既定の AppProject（default、customize無し）の permissive destinations に依存している——次回起動で Application の sync/health を kubectl で確認すること。"
     }
   ]

--- a/ops/dashboard/build.py
+++ b/ops/dashboard/build.py
@@ -353,7 +353,52 @@ def render_health(h):
     return (f'<p class="hl__apps">'
             f'{chip(f"アプリ {len(apps) - len(bad)}/{len(apps)} 正常", "ok" if not bad else "crit")}'
             f'<span class="hl__at">{E(rel_time(h.get("generated_at")))}の状態</span></p>'
-            f"{node_html}{issue_html}")
+            f"{render_autopilot_self(h)}{node_html}{issue_html}")
+
+
+def render_autopilot_self(h):
+    """T-0110: autopilot 自身（namespace autopilot）が report.py の autopilot キーで返す
+    readyReplicas とハートビート（loop.sh の心拍ログ）から、静かなハング/異常終了を示す。"""
+    ap = (h or {}).get("autopilot") or {}
+    if not ap or "error" in ap:
+        return ""
+    dep = ap.get("deployment") or {}
+    hb = ap.get("heartbeat") or {}
+    last_start, last_end = hb.get("last_start"), hb.get("last_end")
+
+    tone, msgs = "ok", []
+    if (dep.get("readyReplicas") or 0) < 1:
+        tone = "crit"
+        msgs.append("readyReplicas 0")
+
+    running = last_start and (not last_end or last_start["iteration"] > last_end["iteration"])
+    if running:
+        started = last_start["timestamp"]
+        try:
+            elapsed = int(
+                (datetime.now(timezone.utc)
+                 - datetime.fromisoformat(started.replace("Z", "+00:00"))).total_seconds()
+            )
+        except ValueError:
+            elapsed = None
+        if elapsed is not None and elapsed > 3700:
+            tone = "crit"
+            msgs.append(f"iteration #{last_start['iteration']} が {elapsed // 60} 分実行中"
+                        " (timeout 3600s 超、ハングの疑い)")
+        else:
+            msgs.append(f"iteration #{last_start['iteration']} 実行中（開始 {rel_time(started)}）")
+    elif last_end:
+        if last_end.get("exit_code") not in (0, None):
+            tone = "crit" if tone != "crit" else tone
+            msgs.append(f"iteration #{last_end['iteration']} exit={last_end['exit_code']}"
+                        f"（{rel_time(last_end['timestamp'])}）")
+        else:
+            msgs.append(f"iteration #{last_end['iteration']} 正常終了（{rel_time(last_end['timestamp'])}）")
+    else:
+        tone = "warn" if tone == "ok" else tone
+        msgs.append("心拍ログがまだ無い")
+
+    return f'<p class="hl__apps">{chip("autopilot " + " / ".join(msgs), tone)}</p>'
 
 
 def render_gantt(tasks, merged, runs):

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,19 +1,13 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 226,
       "title": "chore(backup): restic backup 検証用 Job 3つを削除する (T-0104)",
       "url": "https://github.com/hikuohiku/homelab/pull/226",
-      "isDraft": false,
-      "createdAt": "2026-08-05T18:57:41Z",
-      "statusCheckRollup": [
-        {"conclusion": "PENDING"}
-      ],
-      "headRefName": "autopilot/T-0104-remove-verify-jobs",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-05T19:04:40Z",
+      "headRefName": "autopilot/T-0104-remove-verify-jobs"
+    },
     {
       "number": 225,
       "title": "fix(vaultwarden): restic verify Job の ArgoCD 再作成が失敗していたのを修正 (T-0108)",
@@ -426,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/159",
       "mergedAt": "2026-08-05T05:56:52Z",
       "headRefName": "autopilot/recover-charter-cooldown-rule"
-    },
-    {
-      "number": 158,
-      "title": "T-0015/T-0075: ops-health-reporter の動作確認、run #30 のラップアップ",
-      "url": "https://github.com/hikuohiku/homelab/pull/158",
-      "mergedAt": "2026-08-05T05:39:41Z",
-      "headRefName": "autopilot/T-0075-health-reporter-confirmed"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,5 +1,20 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 227,
+      "title": "feat(ops-health-reporter): autopilot 自身の健全性を latest.json に追加する (T-0110)",
+      "url": "https://github.com/hikuohiku/homelab/pull/227",
+      "isDraft": false,
+      "createdAt": "2026-08-05T19:20:00Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "PENDING"
+        }
+      ],
+      "headRefName": "autopilot/T-0110-autopilot-self-health",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
     {
       "number": 226,

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1787,3 +1787,37 @@
 - 次の起動へ: T-0071（restic 復元試験、priority 41）に着手できる状態。人間の方針
   （『試したことのないバックアップは、バックアップではありません』）に沿って優先度を上げて
   次に選ぶ価値がある。T-0110（autopilot 自身の健全性監視）は引き続き着手前の todo
+
+## 2026-08-06 04:12 JST — run #61
+
+- 前回の中断確認: PR #226（T-0104, restic backup verify Job 3つの削除）が open のまま
+  残っていた。CI の manifest deletion guard が failure だった原因は、PR 本文の
+  `allow-delete:` 3行がバックティックで囲まれていて `ops/check_manifest_deletions.py` の
+  行頭一致の正規表現に一致していなかったこと。PR 本文を修正（バックティックを外す）→
+  close/reopen で `pull_request.body` を新しいイベントとして再送 → CI green → merge。
+  ブランチは GitHub 側で自動削除された（削除確認済み）
+- 読んだフィードバック: PR #226 merge 後の `last_read`（18:47:54Z）で最新コメントまで
+  既に既読。18:47:54 のコメントは run #59 自身が自分の行動を記録した返信で、新規の
+  人間フィードバックは無かった
+- homelab の健全性（ops-health-report ブランチ、generated_at 19:00:04Z）: ArgoCD
+  Application 全件 Synced/Healthy、pod_issues は再起動回数が均一（19回、既存の傾向で
+  新規異常ではない）、immich の backup_listing も直近24時間以内の mtime を確認
+- やったこと: T-0110（priority 15）に着手。ops-health-reporter の report.py に
+  collect_autopilot_health() を追加し、`ops/health/latest.json` の `autopilot` キーで
+  (1) namespace autopilot の Deployment readyReplicas/replicas/unavailableReplicas、
+  (2) pod の restartCount/phase、(3) loop.sh の心拍ログ（`iteration #N start/end
+  exit=... elapsed=...`）から抽出した直近の開始/終了イベントを報告するようにした。
+  pods/log の読み取り権限は cluster-wide ではなく autopilot namespace に閉じた新規
+  Role/RoleBinding のみに絞り、生ログではなく正規表現で抽出した構造化値だけを
+  report に載せる（他 namespace のログを読む経路は新設しない）。CHARTER §2 に
+  次の起動が `autopilot` キーで前回の終了状態を確認する手順を追記。ダッシュボード
+  （`render_autopilot_self`）にも反映
+- 残った不確実性: ops-health-reporter Application の destination namespace
+  （ops-health-reporter）と異なる namespace（autopilot）に namespaced resource
+  （Role/RoleBinding）を作る構成のため、カスタム AppProject が無い前提（default
+  project の permissive destinations）に依存している。kustomize/ArgoCD 実機での
+  sync 成功はこのサンドボックスでは検証できていない
+- 次の起動へ: PR merge 後、ops-health-report ブランチの `latest.json` に `autopilot`
+  キーが実際に現れているか、`autopilot` に `error` が出ていないか（RBAC 未反映や
+  Role/RoleBinding が namespace 不一致で sync 失敗していないか）を kubectl + 次回の
+  ops-health-report 断面の両方で確認する。異常なら原因を切り分けて修正 PR を出す

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1811,7 +1811,7 @@
   Role/RoleBinding のみに絞り、生ログではなく正規表現で抽出した構造化値だけを
   report に載せる（他 namespace のログを読む経路は新設しない）。CHARTER §2 に
   次の起動が `autopilot` キーで前回の終了状態を確認する手順を追記。ダッシュボード
-  （`render_autopilot_self`）にも反映
+  （`render_autopilot_self`）にも反映（PR #227）
 - 残った不確実性: ops-health-reporter Application の destination namespace
   （ops-health-reporter）と異なる namespace（autopilot）に namespaced resource
   （Role/RoleBinding）を作る構成のため、カスタム AppProject が無い前提（default

--- a/ops/state.json
+++ b/ops/state.json
@@ -677,7 +677,9 @@
       "kind": "scheduled",
       "by": "in-cluster autopilot",
       "summary": "前回の中断: PR #226（T-0104, restic backup verify Job 3つの削除）が open のまま残っていた。CI の manifest deletion guard 失敗の原因（PR本文のallow-delete行がバックティックで囲まれ正規表現に一致しなかった）を特定し、本文修正→close/reopen→CI green→merge。issue #56 に新規の人間フィードバックなし（last_readは既にPR#226で最新まで進んでいた）。T-0110（autopilot自身の健全性監視、priority 15）に着手し、ops-health-reporterにautopilot namespaceのDeployment/Pod状態と心拍ログ（iteration開始/終了、生ログは含めない）を追加するPRを出した。",
-      "prs": []
+      "prs": [
+        227
+      ]
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T18:56:00Z",
+  "updated": "2026-08-05T19:12:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -670,6 +670,14 @@
       "prs": [
         226
       ]
+    },
+    {
+      "n": 61,
+      "at": "2026-08-05T19:12:00Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "前回の中断: PR #226（T-0104, restic backup verify Job 3つの削除）が open のまま残っていた。CI の manifest deletion guard 失敗の原因（PR本文のallow-delete行がバックティックで囲まれ正規表現に一致しなかった）を特定し、本文修正→close/reopen→CI green→merge。issue #56 に新規の人間フィードバックなし（last_readは既にPR#226で最新まで進んでいた）。T-0110（autopilot自身の健全性監視、priority 15）に着手し、ops-health-reporterにautopilot namespaceのDeployment/Pod状態と心拍ログ（iteration開始/終了、生ログは含めない）を追加するPRを出した。",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

autopilot 自身（namespace `autopilot`）の健全性を `ops-health-reporter` の収集対象に加えた。
常駐化（run #57）以降、autopilot は自分がハングやクラッシュに陥っても自分では気づけなかった
（issue #56, 2026-08-05T18:34:45Z の指摘: 「crash より静かな失敗のほうが厄介」）。

`ops/health/latest.json` に新しい `autopilot` キーを追加:

- `deployment`: namespace `autopilot` の Deployment の `readyReplicas`/`replicas`/`unavailableReplicas`
- `pods`: pod の `restartCount`/`phase`
- `heartbeat`: loop.sh の心拍ログ（`iteration #N start` / `iteration #N end exit=... elapsed=...s`）
  から正規表現で抽出した直近の開始/終了イベント。**生ログそのものは含めない** — マッチしなかった
  行は捨てる

`pods/log` の読み取り権限は、既存の cluster-wide `ClusterRole`（ops-health-reporter-reader）
ではなく、`autopilot` namespace に閉じた新規 `Role`/`RoleBinding` のみに絞った。
vaultwarden/immich/coder 等、他 namespace のログを読む経路は新設していない。

`ops/CHARTER.md` §2 に、次の起動が起動直後にこの `autopilot` キーで「前回の自分は正常に
終わったか」を確認する手順を追記した。`ops/dashboard/build.py`（`render_autopilot_self`）にも
反映し、ダッシュボードの健全性カードに autopilot 自身の状態チップを出す。

## 検証したこと

- `apps/ops-health-reporter/report.py`: `python3 -m py_compile` で構文確認。
  心拍ログの正規表現は `exit=0`/`exit=1`/`exit=124 (timed out after Ns)` の3パターン全てで
  期待どおりに抽出できることをローカルで確認済み
- `apps/ops-health-reporter/rbac.yaml`: PyYAML で5ドキュメント（ServiceAccount / ClusterRole /
  ClusterRoleBinding / Role / RoleBinding）としてパースできることを確認
- `ops/dashboard/build.py`: `render_autopilot_self()` を正常系（正常終了/実行中/ハング/
  readyReplicas 0/心拍なし）・`autopilot` キー欠落（古い health report との後方互換）・
  `error` キーのケースで手元実行し、期待どおりのチップが出ることを確認
- `python3 ops/validate.py` は 0 error（既存の warning のみ、本 PR 起因の新規 warning は
  「T-0110 が done なのに pr が空」という自明なもののみ。merge 後に PR 番号を追記する）
- `kustomize`/`helm` はこのサンドボックスに無いため、実際のレンダリング結果は CI
  （`kustomize build` / `manifest-diff`）に委ねる

**残った不確実性（実機で確認できていない点）**: `ops-health-reporter` Application の
`destination.namespace`（`ops-health-reporter`）と異なる namespace（`autopilot`）に
namespaced resource（Role/RoleBinding）を作る構成のため、カスタム `AppProject` が無い前提
（default project の permissive destinations）に依存している。ArgoCD が実際にこの
Role/RoleBinding を sync できるかは、次回起動で `ops-health-report` ブランチの
`latest.json` に `autopilot` キーが `error` 無しで現れているかを見て確認する
（backlog に確認待ちタスクを起票済み、下記）。

## ロールバック手順

この PR を revert すれば、追加した Role/RoleBinding と収集ロジックが削除される。
DB マイグレーション等の不可逆操作は含まない。RBAC は読み取り専用の追加のみ（`get`/`list`）で、
書き込み系の verb は一切含まないため、revert してもクラスタの状態に不整合は残らない。

## backlog

- T-0110（ops-health-reporter に autopilot 自身の健全性を追加する）→ done
- 確認待ち: `ops-health-report` ブランチの次回断面（30分毎）で `autopilot` キーに
  `error` が出ていないか、`heartbeat.last_end` が実際に埋まっているかを確認する
  （`status: needs-human` ではなく、次回起動が自分の kubectl で確認できるため todo として
  次回起動への引き継ぎに残す）

risk: medium（実インフラの RBAC・CronJob スクリプトに影響するが、読み取り専用の追加のみで
可逆。ロールバック手順明記により CI green で auto-merge 対象）
