### PR TITLE
ops: ダッシュボード PR キャッシュを最新化する

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,13 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 227,
       "title": "feat(ops-health-reporter): autopilot 自身の健全性を latest.json に追加する (T-0110)",
       "url": "https://github.com/hikuohiku/homelab/pull/227",
-      "isDraft": false,
-      "createdAt": "2026-08-05T19:20:00Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "PENDING"
-        }
-      ],
-      "headRefName": "autopilot/T-0110-autopilot-self-health",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-05T19:18:04Z",
+      "headRefName": "autopilot/T-0110-autopilot-self-health"
+    },
     {
       "number": 226,
       "title": "chore(backup): restic backup 検証用 Job 3つを削除する (T-0104)",
@@ -428,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/160",
       "mergedAt": "2026-08-05T06:05:50Z",
       "headRefName": "autopilot/T-0079-node01-disk-discrepancy"
-    },
-    {
-      "number": 159,
-      "title": "ops: 取り残された cooldown/直列化の衝突対策を CHARTER に戻す",
-      "url": "https://github.com/hikuohiku/homelab/pull/159",
-      "mergedAt": "2026-08-05T05:56:52Z",
-      "headRefName": "autopilot/recover-charter-cooldown-rule"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1821,3 +1821,6 @@
   キーが実際に現れているか、`autopilot` に `error` が出ていないか（RBAC 未反映や
   Role/RoleBinding が namespace 不一致で sync 失敗していないか）を kubectl + 次回の
   ops-health-report 断面の両方で確認する。異常なら原因を切り分けて修正 PR を出す
+- PR #227 merge 後、`ops/dashboard/prs.json` キャッシュを最新化し `index.html` を
+  再生成した。Artifact ツールがこの substrate に無いため再公開はできず（既知、
+  CHARTER §7.1 の対応どおり）


### PR DESCRIPTION
## 変更点

repo 内で閉じる記録更新のみ。`ops/dashboard/prs.json`（`gh` が無いこの環境で
`ops/dashboard/build.py` がフォールバックする PR 一覧キャッシュ）が PR #227 を
open のまま保持していたのを、REST API で再取得して最新化した。`index.html` も
再生成した（Git 管理外、CHARTER §7.1）。

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 例外なく完了

## ロールバック手順

この PR を revert すればキャッシュが古い状態に戻るだけで、次回のダッシュボード更新時に
再度最新化されるので実害は無い。データを失う変更ではない。

## backlog

該当タスクなし（運用記録のみ）。

risk: low（repo 内で閉じる変更）
