### PR TITLE
chore(ops): T-0029 の PR #244 merge を記録する（run #71）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 111,
-  "updated": "2026-08-05T21:10:00Z",
+  "updated": "2026-08-05T21:49:21Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -556,7 +556,7 @@
       "title": "immich の postgres (cloudnative-vectorchord) を 16.9-0.4.3 → 16.14-1.1.1 に上げる（vchord 拡張のメジャー更新）",
       "kind": "upgrade",
       "risk": "high",
-      "status": "todo",
+      "status": "in_progress",
       "priority": 21,
       "why": "T-0005 の調査 (run #6) で判明。postgres 本体は 16.9→16.14 の minor で問題ないが、vchord 拡張が 0.4.3→1.1.1 とメジャー相当の飛びで、ベクタ DB の実データに影響しうる（ops/inventory.json の policy=manual の理由）",
       "dod": "vchord 0.4→1.x の互換性・移行手順を確認する。CHARTER §4『データを失いうる変更』の手順どおり、着手前に immich のバックアップが実際に存在し復元できることを確認する",
@@ -566,8 +566,8 @@
         "ops/inventory.json"
       ],
       "created": "2026-08-04",
-      "pr": null,
-      "notes": " | run #68: T-0071（restic 復元試験）が3コンポーネント全て完了したため blocked_by を解消し todo に戻した。メジャーバージョン更新であることに変わりはないため、着手時は CHARTER §4「high を戻せる形に落とす」（1 PR 1 コンポーネント、変更点を全部読む）を引き続き適用する。"
+      "pr": 244,
+      "notes": " | run #68: T-0071（restic 復元試験）が3コンポーネント全て完了したため blocked_by を解消し todo に戻した。メジャーバージョン更新であることに変わりはないため、着手時は CHARTER §4「high を戻せる形に落とす」（1 PR 1 コンポーネント、変更点を全部読む）を引き続き適用する。 | run #71: 前回起動が作成していた PR #244（CI green 済み）を、縛る変更（memory limits 等）に該当しないこと・T-0071 でリストア確認済みであることを確認したうえで merge した。ArgoCD の immich sync はまだ反映前（sync revision が旧 commit のまま）。`ALTER EXTENSION vchord UPDATE` + REINDEX の一度きり Job（`immich-vchord-upgrade`）の成否は次回起動で `kubectl get pod -n immich -l job-name=immich-vchord-upgrade` の terminationMessage を確認してから done にする。"
     },
     {
       "id": "T-0030",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,20 @@
   "open": [],
   "merged": [
     {
+      "number": 244,
+      "title": "feat(immich): postgres (cloudnative-vectorchord) を 16.9-0.4.3 → 16.14-1.1.1 に上げる (T-0029)",
+      "url": "https://github.com/hikuohiku/homelab/pull/244",
+      "mergedAt": "2026-08-05T21:45:46Z",
+      "headRefName": "autopilot/T-0029-immich-vchord-upgrade"
+    },
+    {
+      "number": 243,
+      "title": "chore(ops): T-0027 を done に、PR #242 の merge を記録する",
+      "url": "https://github.com/hikuohiku/homelab/pull/243",
+      "mergedAt": "2026-08-05T21:28:01Z",
+      "headRefName": "autopilot/T-0027-done-followup"
+    },
+    {
       "number": 242,
       "title": "feat(immich): server / machine-learning を v2.7.5 → v3.1.0 に上げる (T-0027)",
       "url": "https://github.com/hikuohiku/homelab/pull/242",
@@ -406,20 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/177",
       "mergedAt": "2026-08-05T08:48:16Z",
       "headRefName": "autopilot/run42-wrapup"
-    },
-    {
-      "number": 176,
-      "title": "docs: CLAUDE.md の Apps/ディレクトリ構造を実態に合わせる (T-0089)",
-      "url": "https://github.com/hikuohiku/homelab/pull/176",
-      "mergedAt": "2026-08-05T08:46:20Z",
-      "headRefName": "autopilot/T-0089-claude-md-apps"
-    },
-    {
-      "number": 175,
-      "title": "ops: T-0087/T-0088 完遂の記録、T-0090 起票 (run #42)",
-      "url": "https://github.com/hikuohiku/homelab/pull/175",
-      "mergedAt": "2026-08-05T08:44:20Z",
-      "headRefName": "autopilot/T-0087-record"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2096,3 +2096,26 @@
 （run #70 続き）PR #242 の CI 6件全て green を確認し、自分の判断で merge した（4aa7426）。
 T-0027 完了。ArgoCD の sync/health 反映確認は次回起動の ops-health-report に持ち越す。
 続けて T-0029（immich postgres/vchord メジャー更新）に着手する。
+
+## 2026-08-06 06:49 JST — run #71
+
+- 前回の中断確認: オープン PR #244（T-0029, run #70 が作成済み）。CI 6件全て green
+  （manifest deletion guard / nix flake check / ops state validate / terraform validate /
+  kustomize build / GitGuardian）・`mergeable_state: clean` を確認した
+- 読んだフィードバック: issue #56 のコメント 100 件（`per_page=100`）+ page2 の 2 件、計 102 件を
+  機械的に確認。last_read（2026-08-05T18:47:54Z）以降の新規コメント無し
+- homelab の健全性: `ops-health-report`（generated_at 2026-08-05T21:30:09Z）で確認。Application
+  11 件全て Synced/Healthy、pod_issues は常連の再起動カウントのみ。autopilot 自身の heartbeat も
+  `exit_code=0`・`readyReplicas=1`（前回イテレーション #16 終了、#17 開始）で正常
+- やったこと: PR #244 は「縛る変更」（memory limits 等の新設）に該当せず、T-0071 で immich の
+  リストアを確認済みのため、CHARTER §4 の high risk 手順（戻せる形に落とす）を満たしていると判断し
+  merge した（91243f1）。ブランチは GitHub 側で自動削除済み。merge 直後に ArgoCD の immich
+  Application を確認したが、sync revision がまだ旧 commit のままで反映前だった（ポーリング間隔待ち、
+  2分待って再確認したが変化なし）
+- backlog: T-0029 を `in_progress` にした（`done` にはしていない）。理由: この PR には
+  `ALTER EXTENSION vchord UPDATE` + REINDEX を行う一度きりの Job が含まれており、その成否は
+  autopilot の read-only 権限では termination message からしか確認できない。ArgoCD 同期が
+  終わっていない今は Job 自体がまだ作られていない
+- 次の起動へ: `kubectl get pod -n immich -l job-name=immich-vchord-upgrade` で Job の
+  terminationMessage を確認し、成功していれば T-0029 を `done` にする。ArgoCD の immich sync が
+  まだ反映されていなければ、先に sync revision が新しい commit に追いついているか確認する

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T21:20:00Z",
+  "updated": "2026-08-05T21:49:21Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -772,6 +772,14 @@
       "prs": [
         242
       ]
+    },
+    {
+      "n": 71,
+      "at": "2026-08-05T21:49:21Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "前回の中断（PR #244, T-0029 immich postgres/vchord メジャー更新, run #70 由来）を拾った。CI 6件全て green・mergeable_state: clean を確認し、「縛る変更」に該当しないこと（memory limits 未設定）・T-0071 でリストア確認済みであることから CHARTER §4 の high risk 手順を満たしていると判断して merge した（91243f1）。merge 直後に ArgoCD の immich sync を確認したが、まだ旧 commit のまま反映前だった（2分待って再確認したが変化なし、ポーリング間隔待ちと判断）。backlog の T-0029 は `done` にはせず `in_progress` にした。PR に含まれる vchord 拡張の `ALTER EXTENSION UPDATE` + REINDEX の一度きり Job の成否は autopilot の read-only 権限では次回 ArgoCD 同期後に kubectl でしか確認できないため。issue #56 に新規フィードバックなし。homelab の健全性（ops-health-report, generated_at 21:30:09Z）は Application 11 件全て Synced/Healthy、autopilot 自身の heartbeat も正常。",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

運用記録の更新のみ。コンポーネント自体の変更は無い。

- `ops/backlog.json`: T-0029（immich postgres/vchord メジャー更新）を `todo` → `in_progress` に。merge した PR番号（244）を記録
- `ops/journal/2026-08.md`: run #71 の記録を追記
- `ops/state.json`: run #71 のエントリを追加
- `ops/dashboard/prs.json`: GitHub REST API から最新の open/merged PR 一覧を取得しキャッシュを更新

## 経緯

前回起動（run #70）が作成していた PR #244（T-0029, immich postgres の vchord 拡張メジャー更新）を、
この起動で CI green・「縛る変更」に非該当・T-0071 でのリストア確認済みを確認したうえで merge した
（91243f1）。ただしこの PR には `ALTER EXTENSION vchord UPDATE` + REINDEX を行う一度きりの Job が
含まれており、ArgoCD の同期がまだ反映されていないため Job の成否を確認できていない。そのため
T-0029 は `done` ではなく `in_progress` のまま次回起動に持ち越す。

## 検証したこと

- `python3 ops/validate.py` で 0 error（11 warning は既存のもの + 今回 todo が0件になった旨の警告で、
  次回起動で調査タスクを起票する予定）
- `python3 ops/dashboard/build.py` が例外なく完了

## ロールバック手順

記録ファイルのみの変更のため、revert すれば即座に元に戻る。データやスキーマへの影響は無い。

## backlog task id

T-0029（記録のみ。コンポーネント変更は #244 で完了済み）