### PR TITLE
chore(ops): run #64 の記録更新（journal/state/CHARTER/prs cache）

### DIFF
--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -331,6 +331,14 @@ Application は読めない**）、restic/B2 の直接操作、node01 のファ�
   意図的にオブジェクトを消す PR では本文に `allow-delete: <Kind>/<namespace>/<name>` を明記する。
   **この検証は「データを失いうる変更」の判断材料の 1 つであって、バックアップの健全性確認の代わりにはならない**
   （T-0029/T-0023 のように DB のメジャー更新でスキーマが壊れるケースは render の差分には出ない）
+  - **`allow-delete:` 行は Markdown 装飾（バッククォート等）で囲まない。** `ops/check_manifest_deletions.py`
+    の正規表現は `^allow-delete:` を行頭一致で要求しており、` `` allow-delete: ... `` ` のように
+    バッククォートで囲むと一致せず CI が fail-closed で落ちる（issue #56 は関与せず、T-0071/#234 で
+    自分のミスとして発見・修正した実例）。地の文としてそのまま書く
+  - **PR 本文だけ直しても CI は自動で再実行されない。** `ci.yml` の `on: pull_request` は `types` を
+    指定していないため既定の `opened`/`synchronize`/`reopened` のみが対象で、`edited`（本文の PATCH）は
+    含まれない。本文の `allow-delete` 誤記を直した後は `git commit --allow-empty` 等で新しい commit を
+    push し `synchronize` を発火させないと、古い本文のまま実行された失敗結果が残り続ける
 - **「評価が通る」と「上げてよい」は別。pin を上げるときは、その pin が間接的に何を決めているかまで辿る。**
   issue #56（2026-08-05 04:24:40）の指摘。T-0049（`nix flake update` による `flake.lock` 更新、#146）は
   `nix flake check` が green だったが、`configuration.nix` が `services.k3s` のバージョンを pin していない

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,41 @@
   "open": [],
   "merged": [
     {
+      "number": 234,
+      "title": "docs(backup): immich の restic 復元試験の成功を記録し、検証用リソースを削除する (T-0071)",
+      "url": "https://github.com/hikuohiku/homelab/pull/234",
+      "mergedAt": "2026-08-05T20:15:43Z",
+      "headRefName": "autopilot/T-0071-immich-restore-cleanup"
+    },
+    {
+      "number": 233,
+      "title": "fix(immich): restic restore-verify Job に CAP_DAC_OVERRIDE を足し、target を毎回クリーンアップする (T-0071)",
+      "url": "https://github.com/hikuohiku/homelab/pull/233",
+      "mergedAt": "2026-08-05T20:05:10Z",
+      "headRefName": "autopilot/T-0071-immich-restore-cap-simplify"
+    },
+    {
+      "number": 232,
+      "title": "fix(immich): restic restore-verify Job に CAP_FOWNER も足してタイムスタンプ復元エラーを解消する (T-0071)",
+      "url": "https://github.com/hikuohiku/homelab/pull/232",
+      "mergedAt": "2026-08-05T19:58:40Z",
+      "headRefName": "autopilot/T-0071-immich-restore-fowner-fix"
+    },
+    {
+      "number": 231,
+      "title": "fix(immich): restic restore-verify Job に CAP_CHOWN を足して所有者復元エラーを解消する (T-0071)",
+      "url": "https://github.com/hikuohiku/homelab/pull/231",
+      "mergedAt": "2026-08-05T19:50:17Z",
+      "headRefName": "autopilot/T-0071-immich-restore-chown-fix"
+    },
+    {
+      "number": 230,
+      "title": "fix(immich): restic restore-verify Job に diagnostic 出力を追加する (T-0071)",
+      "url": "https://github.com/hikuohiku/homelab/pull/230",
+      "mergedAt": "2026-08-05T19:42:03Z",
+      "headRefName": "autopilot/T-0071-immich-restore-diagnose"
+    },
+    {
       "number": 229,
       "title": "feat(immich): restic 復元試験用の使い捨て Job を追加する (T-0071)",
       "url": "https://github.com/hikuohiku/homelab/pull/229",
@@ -385,41 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/167",
       "mergedAt": "2026-08-05T07:26:09Z",
       "headRefName": "autopilot/T-0082-pvc-usage-reporter-image-inventory"
-    },
-    {
-      "number": 166,
-      "title": "ci: pvc-usage-reporter の埋め込みスクリプト3ファイルの一致を検証する (T-0081)",
-      "url": "https://github.com/hikuohiku/homelab/pull/166",
-      "mergedAt": "2026-08-05T07:09:53Z",
-      "headRefName": "autopilot/T-0081-pvc-usage-script-sync"
-    },
-    {
-      "number": 165,
-      "title": "run #35: T-0080 完遂の記録更新",
-      "url": "https://github.com/hikuohiku/homelab/pull/165",
-      "mergedAt": "2026-08-05T07:03:37Z",
-      "headRefName": "autopilot/T-0080-records-2"
-    },
-    {
-      "number": 163,
-      "title": "PVC の実使用量を計測する namespace 別 CronJob を追加 (T-0080)",
-      "url": "https://github.com/hikuohiku/homelab/pull/163",
-      "mergedAt": "2026-08-05T06:59:02Z",
-      "headRefName": "autopilot/T-0080-pvc-usage"
-    },
-    {
-      "number": 164,
-      "title": "run #34: T-0080 の並行セッション調整反映、記録更新",
-      "url": "https://github.com/hikuohiku/homelab/pull/164",
-      "mergedAt": "2026-08-05T06:37:26Z",
-      "headRefName": "autopilot/T-0080-records"
-    },
-    {
-      "number": 162,
-      "title": "ops: T-0080 に fsGroup 再帰 chown リスクを追記 (run #33)",
-      "url": "https://github.com/hikuohiku/homelab/pull/162",
-      "mergedAt": "2026-08-05T06:33:03Z",
-      "headRefName": "autopilot/T-0080-fsgroup-risk-note"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -1890,21 +1890,44 @@
   （T-0071, restic 出力を診断用に追加）が main に merge 済みであることを確認
 - 読んだフィードバック: issue #56 のコメントは 102 件（`per_page=100` で2ページとも確認）。
   最新は `last_read`（2026-08-05T18:47:54Z）と一致。未読なし
-- homelab の健全性: `ops-health-report` ブランチは未確認（次の起動で見る）。kubectl で
-  immich-restic-restore-verify Job を直接確認した（PR #230 merge・ArgoCD Force sync 後、
-  Job は既に再実行され Failed 状態だった）
-- やったこと: `restore_output_tail` を読んだところ原因判明。securityContext が
-  `capabilities.drop: ["ALL"]` のため、コンテナが root で動いていても CAP_CHOWN が無く、
-  restic がバックアップ時点のファイル所有者へ `lchown` できず大量に "operation not permitted"
-  になり、restic 自身が `Fatal: There were 158 errors` で exit 1 していた（データ内容自体は
-  file_count=82・db_dump_gzip_magic_ok=true で正しく復元できていた）。
-  `apps/immich/restic-restore-verify-job.yaml` の restore コンテナに
-  `capabilities.add: ["CHOWN"]` を足す PR を出した（T-0071、`drop: ["ALL"]` は維持し
-  必要な capability だけ足し戻す形。risk は low、この使い捨て Job のみが対象で本番の
-  immich Pod・他コンポーネントの securityContext には影響しない）
-- 次の起動へ: PR merge → ArgoCD sync（Force=true での delete→create）後、
-  `kubectl get job/pod -n immich immich-restic-restore-verify` で `restore_rc=0` になるか
-  確認する。0 になれば `elapsed_seconds` を `docs/backup.md` に記録し、同じパターンで
-  vaultwarden・coder-postgres の restore-verify Job を追加する PR を続けて出す
-  （T-0071 は in_progress のまま、3コンポーネント揃うまで done にしない）。まだ `restore_rc=1`
-  なら `restore_output_tail` を再度読んで別原因を切り分ける
+- homelab の健全性: `ops-health-report` ブランチ（generated_at 2026-08-05T19:30:04Z）で確認。
+  Application 11 件全て Synced/Healthy、pod_issues は常連の再起動カウントのみで新規異常なし、
+  autopilot 自身の heartbeat も `exit_code=0` で正常。immich の `backup_listing` も直近まで
+  ファイルが存在し健全
+- やったこと: T-0071（immich の restic 復元試験）を、CI green→merge→ArgoCD sync→Job 再実行の
+  サイクルを4周回して完遂した。
+  1. `restore_output_tail` を読み原因判明: `capabilities.drop: ["ALL"]` によりコンテナが
+     root で動いていても `CAP_CHOWN` が無く、restic が backup 時点の所有者へ `lchown`
+     できず exit 1（データ内容自体は file_count=82・DB dump 整合性 OK で正しく復元できていた）。
+     `capabilities.add: ["CHOWN"]` で解消（#231）
+  2. 再実行すると今度は `utime(2)`（タイムスタンプ復元）に `CAP_FOWNER` が必要と判明
+     （`man 7 capabilities` に明記）。`FOWNER` を追加（#232）
+  3. さらに再実行すると `EACCES`（permission denied）の `lchown` 失敗。原因は capability
+     不足ではなく、PVC が Job 再実行間で残ること — 前回実行で一部ディレクトリが実際に
+     backup 側所有者へ chown され、その通常権限ビットが `CAP_DAC_OVERRIDE` の無い root の
+     アクセスを塞いでいた。`DAC_OVERRIDE` を追加し、`restic restore` 前に
+     `rm -rf /mnt/restore/*` でクリーンアップするステップも追加（#233）
+  4. 再実行して成功（`restore_rc=0`, `file_count=82` 一致, `elapsed_seconds=16`,
+     DB dump 整合性 OK）。結果と試行錯誤の教訓を `docs/backup.md` に記録し、検証用の
+     `immich-restore-verify` PVC/Job を削除する PR を出した（#234）
+  - **副産物のハマりどころ**: #234 の PR 本文で `allow-delete:` 行をコードスタイルの
+    つもりで ` `` ` （バッククォート）で囲んで書いたところ、`manifest deletion guard` の
+    正規表現が `^allow-delete:` を行頭一致で要求しているため一致せず CI が落ちた。
+    PR 本文の PATCH だけでは `pull_request` イベントが再発火しない（`ci.yml` は
+    `types` 未指定＝`opened`/`synchronize`/`reopened` のみで `edited` は対象外）ため、
+    空コミット (`git commit --allow-empty`) を push して再トリガーした。
+    **`allow-delete:` 行は Markdown 装飾（バッククォート等）で囲まない**、
+    PR 本文だけ直しても CI は自動で再実行されないので新しい commit の push が要る、
+    の 2 点を次回のために書き残す
+- T-0071 は immich 分が完了。vaultwarden/coder-postgres 分が残っているため `in_progress` の
+  まま継続（backlog notes に経緯を全て記録済み）
+- ダッシュボード: `ops/dashboard/prs.json` を REST API（open 0件・merged 60件、#231〜#234 反映済み）
+  で最新化し、`python3 ops/validate.py`（0 error）→ `python3 ops/dashboard/build.py` で再生成した。
+  Artifact ツールがこの環境には見当たらず publish できなかった
+- 次の起動へ: vaultwarden・coder-postgres の restore-verify Job を同じ設計（使い捨て PVC + Job、
+  `Replace=true,Force=true` sync、termination message 経由で結果受信）で追加する。immich で
+  判明した 3 capability（`CHOWN`/`FOWNER`/`DAC_OVERRIDE`）+ クリーンアップステップを
+  **初回実装から** 織り込み、同じ試行錯誤を繰り返さないこと。coder-postgres は PVC 直接では
+  なく `pg_restore` 経由の設計（`docs/backup.md` 参照）のため、権限まわりの事情が
+  immich/vaultwarden と異なる可能性がある点に注意。`allow-delete:` を書くときは PR 本文で
+  バッククォート装飾しない

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T19:35:00Z",
+  "updated": "2026-08-05T20:25:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -698,6 +698,19 @@
       "by": "in-cluster autopilot",
       "summary": "immich-restic-restore-verify Job の初回実行結果を確認: restore_rc=1 で Failed だったが file_count=82・db_dump_gzip_magic_ok=true で一見データは正しく復元できていた。原因を切り分けるため、restic restore の出力を termination message に含めるよう修正し、Job.spec.template の immutable 制約に対応する sync-options も追加した。",
       "prs": []
+    },
+    {
+      "n": 64,
+      "at": "2026-08-05T19:48:16Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "T-0071（immich の restic 復元試験）完遂。restore_output_tail の診断から securityContext.capabilities に CHOWN/FOWNER/DAC_OVERRIDE の3段階の権限不足を切り分け、restore前クリーンアップも追加して restore_rc=0（elapsed 16秒, file_count=82一致, DB dump整合性OK）を達成。結果をdocs/backup.mdに記録し検証用リソースを削除。allow-delete行をバッククォートで囲むとCI正規表現に一致しない落とし穴を発見しCHARTERに記録。vaultwarden/coder-postgres分は次回に持ち越し（T-0071はin_progress継続）",
+      "prs": [
+        231,
+        232,
+        233,
+        234
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

run #64（T-0071, immich の restic 復元試験）の記録更新です。運用記録のみで、実インフラへの
変更はありません（CHARTER §4 の相乗り例外扱い、低リスク）。

- `ops/journal/2026-08.md`: run #64 の詳細（4段階の権限デバッグ経緯、allow-delete のハマりどころ）
- `ops/state.json`: `runs` に run #64 のまとめと PR 番号（#231-234）を追加
- `ops/CHARTER.md`: `allow-delete:` 行を Markdown 装飾で囲むと CI の正規表現に一致しないこと、
  PR 本文の PATCH だけでは CI が再実行されないことを記録
- `ops/dashboard/prs.json`: REST API で最新化（open 0件、merged 60件、#231-234 反映済み）

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 例外なく生成成功

## ロールバック手順

このコミットを revert すれば記録ファイルが元に戻ります。実インフラ・DB スキーマには
一切触れていないため、revert しても不整合は残りません。

## backlog task id

T-0071
