### PR TITLE
chore(ops): T-0029 の PR #244 merge を記録し、ブランチ分岐タイミングの教訓を CHARTER に追記する（run #72）

### DIFF
--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -163,6 +163,16 @@ backlog が空、または全部 `blocked` のときは**調査タスクを自�
   拾い直す原因になる（issue #56, 2026-08-04 23:59:38。#105 close 時にブランチを消し忘れ、
   既に #106 で main に入っている T-0037 を中断中と誤認しかけた）。§2 の中断検知でブランチを
   見つけたら、存在だけでなく **main に同内容が既に入っていないか** も確認してから着手する
+- **新しいブランチを切る前に、ローカル `main` が `origin/main` と同じ commit か確認する。**
+  `git fetch` はリモート追跡ブランチ（`origin/main`）を更新するだけで、ローカル `main` の HEAD は
+  動かさない。`git checkout -b <new-branch>` を実行するとその時点のローカル `main` から分岐する
+  ため、`git fetch` 直後でも stale なローカル `main` から分岐してしまうことがある（run #72 の実例。
+  直前の起動が作った PR を merge した直後に別ブランチを切ったところ、ローカル `main` が merge 前の
+  ままだったため、その merge コミットに含まれていた `ops/backlog.json`/`ops/journal/*.md` の運用記録
+  更新と自分の更新が競合し、新しい PR が `mergeable_state: dirty` になった）。
+  `git log -1 --format=%H main` と `git log -1 --format=%H origin/main` を比較し、一致していなければ
+  `git checkout main && git reset --hard origin/main`（ローカル `main` はどうせ origin の写しなので
+  巻き戻しても失うものはない）してから新しいブランチを切る
 - **PR を別 PR で置き換えるとき（レビュー指摘・DIRTY・重複の作り直し）は、置き換え後に
   `git diff <新ブランチ>...<旧ブランチ>` が空であることを確認する。** ブランチ単位の存在確認
   （直前の項目）だけでは、内容の一部が引き継がれず消えるケースを検出できない（issue #56,

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 111,
-  "updated": "2026-08-05T21:10:00Z",
+  "updated": "2026-08-05T21:54:49Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -566,8 +566,8 @@
         "ops/inventory.json"
       ],
       "created": "2026-08-04",
-      "pr": null,
-      "notes": " | run #68: T-0071（restic 復元試験）が3コンポーネント全て完了したため blocked_by を解消し todo に戻した。メジャーバージョン更新であることに変わりはないため、着手時は CHARTER §4「high を戻せる形に落とす」（1 PR 1 コンポーネント、変更点を全部読む）を引き続き適用する。 | run #70: subagent に VectorChord 0.4.3→1.1.1 の release notes / immich 公式ドキュメント / immich PR #23845 を一次情報源で確認させた。ベアなイメージタグ差し替えだけでは不十分で、`ALTER EXTENSION vchord UPDATE;`（sql/upgrade/ の連鎖スクリプトを1コマンドで適用、immich公式も手動作業と明記）と、オンディスク形式が変わるインデックスの REINDEX が別途必要と判明。postgres.yaml の image タグ更新と同じ PR で `apps/immich/vchord-upgrade-job.yaml`（ALTER EXTENSION UPDATE→バージョン確認→vchord系インデックスを動的検出しREINDEX、接続リトライ付きで Deployment の Recreate ロールアウトと順序非依存に設計）を追加した。戻し方: ALTER EXTENSION UPDATE は単一トランザクションでアトミック、失敗時は image タグを16.9-0.4.3 に戻せば catalog と .so の整合が復元する。REINDEX 個別失敗はテーブル本体データに触れないため再実行で復旧可。T-0071 でバックアップ復元は確認済み。CI green を確認のうえ、high risk のため縛る変更同様に慎重を期し、Job の termination-log 結果を次回起動でkubectl get pod 経由で確認してから最終的に done とする。"
+      "pr": 244,
+      "notes": " | run #68: T-0071（restic 復元試験）が3コンポーネント全て完了したため blocked_by を解消し todo に戻した。メジャーバージョン更新であることに変わりはないため、着手時は CHARTER §4「high を戻せる形に落とす」（1 PR 1 コンポーネント、変更点を全部読む）を引き続き適用する。 | run #70: subagent に VectorChord 0.4.3→1.1.1 の release notes / immich 公式ドキュメント / immich PR #23845 を一次情報源で確認させた。ベアなイメージタグ差し替えだけでは不十分で、`ALTER EXTENSION vchord UPDATE;`（sql/upgrade/ の連鎖スクリプトを1コマンドで適用、immich公式も手動作業と明記）と、オンディスク形式が変わるインデックスの REINDEX が別途必要と判明。postgres.yaml の image タグ更新と同じ PR で `apps/immich/vchord-upgrade-job.yaml`（ALTER EXTENSION UPDATE→バージョン確認→vchord系インデックスを動的検出しREINDEX、接続リトライ付きで Deployment の Recreate ロールアウトと順序非依存に設計）を追加した。戻し方: ALTER EXTENSION UPDATE は単一トランザクションでアトミック、失敗時は image タグを16.9-0.4.3 に戻せば catalog と .so の整合が復元する。REINDEX 個別失敗はテーブル本体データに触れないため再実行で復旧可。T-0071 でバックアップ復元は確認済み。CI green を確認のうえ、high risk のため縛る変更同様に慎重を期し、Job の termination-log 結果を次回起動でkubectl get pod 経由で確認してから最終的に done とする。 | run #72: PR #244 の CI 6件全て green・mergeable_state: clean を確認し、「縛る変更」（memory limits 等）に該当しないこと・T-0071 でリストア確認済みであることから merge した（91243f1）。merge 直後に ArgoCD の immich Application を確認したが sync revision がまだ旧 commit のままで反映前だった（2分待って再確認したが変化なし）。ALTER EXTENSION UPDATE + REINDEX Job の成否はまだ確認できないため in_progress のまま。次回起動で ArgoCD 同期後の Job の termination message を確認してから done にする。"
     },
     {
       "id": "T-0030",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,13 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 244,
       "title": "feat(immich): postgres (cloudnative-vectorchord) を 16.9-0.4.3 → 16.14-1.1.1 に上げる (T-0029)",
       "url": "https://github.com/hikuohiku/homelab/pull/244",
-      "isDraft": false,
-      "createdAt": "2026-08-05T21:40:48Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "PENDING"
-        }
-      ],
-      "headRefName": "autopilot/T-0029-immich-vchord-upgrade",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-05T21:45:46Z",
+      "headRefName": "autopilot/T-0029-immich-vchord-upgrade"
+    },
     {
       "number": 243,
       "title": "chore(ops): T-0027 を done に、PR #242 の merge を記録する",
@@ -428,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/177",
       "mergedAt": "2026-08-05T08:48:16Z",
       "headRefName": "autopilot/run42-wrapup"
-    },
-    {
-      "number": 176,
-      "title": "docs: CLAUDE.md の Apps/ディレクトリ構造を実態に合わせる (T-0089)",
-      "url": "https://github.com/hikuohiku/homelab/pull/176",
-      "mergedAt": "2026-08-05T08:46:20Z",
-      "headRefName": "autopilot/T-0089-claude-md-apps"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2129,3 +2129,33 @@ T-0027 完了。ArgoCD の sync/health 反映確認は次回起動の ops-health
   失敗していれば termination message の内容を見て原因を切り分ける（image タグを戻す/Job を
   作り直す等）。backlog の todo が現在 0 件のため（T-0029 を in_progress にしたことで）、
   T-0029 の後始末が終わってなお todo が無ければ CHARTER §3 のとおり調査タスクを自分で起票する
+
+## 2026-08-06 06:54 JST — run #72
+
+- 前回の中断確認: オープン PR #244（T-0029, run #71 が作成）が残っていた。CI 6件全て green・
+  `mergeable_state: clean` を確認した
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` 2ページとも）を機械的に確認。
+  last_read（2026-08-05T18:47:54Z）以降の新規コメント無し
+- homelab の健全性: `ops-health-report`（generated_at 2026-08-05T21:30:09Z）で確認。Application
+  11 件全て Synced/Healthy、pod_issues は常連の再起動カウントのみ。autopilot 自身の heartbeat も
+  `exit_code=0`・`readyReplicas=1`（iteration #16 終了・#17 開始）で正常
+- やったこと: PR #244 は「縛る変更」（memory limits 等の新設）に該当せず、T-0071 でリストア確認済み
+  のため CHARTER §4 の high risk 手順を満たしていると判断し merge した（91243f1）。ブランチは
+  GitHub 側で自動削除済み。merge 直後に ArgoCD の immich Application を確認したが、sync revision が
+  まだ旧 commit のままで反映前だった（2分待って再確認したが変化なし、ポーリング間隔待ちと判断）
+  - **教訓**: この記録更新 PR を最初に作った際、`git checkout -b` を `git fetch` 直後にもかかわらず
+    ローカル `main`（stale, merge前）から分岐させてしまい、origin/main（91243f1 merge 済み）との間で
+    `ops/backlog.json`/`ops/journal/2026-08.md` に重複編集が生じ PR が `mergeable_state: dirty` に
+    なった（run #71 の commit 71f410b が既に同じファイルへ運用記録を相乗りさせていたため）。
+    PR を close・ブランチ削除のうえ `git reset --hard origin/main` でローカル main を最新化してから
+    作り直した。**`git fetch` はリモート追跡ブランチを更新するだけでローカル `main` の HEAD は
+    動かさない。** 新しいブランチを切る前に、ローカル `main` が `origin/main` と同じ commit かを
+    `git log -1 --format=%H main` と `git log -1 --format=%H origin/main` の一致で確認する
+    （§5.1 の「`git checkout <ref> -- .` は使わない」に続く、ブランチ作成タイミングの教訓として
+    CHARTER に追記する）
+- backlog: T-0029 は `done` にはせず `in_progress` のまま。`pr` を 244 に更新。ALTER EXTENSION
+  UPDATE + REINDEX の一度きり Job の成否は ArgoCD 同期後でないと確認できないため
+- 次の起動へ: ArgoCD の immich sync revision が最新 commit に追いついているか確認し、追いついて
+  いれば `kubectl get pod -n immich -l job-name=immich-vchord-upgrade` の terminationMessage で
+  Job の成否を確認する。成功していれば T-0029 を done にする。backlog の todo が 0 件のままなら
+  CHARTER §3 のとおり調査タスクを自分で起票する

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T21:20:00Z",
+  "updated": "2026-08-05T21:54:49Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -772,6 +772,24 @@
       "prs": [
         242
       ]
+    },
+    {
+      "n": 71,
+      "at": "2026-08-05T21:41:20Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "前回起動が PR #242 を merge した（4aa7426）のを受け T-0027 完了、続けて T-0029（immich postgres/vchord メジャー更新）に着手。subagent に VectorChord 0.4.3→1.1.1 の release notes・immich 公式ドキュメント・immich 本体 PR #23845 を一次情報源で確認させ、ベアなイメージタグ差し替えだけでは不十分で `ALTER EXTENSION vchord UPDATE;` とオンディスク形式が変わるインデックスの REINDEX が別途必要と判明。`apps/immich/postgres.yaml` のイメージタグ更新と同じ PR に `apps/immich/vchord-upgrade-job.yaml`（ALTER EXTENSION UPDATE→バージョン確認→REINDEX、接続リトライ付き）を追加し PR #244 を作成した（CI green 確認・merge は次回起動に持ち越し）。この起動は ops/state.json への記録を残さないまま終了していたため、run #72 が journal を基に事後追記した。",
+      "prs": [
+        244
+      ]
+    },
+    {
+      "n": 72,
+      "at": "2026-08-05T21:54:49Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "前回の中断（PR #244, T-0029）を拾った。CI 6件全て green・mergeable_state: clean を確認し、「縛る変更」に該当しないこと・T-0071 でリストア確認済みであることから merge した（91243f1）。merge 直後に ArgoCD の immich sync を確認したが、まだ旧 commit のまま反映前だった（ポーリング間隔待ちと判断）。backlog の T-0029 は `done` にはせず `in_progress`（pr:244）のまま、vchord アップグレード Job の成否確認は次回起動に持ち越し。副次的に、この記録更新PR作成時に stale なローカル main から分岐してしまい PR が dirty になった事故があり、原因と対処を CHARTER §4 に追記した。issue #56 に新規フィードバックなし。homelab の健全性（ops-health-report, generated_at 21:30:09Z）は Application 11 件全て Synced/Healthy、autopilot 自身の heartbeat も正常。",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

運用記録の更新と CHARTER の小改訂。コンポーネント自体の変更は無い。

- `ops/backlog.json`: T-0029（immich postgres/vchord メジャー更新）の `pr` を 244 に更新し、run #72 の note を追記（`in_progress` のまま維持）
- `ops/journal/2026-08.md`: run #72 の記録を追記
- `ops/state.json`: run #71（PR #244 作成、前回起動が記録漏れ）・run #72（今回の merge）のエントリを追加
- `ops/dashboard/prs.json`: GitHub REST API から最新の open/merged PR 一覧を取得しキャッシュを更新（open 0件）
- `ops/CHARTER.md`: §4 共通ルールに「新しいブランチを切る前にローカル main が origin/main と同じ commit か確認する」を追記。今回、記録更新の作業ブランチを stale なローカル main から誤って分岐させ、PR が `mergeable_state: dirty` になる事故があったための再発防止

## 経緯

前々回起動（journal 上は run #71 表記）が作成していた PR #244（T-0029, immich postgres の vchord 拡張メジャー更新）を、この起動で CI green・「縛る変更」に非該当・T-0071 でのリストア確認済みを確認したうえで merge した（91243f1）。この PR には `ALTER EXTENSION vchord UPDATE` + REINDEX を行う一度きりの Job が含まれており、ArgoCD の同期がまだ反映されていないため Job の成否を確認できていない。そのため T-0029 は `done` ではなく `in_progress` のまま次回起動に持ち越す。

記録用の最初のブランチ作成時、`git fetch` 直後にもかかわらずローカル `main` の HEAD が古いままだったため、そこから分岐した結果 origin/main（PR #244 merge 済み）とファイルが競合し PR が dirty になった。close・ブランチ削除のうえ `git reset --hard origin/main` でローカル main を最新化してから作り直した。

## 検証したこと

- `python3 ops/validate.py` で 0 error（11 warning は既存分 + todo 0件の警告。次回起動で調査タスクを起票する想定）
- `python3 ops/dashboard/build.py` が例外なく完了
- ブランチ作成前に `git log -1 --format=%H main` と `origin/main` が一致することを確認済み

## ロールバック手順

記録ファイルとドキュメント（CHARTER）のみの変更のため、revert すれば即座に元に戻る。データやスキーマへの影響は無い。

## backlog task id

T-0029（記録のみ。コンポーネント変更は #244 で完了済み）