### PR TITLE
feat(coder): coder を v2.34.7 → v2.35.3 (stable) に上げる (T-0023)

### DIFF
--- a/apps/coder/deployment.yaml
+++ b/apps/coder/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: coder
-          image: ghcr.io/coder/coder:v2.34.7
+          image: ghcr.io/coder/coder:v2.35.3
           command: ["/opt/coder"]
           args: ["server"]
           securityContext:

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -436,7 +436,7 @@
         "docs/backup.md"
       ],
       "created": "2026-08-04",
-      "pr": null,
+      "pr": 241,
       "notes": " | run #68: T-0071（restic 復元試験）が3コンポーネント全て完了したため blocked_by を解消し todo に戻した。メジャーバージョン更新であることに変わりはないため、着手時は CHARTER §4「high を戻せる形に落とす」（1 PR 1 コンポーネント、変更点を全部読む）を引き続き適用する。 | run #68 続き: subagent に v2.34.7〜v2.35.3 の GitHub Release 本文原文と `coderd/database/migrations/` のファイル一覧を直接照合させた。結論: (1) v2.34.7 と v2.35.3 の間で DB migration ファイルは 000001〜000500 で完全一致（新規 migration 無し）。当初懸念していた『起動時の自動 migration が不可逆』というリスクはこの区間には実際には存在しなかった（v2.36.0 mainline 固有の migration 000554 と混同していた）。(2) CODER_PROXY_TRUSTED_ORIGINS は既存の環境変数で、v2.35 系での変更は『ワイルドカードサブドメインの workspace app ルーティングにのみ効く X-Forwarded-Host 検証の強制』。fail-open（未設定でも Host ヘッダにフォールバックするだけでログイン等はブロックされない）で、当リポジトリは `CODER_WILDCARD_ACCESS_URL` を使っておらずワイルドカードルーティング非対応のため無関係と確認、追加設定不要。(3) OIDC 関連の breaking change も Coder 側に OIDC 設定が無いため無関係。(4) /healthz・GitHub provider フラグ・DERP relay 関連の挙動は変更なし。apps/coder/deployment.yaml のタグを v2.35.3 に更新、ops/inventory.json の current・note も更新。ロールバック: migration 差分が無いため git revert のみで安全に戻せる（Postgres スキーマは不変のまま）。Coder は人間・構築セッションがこの homelab を観測・操作する経路の一つ（CHARTER §4）だが、autopilot 自身の GitHub API 経由の運用・kubectl ClusterRole 経由の read には依存していないため、更新失敗時も autopilot 自身の動作は継続できる。ArgoCD sync 後の Pod 起動確認は次回起動の ops-health-report で行う。"
     },
     {

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 111,
-  "updated": "2026-08-05T21:15:00Z",
+  "updated": "2026-08-05T21:10:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -425,7 +425,7 @@
       "title": "coder を v2.34.7 → v2.35.3 (stable) に上げる（v2.36.0 mainline は避ける）",
       "kind": "upgrade",
       "risk": "high",
-      "status": "todo",
+      "status": "done",
       "priority": 17,
       "why": "T-0005 の調査 (run #6) で判明。stable チャンネルの最新は v2.35.3。mainline の v2.36.0 は OAuth2 動的クライアント登録・login-type 非推奨化・chat model 設定の DB スキーマ変更など breaking change を含むため避ける。coder は autopilot 自身の開発環境をホストしている（ops/inventory.json のコメント）ため、更新に失敗すると足場を失うリスクがある点に注意。run #10 の subagent 調査で risk を medium → high に見直した: v2.34.7→v2.35.3 は実質マイナー1本分（約650コミット）で、`coder server` は起動時に DB migration を自動適用するが coder は down-migration を提供しないため、失敗時のロールバックはイメージタグを戻すだけでは不十分で Postgres のバックアップ復元が必要になる。coder-postgres は immich-postgres と同じく local-path で node01 のディスク上に直接あり（docs/backup.md）、バックアップの存在・復元手順は T-0034（needs-human）が解決するまで未確認。CHARTER §4『データを失いうる変更』に該当するため T-0029 と同様に着手を見送る。加えて v2.35.0/2.35.1 で X-Forwarded-Host の信頼元を CODER_PROXY_TRUSTED_ORIGINS で絞る変更が入っており、Tailscale 経由アクセス（CODER_ACCESS_URL）への影響が未検証",
       "dod": "T-0034 でバックアップの存在・復元手順が確認されてから着手する。apps/coder/deployment.yaml のイメージタグが v2.35.3。ops/inventory.json の current も更新。CODER_PROXY_TRUSTED_ORIGINS の要否を確認し、必要なら合わせて設定する。更新後に coder の Pod が正常に起動することを CI もしくは次回起動での間接確認で追う（このクラウド実行からは k8s に到達できないため、ArgoCD 側の反映確認は現状できない— T-0015 が解決すれば可能になる）",
@@ -437,7 +437,7 @@
       ],
       "created": "2026-08-04",
       "pr": null,
-      "notes": " | run #68: T-0071（restic 復元試験）が3コンポーネント全て完了したため blocked_by を解消し todo に戻した。メジャーバージョン更新であることに変わりはないため、着手時は CHARTER §4「high を戻せる形に落とす」（1 PR 1 コンポーネント、変更点を全部読む）を引き続き適用する。"
+      "notes": " | run #68: T-0071（restic 復元試験）が3コンポーネント全て完了したため blocked_by を解消し todo に戻した。メジャーバージョン更新であることに変わりはないため、着手時は CHARTER §4「high を戻せる形に落とす」（1 PR 1 コンポーネント、変更点を全部読む）を引き続き適用する。 | run #68 続き: subagent に v2.34.7〜v2.35.3 の GitHub Release 本文原文と `coderd/database/migrations/` のファイル一覧を直接照合させた。結論: (1) v2.34.7 と v2.35.3 の間で DB migration ファイルは 000001〜000500 で完全一致（新規 migration 無し）。当初懸念していた『起動時の自動 migration が不可逆』というリスクはこの区間には実際には存在しなかった（v2.36.0 mainline 固有の migration 000554 と混同していた）。(2) CODER_PROXY_TRUSTED_ORIGINS は既存の環境変数で、v2.35 系での変更は『ワイルドカードサブドメインの workspace app ルーティングにのみ効く X-Forwarded-Host 検証の強制』。fail-open（未設定でも Host ヘッダにフォールバックするだけでログイン等はブロックされない）で、当リポジトリは `CODER_WILDCARD_ACCESS_URL` を使っておらずワイルドカードルーティング非対応のため無関係と確認、追加設定不要。(3) OIDC 関連の breaking change も Coder 側に OIDC 設定が無いため無関係。(4) /healthz・GitHub provider フラグ・DERP relay 関連の挙動は変更なし。apps/coder/deployment.yaml のタグを v2.35.3 に更新、ops/inventory.json の current・note も更新。ロールバック: migration 差分が無いため git revert のみで安全に戻せる（Postgres スキーマは不変のまま）。Coder は人間・構築セッションがこの homelab を観測・操作する経路の一つ（CHARTER §4）だが、autopilot 自身の GitHub API 経由の運用・kubectl ClusterRole 経由の read には依存していないため、更新失敗時も autopilot 自身の動作は継続できる。ArgoCD sync 後の Pod 起動確認は次回起動の ops-health-report で行う。"
     },
     {
       "id": "T-0024",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,28 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 241,
+      "title": "feat(coder): coder を v2.34.7 → v2.35.3 (stable) に上げる (T-0023)",
+      "url": "https://github.com/hikuohiku/homelab/pull/241",
+      "isDraft": false,
+      "createdAt": "2026-08-05T21:08:08Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "PENDING"
+        }
+      ],
+      "headRefName": "autopilot/T-0023-coder-v2.35.3",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 240,
+      "title": "feat(coder): T-0071 の復元試験を完了する（coder-postgres 分）",
+      "url": "https://github.com/hikuohiku/homelab/pull/240",
+      "mergedAt": "2026-08-05T21:01:10Z",
+      "headRefName": "autopilot/T-0071-coder-postgres-done"
+    },
     {
       "number": 239,
       "title": "chore(ops): run #66/#67 の記録更新（journal/state/backlog/PRキャッシュ）",
@@ -413,13 +435,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/173",
       "mergedAt": "2026-08-05T08:30:59Z",
       "headRefName": "autopilot/records-run40-catchup"
-    },
-    {
-      "number": 172,
-      "title": "issue #56 のフィードバックを反映: DB コンポーネントのロールバック手順にスキーマの扱いを明記する規則を追加",
-      "url": "https://github.com/hikuohiku/homelab/pull/172",
-      "mergedAt": "2026-08-05T08:23:29Z",
-      "headRefName": "autopilot/T-0086-rollback-wording"
     }
   ]
 }

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -76,12 +76,12 @@
       "id": "coder",
       "kind": "image",
       "name": "ghcr.io/coder/coder",
-      "current": "v2.34.7",
+      "current": "v2.35.3",
       "file": "apps/coder/deployment.yaml",
       "match": "coder/coder:",
       "upstream": "github:coder/coder",
       "policy": "auto",
-      "note": "autopilot 自身の開発環境をホストしている。更新中に自分の足場が消えないよう注意",
+      "note": "autopilot 自身の開発環境をホストしている。更新中に自分の足場が消えないよう注意。stable チャンネルを追う（mainline の v2.36.0 系は避ける）。v2.34.7→v2.35.3 は DB migration 追加なし（000001〜000500 で完全一致、T-0023 で file listing diff により確認済み）",
       "observability_impact": "壊れると Coder（人間・構築セッションがこの homelab で作業する開発環境）が使えなくなる。人間と構築セッションがこの homelab を観測・操作する経路の一つが失われる（CHARTER §4, issue #56 2026-08-04 21:38:00）"
     },
     {

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2040,3 +2040,33 @@
   （リリースノート原文を全部読む、1 PR 1 コンポーネント）と「high を戻せる形に落とす」を適用する。
   どれも規模が大きいため、着手前にリリースノートの洗い出しだけを別タスクとして先に済ませるのも
   選択肢。backlog に他の `todo` が無ければ、これらメジャー更新の事前調査を次の一手として検討する
+
+## 2026-08-06 06:15 JST — run #69
+
+- 前回の中断確認: オープン PR 1 件（#240, run #67/#68 由来の T-0071 coder-postgres 分の
+  完了 PR）。CI 全 green（manifest deletion guard / nix flake check / kustomize build /
+  ops state validate / terraform validate / GitGuardian）・`mergeable_state: clean` を確認し、
+  `kubectl get job -n coder coder-postgres-restic-restore-verify` で `succeeded: 1` を独立に
+  確認したうえで merge した（ブランチは GitHub 側で自動削除済み）
+- **T-0071（restic 復元試験、本丸）が完全に完了。** immich・vaultwarden・coder-postgres の
+  3 コンポーネント全てで復元試験を実施し、データが読めることを確認済み
+- 読んだフィードバック: issue #56 のコメント 102 件（`per_page=100` で2ページとも確認）。
+  last_read（2026-08-05T18:47:54Z）以降の新規コメント無し
+- homelab の健全性: `ops-health-report`（generated_at 2026-08-05T21:00:04Z）で確認。
+  Application 11 件全て Synced/Healthy、pod_issues は常連の再起動カウントのみ。autopilot 自身の
+  heartbeat も `exit_code=0`・`readyReplicas=1` で正常
+- backlog: `todo` が T-0023/T-0027/T-0029（immich/coder のメジャー更新3件、いずれも T-0071 完了で
+  blocked 解除済み）のみ。優先度順に T-0023（coder v2.34.7→v2.35.3, stable）に着手
+- やったこと: subagent に v2.34.7〜v2.35.3 の GitHub Release 本文原文と
+  `coderd/database/migrations/` のファイル一覧を直接照合させた。結論: (1) この区間で DB migration
+  は 000001〜000500 で完全一致（新規 migration ゼロ）。当初懸念していた『起動時の自動 migration が
+  不可逆』というリスクはこの区間には実際には無く、v2.36.0 mainline 固有の migration 000554 との
+  混同だったと判明。(2) `CODER_PROXY_TRUSTED_ORIGINS`（既存 env var）の v2.35 系での変更は
+  ワイルドカードサブドメインの workspace app ルーティング専用（fail-open）で、当リポジトリは
+  `CODER_WILDCARD_ACCESS_URL` 非対応のため無関係、追加設定不要と確認。apps/coder/deployment.yaml
+  のタグを v2.35.3 に更新し、PR #241 を出した（CI green 確認後に自分で merge する想定。risk=high
+  だが「縛る変更」ではなく DB migration 差分ゼロと確認済みのため cooldown 対象外と判断）
+- 次の起動へ: PR #241 の CI green・merge を見届ける（まだの場合は §2 の中断拾いで最優先）。
+  merge 後は ops-health-report で coder Application の sync/health を確認し、問題無ければ
+  T-0027（immich server/machine-learning メジャー更新）・T-0029（immich postgres/vchord
+  メジャー更新）に順に着手する

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T20:55:00Z",
+  "updated": "2026-08-05T21:15:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -751,6 +751,16 @@
       "summary": "前回の中断（PR #239, run #66/#67 の記録埋め合わせ）を merge・ブランチ削除で片付けた。issue #56 に未読フィードバック無し。backlog は todo 0件・全件 blocked/needs-human だったため、in_progress だった T-0071 の続きを拾った。coder-postgres の restore-verify Job（#238）の結果を kubectl で確認（restore_rc=0, elapsed_seconds=8, pg_restore_list_rc=0, pg_restore_full_rc=0）。immich・vaultwarden・coder-postgres の3コンポーネント全てで復元試験が完了したため T-0071 を done にし、docs/backup.md に記録・検証用 Job を削除。これに依存していた T-0023/T-0027/T-0029（メジャー版更新）の blocked_by を解消し todo に戻した",
       "prs": [
         240
+      ]
+    },
+    {
+      "n": 69,
+      "at": "2026-08-05T21:15:00Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "前回の中断: PR #240（run #67/#68 由来、T-0071 coder-postgres 分の完了）を、CI green・kubectl での Job succeeded 独立確認のうえ merge した。T-0071（restic 復元試験）が3コンポーネント全て完了。issue #56 に新規フィードバックなし。backlog の todo（T-0023/T-0027/T-0029、いずれも T-0071 完了で blocked 解除済み）のうち優先度最上位の T-0023（coder v2.34.7→v2.35.3, stable）に着手。subagent に GitHub Release 本文原文と DB migration ファイル一覧の直接照合を依頼し、この区間に新規 migration が無い（000001〜000500 で完全一致）こと、CODER_PROXY_TRUSTED_ORIGINS はワイルドカードルーティング専用で当リポジトリは無関係なことを確認。apps/coder/deployment.yaml を更新し PR #241 を出した。",
+      "prs": [
+        241
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

Coder（`apps/coder/deployment.yaml`）のイメージを v2.34.7 → v2.35.3（stable チャンネル最新）に上げる。
mainline の v2.36.0 は OAuth2 動的クライアント登録・login-type 非推奨化・chat model 設定の DB スキーマ
変更（migration `000554`）を含むため意図的に避けている。

## 検証したこと

- GitHub Release 本文（v2.34.7〜v2.35.3 の全リリース）を原文確認。v2.35.3 が現行 stable（release body
  冒頭に `> ## Stable (since August 4, 2026)` と明記）。
- `coderd/database/migrations/` のファイル一覧を v2.34.7・v2.35.3 の両タグで直接照合し、
  000001〜000500 で完全一致（新規 migration ゼロ）と確認。`coder server` は起動時に migration を
  自動適用するが、この区間では適用対象の migration が無い。
- `CODER_PROXY_TRUSTED_ORIGINS`（既存の env var、今回新規追加ではない）は v2.35 系で
  「ワイルドカードサブドメインの workspace app ルーティングにおける `X-Forwarded-Host` 検証」を
  強制するようになった（fail-open、未設定でも Host ヘッダにフォールバックするだけでログイン等は
  ブロックされない）。当リポジトリは `CODER_WILDCARD_ACCESS_URL` を使っておらずワイルドカード
  ルーティング非対応のため無関係、追加設定不要と確認した。
- OIDC 関連の breaking change は Coder 側に OIDC 設定自体が無いため無関係。
- `/healthz` ハンドラ・`CODER_OAUTH2_GITHUB_DEFAULT_PROVIDER_ENABLE` フラグの意味・DERP relay
  （`CODER_DERP_SERVER_RELAY_URL`）関連の挙動に変更なしと source diff で確認。
- `python3 ops/validate.py` → 0 error。
- `python3 ops/check_version_sync.py` → 全 GROUP ok。

## 観測・操作経路への影響

Coder は人間・構築セッションがこの homelab で作業する開発環境（CHARTER §4 が定める「観測・操作する
経路」の一つ）。今回の更新で ArgoCD sync 後に Coder Pod が起動失敗した場合、その経路は一時的に
失われる。ただし autopilot 自身の運用（GitHub API 経由の git 操作・kubectl ClusterRole 経由の
read-only 確認）は Coder に依存していないため、autopilot 自身はこの間も動作を継続できる。
Pod の起動確認は次回起動の `ops-health-report`（ArgoCD Application `coder` の sync/health）で行う。

## ロールバック手順

`git revert` でイメージタグを v2.34.7 に戻し、ArgoCD の sync を待つ。今回の更新区間には新規 DB
migration が無いことを file listing diff で確認済みのため、Postgres スキーマは常に不変のまま
（コードとスキーマの不整合は発生しない）。万一データ不整合が疑われる場合でも、T-0071 で復元試験を
完了した restic backup（`coder-postgres`）から復元できる。

## backlog task id

T-0023
