### PR TITLE
feat(immich): restic 復元試験用の使い捨て Job を追加する (T-0071)

### DIFF
--- a/apps/immich/kustomization.yaml
+++ b/apps/immich/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - pvc-usage-cronjob.yaml
   - restic-external-secret.yaml
   - restic-backup-cronjob.yaml
+  - restic-restore-verify-job.yaml

--- a/apps/immich/restic-restore-verify-job.yaml
+++ b/apps/immich/restic-restore-verify-job.yaml
@@ -1,0 +1,109 @@
+# T-0071: restic バックアップの復元試験（immich 分）。
+#
+# immich-restic-backup CronJob（apps/immich/restic-backup-cronjob.yaml）が B2 に取っている
+# スナップショットを、本番の immich-library PVC には一切触れずに使い捨ての別 PVC へ実際に
+# restic restore し、「データが読めること」を機械的に確認する。人間の新方針
+# （issue #56, 2026-08-05 04:40:59「試したことのないバックアップは、バックアップではありません」）
+# に沿った一度きりの検証。確認が取れ次第、この PVC/Job は削除する PR を出す
+# （immich-restic-backup 側の CronJob は変更しない）。
+#
+# 結果の受け取り方: autopilot の ClusterRole (autopilot-reader) には pods/log 権限が無いため、
+# コンテナの stdout は読めない。代わりに /dev/termination-log に判定用のサマリ行を書き、
+# `kubectl get pod -n immich -l job-name=immich-restic-restore-verify -o json` の
+# status.containerStatuses[].state.terminated.message から読む（get pods は許可されている、
+# ops/CHARTER.md §5.5 の RBAC 一覧参照）。restic/restic イメージは alpine ベース (busybox) で
+# find/od/date が使えることを Dockerfile 確認済み（restic v0.19.1 の docker/Dockerfile,
+# alpine:latest + apk add ca-certificates fuse openssh-client tzdata jq）。
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-restore-verify
+  namespace: immich
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: immich-restic-restore-verify
+  namespace: immich
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 1800
+  template:
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      containers:
+        - name: restic-restore
+          image: restic/restic:0.19.1
+          command:
+            - sh
+            - -c
+            - |
+              set -u
+              START=$(date +%s)
+              restic restore latest --target /mnt/restore
+              RESTORE_RC=$?
+              END=$(date +%s)
+              ELAPSED=$((END - START))
+              FILE_COUNT=$(find /mnt/restore -type f 2>/dev/null | wc -l | tr -d ' ')
+              DUMP=$(find /mnt/restore -path '*/backups/*.sql.gz' 2>/dev/null | sort | tail -1)
+              DUMP_OK=false
+              if [ -n "$DUMP" ]; then
+                MAGIC=$(od -An -tx1 -N2 "$DUMP" 2>/dev/null | tr -d ' ')
+                [ "$MAGIC" = "1f8b" ] && DUMP_OK=true
+              fi
+              MSG="restore_rc=$RESTORE_RC elapsed_seconds=$ELAPSED file_count=$FILE_COUNT db_dump=${DUMP:-none} db_dump_gzip_magic_ok=$DUMP_OK"
+              echo "$MSG"
+              echo "$MSG" > /dev/termination-log
+              if [ "$RESTORE_RC" -ne 0 ] || [ "$FILE_COUNT" -eq 0 ] || [ "$DUMP_OK" != "true" ]; then
+                exit 1
+              fi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          env:
+            - name: RESTIC_B2_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: immich-restic-credentials
+                  key: RESTIC_B2_BUCKET
+            - name: RESTIC_REPOSITORY
+              value: "b2:$(RESTIC_B2_BUCKET):immich"
+            - name: RESTIC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: immich-restic-credentials
+                  key: RESTIC_PASSWORD
+            - name: B2_ACCOUNT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: immich-restic-credentials
+                  key: B2_ACCOUNT_ID
+            - name: B2_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: immich-restic-credentials
+                  key: B2_ACCOUNT_KEY
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+          volumeMounts:
+            - name: restore-target
+              mountPath: /mnt/restore
+      volumes:
+        - name: restore-target
+          persistentVolumeClaim:
+            claimName: immich-restore-verify

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1316,7 +1316,7 @@
       "title": "restic バックアップの復元試験を実施する（本丸）",
       "kind": "investigate",
       "risk": "low",
-      "status": "todo",
+      "status": "in_progress",
       "priority": 41,
       "why": "issue #56 (2026-08-05 04:40:59) の人間の新方針。『試したことのないバックアップは、バックアップではありません』。T-0068〜T-0070 で作った CronJob が実際に復元可能なデータを作れているかを、別 namespace か使い捨て環境に実際に復元して確認する。T-0023/T-0027/T-0029（データを失いうるメジャー更新）はこれが通るまで着手できない（T-0034 dropped に伴い、これらの blocked_by をここに張り替え済み）",
       "dod": "immich / vaultwarden / coder-postgres それぞれについて、restic のバックアップから使い捨て環境（別 namespace 等）に実際に復元し、データが読めることを確認する。**復元にかかった時間を実測して記録する**（PBS 退役判断の材料になる、人間の依頼どおり）。結果を docs/backup.md に記録する",
@@ -1327,7 +1327,7 @@
       ],
       "created": "2026-08-05",
       "pr": null,
-      "notes": " | run #50: issue #56 (12:48:16) の指摘で、immich がまだほとんど使われていない（332MiB）今のうちに復元試験まで通しておくべきと助言された。T-0068〜T-0070 の実装は完了済みのため blocked_by を T-0067 のみに絞った。T-0067 が片付き次第、最優先で着手する。 | run #53: T-0067 done。ただし T-0103（remoteRef タイポ）修正直後のため、まだ一度も backup が成功した実績が無い。T-0104（検証 Job）の結果を待ってから着手する。 | run #57 (2巡目): substrate が in-cluster 常駐に変わったため『write 権限が要るため実行できない可能性』という懸念は解消（T-0104 と同じ Git→ArgoCD 経路で書き込み不要のまま実行できる） | run #60: T-0104 が done になり blocked_by 解消。immich/coder-postgres/vaultwarden 全3コンポーネントで restic backup 成功が確認できたので着手可能な todo に上げる"
+      "notes": " | run #50: issue #56 (12:48:16) の指摘で、immich がまだほとんど使われていない（332MiB）今のうちに復元試験まで通しておくべきと助言された。T-0068〜T-0070 の実装は完了済みのため blocked_by を T-0067 のみに絞った。T-0067 が片付き次第、最優先で着手する。 | run #53: T-0067 done。ただし T-0103（remoteRef タイポ）修正直後のため、まだ一度も backup が成功した実績が無い。T-0104（検証 Job）の結果を待ってから着手する。 | run #57 (2巡目): substrate が in-cluster 常駐に変わったため『write 権限が要るため実行できない可能性』という懸念は解消（T-0104 と同じ Git→ArgoCD 経路で書き込み不要のまま実行できる） | run #60: T-0104 が done になり blocked_by 解消。immich/coder-postgres/vaultwarden 全3コンポーネントで restic backup 成功が確認できたので着手可能な todo に上げる | run #62: 3コンポーネント同時は1PRとして大きいため immich から着手（run #50 の助言どおり、まだ使用量が少ないうち）。apps/immich/restic-restore-verify-job.yaml で使い捨て PVC (immich-restore-verify) + 一度きりの Job を追加、restic restore latest → ファイル数と DB ダンプの gzip マジックバイト確認 → 結果を /dev/termination-log に書く方式にした（autopilot に pods/log 権限が無いため、get pods で読める terminationMessage 経由で結果を受け取る）。次の起動で Job の Complete/Failed と terminationMessage を確認し、成功していれば docs/backup.md に実測時間を記録した上で vaultwarden/coder-postgres も同じ形で続ける。in_progress のまま、3コンポーネント全部終わってから done にする"
     },
     {
       "id": "T-0072",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 228,
+      "title": "ops: ダッシュボード PR キャッシュを最新化する",
+      "url": "https://github.com/hikuohiku/homelab/pull/228",
+      "mergedAt": "2026-08-05T19:20:27Z",
+      "headRefName": "autopilot/ops-dashboard-cache-refresh"
+    },
+    {
       "number": 227,
       "title": "feat(ops-health-reporter): autopilot 自身の健全性を latest.json に追加する (T-0110)",
       "url": "https://github.com/hikuohiku/homelab/pull/227",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/161",
       "mergedAt": "2026-08-05T06:27:26Z",
       "headRefName": "autopilot/T-0077-metrics-collect"
-    },
-    {
-      "number": 160,
-      "title": "ops: node01 実ディスク容量の食い違いを起票、PR作り直し時の規則を追記 (T-0079)",
-      "url": "https://github.com/hikuohiku/homelab/pull/160",
-      "mergedAt": "2026-08-05T06:05:50Z",
-      "headRefName": "autopilot/T-0079-node01-disk-discrepancy"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1824,3 +1824,36 @@
 - PR #227 merge 後、`ops/dashboard/prs.json` キャッシュを最新化し `index.html` を
   再生成した。Artifact ツールがこの substrate に無いため再公開はできず（既知、
   CHARTER §7.1 の対応どおり）
+
+## 2026-08-06 04:28 JST — run #62
+
+- 前回の中断確認: オープン PR 0 件、`autopilot/*` ブランチも無し（クリーンな状態から開始）
+- 読んだフィードバック: issue #56 の `last_read`（2026-08-05T18:47:54Z）と最新コメント
+  （2026-08-05T18:47:54Z、run #61 自身の返信）が一致。新規の人間フィードバック無し
+- T-0110 の効果確認: `kubectl get application ops-health-reporter -n argocd` で
+  operationState.phase=Succeeded（finishedAt 2026-08-05T19:23:03Z）、
+  `Role`/`RoleBinding ops-health-reporter-autopilot-log-reader`（namespace autopilot）が
+  Synced を確認。ops-health-report ブランチの `latest.json`（generated_at 19:00:04Z、
+  この sync より前の断面）にはまだ `autopilot` キーが無いが、sync 自体は成功しているので
+  次回のレポート断面（30分毎、次は19:30 UTC 頃）で確認できる見込み。CronJob の実行を待つ
+  必要があり本人はこの起動では確認しなかった（次の起動で latest.json を再確認する）
+- やったこと: backlog に唯一残っていた todo、T-0071（restic 復元試験、本丸）に着手。
+  DoD は immich/vaultwarden/coder-postgres の3コンポーネントだが、1 PR 1 論点のため
+  immich から着手（run #50 の助言どおり、まだ使用量が少ないうちに）。
+  `apps/immich/restic-restore-verify-job.yaml` に使い捨て PVC（`immich-restore-verify`,
+  5Gi, local-path）と一度きりの Job（`immich-restic-restore-verify`）を追加した。
+  Job は `restic restore latest --target /mnt/restore` を実行し、復元されたファイル数と
+  `backups/*.sql.gz`（immich 内蔵DBダンプ）の gzip マジックバイトを確認、経過秒数と結果を
+  `/dev/termination-log` に書く。autopilot の ClusterRole には pods/log 権限が無いため、
+  stdout ではなく `kubectl get pod ... -o json` の
+  `status.containerStatuses[].state.terminated.message`（get pods は許可済み）経由で
+  結果を読む設計にした。本番の `immich-library` PVC には一切書き込まない。risk は medium
+  （新規 PVC/Job の作成で実インフラに影響するが、revert すれば ArgoCD が prune して消える。
+  データ喪失や到達性への影響は無い）
+- 次の起動へ: PR merge → ArgoCD sync 後、`kubectl get job -n immich
+  immich-restic-restore-verify` で Complete/Failed を確認し、対応する Pod の
+  terminationMessage を読む。成功なら elapsed_seconds を docs/backup.md に記録し、
+  同じパターンで vaultwarden・coder-postgres 分の restore-verify Job を追加する PR を
+  続けて出す（T-0071 は in_progress のまま、3コンポーネント揃うまで done にしない）。
+  失敗した場合は原因を切り分ける（credential/repository 未初期化等）。検証が終わったら
+  immich-restore-verify PVC/Job を削除する PR も忘れずに出す


### PR DESCRIPTION
## 変更点

`ops/backlog.json` T-0071（restic バックアップの復元試験、人間の新方針「試したことのないバックアップは、バックアップではありません」への対応）の immich 分。

- `apps/immich/restic-restore-verify-job.yaml` を追加
  - 使い捨て PVC `immich-restore-verify`（5Gi, local-path）
  - 一度きりの Job `immich-restic-restore-verify`: `restic restore latest --target /mnt/restore` を実行し、復元されたファイル数と内蔵 DB ダンプ（`backups/*.sql.gz`）の gzip マジックバイトを確認する
  - 結果（`restore_rc` / `elapsed_seconds` / `file_count` / `db_dump` / `db_dump_gzip_magic_ok`）は `/dev/termination-log` に書く。autopilot の ClusterRole には pods/log 権限が無いため、`kubectl get pod -n immich -l job-name=immich-restic-restore-verify -o json` の `status.containerStatuses[].state.terminated.message` から読む設計
  - **本番の `immich-library` PVC には一切書き込まない**（読み取りもしない。restore 先は新規の別 PVC のみ）
- `ops/backlog.json`: T-0071 を `in_progress` にし、進捗を notes に追記（3コンポーネントのうち immich から着手、次に vaultwarden/coder-postgres と続ける）
- `ops/journal/2026-08.md`, `ops/dashboard/prs.json`: 定例の記録更新

## 検証したこと

- 手元で YAML パース（`python3 -c "import yaml; ..."`）が通ることを確認（`kustomize` がこの実行環境に無いため、レンダリング自体は CI (`kustomize build`) に委ねる）
- restic 公式イメージ（`restic/restic:0.19.1`）の Dockerfile を確認し、alpine ベース + busybox で `find`/`od`/`date`/`gzip` が使えることを確認済み
- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 例外なく `index.html` を再生成

## ロールバック手順

このブランチを revert すれば `apps/immich/restic-restore-verify-job.yaml` と kustomization への参照が消え、ArgoCD が次回 sync で `immich-restore-verify` PVC と Job を prune する。**本番の `immich-library` / `immich-postgres-data` には一切触れていないため、revert してもデータ不整合は残らない**（このタスク自体が新規の使い捨てリソースの追加のみで、既存リソースの変更を含まない）。

## backlog task id

T-0071（in_progress のまま。immich 分の効果確認後、vaultwarden/coder-postgres も同じ形で追加し、3コンポーネント揃ってから done にする）
