### PR TITLE
feat(immich): T-0111 postgres 手動 initdb ブートストラップの検証 Job (16.14-1.1.1)

### DIFF
--- a/apps/immich/kustomization.yaml
+++ b/apps/immich/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ingress.yaml
   - library-pvc.yaml
   - postgres.yaml
+  - postgres-bootstrap-verify-job.yaml
   - postgres-external-secret.yaml
   - pvc-usage-cronjob.yaml
   - restic-external-secret.yaml

--- a/apps/immich/postgres-bootstrap-verify-job.yaml
+++ b/apps/immich/postgres-bootstrap-verify-job.yaml
@@ -1,0 +1,152 @@
+# T-0111: cloudnative-vectorchord 16.10-1.0.0 以降で initdb ブートストラップ（docker-entrypoint.sh
+# 相当の自動初期化）が無くなった件の検証。空の使い捨て PVC に対して、T-0029 が上げようとしている
+# 実際のターゲットタグ (16.14-1.1.1) で手動 initdb ブートストラップが機能することを確認する。
+#
+# 手順は docker-library/postgres の docker-entrypoint.sh の挙動を手で再現する:
+#   1. initdb --username --pwfile --data-checksums で PGDATA を作成
+#   2. pg_hba.conf に `host all all all scram-sha-256` を追記（初期状態は socket の trust のみで
+#      TCP + パスワード認証が通らないため）
+#   3. 一時サーバー（listen_addresses='' で socket のみ）を起動し、POSTGRES_DB が
+#      POSTGRES_USER と異なる場合のみ createdb（initdb は POSTGRES_USER を初期スーパーユーザーとして
+#      作成済みなので createuser は不要）→ 停止
+#   4. 本番と同じ `shared_preload_libraries=vchord.so` を付けて再起動 → CREATE EXTENSION vchord
+#      が通ることを確認（vchord は shared_preload_libraries 有効化後の再起動を経てからでないと
+#      CREATE EXTENSION できない仕様、docs.vectorchord.ai 確認済み）
+#
+# 確認が取れたら、この PVC/Job は削除する PR を出す（immich-postgres の本番 Deployment は変更しない）。
+# 検証専用のため POSTGRES_PASSWORD は実運用と無関係な使い捨て値をハードコードしている。
+#
+# 結果の受け取り方: autopilot の ClusterRole には pods/log 権限が無いため stdout は読めない。
+# /dev/termination-log に判定用のサマリ行を書き、
+# `kubectl get pod -n immich -l job-name=immich-postgres-bootstrap-verify -o json` の
+# status.containerStatuses[].state.terminated.message から読む（T-0071 と同じ方式）。
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-postgres-bootstrap-verify
+  namespace: immich
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: immich-postgres-bootstrap-verify
+  namespace: immich
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 600
+  template:
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      securityContext:
+        fsGroup: 999
+      initContainers:
+        - name: init-permissions
+          image: busybox:1.38.0
+          command: ["sh", "-c", "chown -R 26:999 /var/lib/postgresql/data"]
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      containers:
+        - name: postgres-bootstrap
+          image: ghcr.io/tensorchord/cloudnative-vectorchord:16.14-1.1.1
+          command:
+            - bash
+            - -c
+            - |
+              set -u
+              LOGFILE=/tmp/pg-bootstrap.log
+              : > "$LOGFILE"
+              START=$(date +%s)
+
+              if [ -s "$PGDATA/PG_VERSION" ]; then
+                INITDB_RC=99
+              else
+                initdb --username="$POSTGRES_USER" --pwfile=<(printf '%s\n' "$POSTGRES_PASSWORD") $POSTGRES_INITDB_ARGS -D "$PGDATA" >>"$LOGFILE" 2>&1
+                INITDB_RC=$?
+              fi
+
+              BOOT_START_RC=1
+              START_RC=1
+              EXT_RC=1
+              EXT_VERSION=none
+
+              if [ "$INITDB_RC" -eq 0 ]; then
+                echo "host all all all scram-sha-256" >> "$PGDATA/pg_hba.conf"
+
+                pg_ctl -D "$PGDATA" -o "-c listen_addresses='' -p 5432" -w start >>"$LOGFILE" 2>&1
+                BOOT_START_RC=$?
+
+                if [ "$BOOT_START_RC" -eq 0 ]; then
+                  if [ "$POSTGRES_DB" != "$POSTGRES_USER" ]; then
+                    createdb --username="$POSTGRES_USER" "$POSTGRES_DB" >>"$LOGFILE" 2>&1
+                  fi
+                  pg_ctl -D "$PGDATA" -w stop >>"$LOGFILE" 2>&1
+
+                  pg_ctl -D "$PGDATA" -o "-c listen_addresses=* -c shared_preload_libraries=vchord.so -p 5432" -w start >>"$LOGFILE" 2>&1
+                  START_RC=$?
+
+                  if [ "$START_RC" -eq 0 ]; then
+                    EXT_OUT=$(PGPASSWORD="$POSTGRES_PASSWORD" psql -h 127.0.0.1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc "CREATE EXTENSION IF NOT EXISTS vchord CASCADE; SELECT extversion FROM pg_extension WHERE extname='vchord';" 2>>"$LOGFILE")
+                    EXT_RC=$?
+                    EXT_VERSION=$(printf '%s' "$EXT_OUT" | tail -1 | tr -d ' \n')
+
+                    pg_ctl -D "$PGDATA" -w stop >>"$LOGFILE" 2>&1
+                  fi
+                fi
+              fi
+
+              END=$(date +%s)
+              ELAPSED=$((END - START))
+              LOG_TAIL=$(tail -c 1500 "$LOGFILE" 2>/dev/null | tr '\n' ' ')
+              MSG="initdb_rc=$INITDB_RC boot_start_rc=$BOOT_START_RC start_rc=$START_RC extension_rc=$EXT_RC vchord_version=$EXT_VERSION elapsed_seconds=$ELAPSED log_tail=$LOG_TAIL"
+              echo "$MSG"
+              echo "$MSG" > /dev/termination-log
+
+              if [ "$INITDB_RC" -ne 0 ] || [ "$START_RC" -ne 0 ] || [ "$EXT_RC" -ne 0 ] || [ "$EXT_VERSION" = "none" ]; then
+                exit 1
+              fi
+              exit 0
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 26
+            runAsGroup: 999
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: POSTGRES_USER
+              value: verify
+            - name: POSTGRES_DB
+              value: verify
+            - name: POSTGRES_PASSWORD
+              value: postgres-bootstrap-verify-throwaway
+            - name: POSTGRES_INITDB_ARGS
+              value: "--data-checksums"
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: immich-postgres-bootstrap-verify

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2075,7 +2075,7 @@
       "title": "cloudnative-vectorchord 16.10-1.0.0 以降で消えた initdb ブートストラップに代わる初期化経路を用意する（T-0029 の前提条件）",
       "kind": "investigate",
       "risk": "medium",
-      "status": "todo",
+      "status": "in_progress",
       "priority": 21,
       "why": "run #73 の調査（T-0029 参照）で判明。cloudnative-vectorchord は 2025-11-12 のベースイメージ変更で docker-library postgres 系（ENTRYPOINT docker-entrypoint.sh）から CloudNativePG operand 系（`cloudnative-pg/postgres-containers`、ENTRYPOINT 無し）に切り替わり、`16.10-1.0.0` 以降（`16.14-1.1.1` を含む）には initdb/createuser/createdb のブートストラップが一切無い。既存の初期化済み PVC への in-place upgrade には影響しないが、T-0071 で確立した immich-postgres の災害復旧手順（新規 PVC 上で immich-postgres を起動し psql でダンプを流し込む）はこのイメージ系統では新規 PVC からの起動自体ができず機能しない。CHARTER §4『データを失いうる変更』は revert 経路だけでなく DR 経路の健全性も要求すると判断し、T-0029 を blocked にして本タスクを切り出した",
       "dod": "cloudnative-vectorchord 16.10-1.0.0 以降のイメージのまま、新規（空の）PVC から immich-postgres を初期化できる経路を用意する。候補: (a) initContainer で PGDATA が空の場合のみ initdb + createuser/createdb/ALTER ROLE PASSWORD を実行する、(b) CloudNativePG operator を導入し operand イメージ本来の使われ方（operator の instance-manager が initdb を制御）に寄せる、(c) 新規 PVC からの起動が要るのは実質 DR 時のみと割り切り、docs/backup.md に『まず 16.9-0.4.3 系イメージで initdb させてから 16.14 系に切り替える』といった明示的な回避手順を書いて代替する。どの案でも、使い捨て PVC + Job で実際に空の PGDATA から起動できることを検証してから T-0029 の blocked_by を解除する",
@@ -2087,7 +2087,7 @@
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": ""
+      "notes": "run #74: apps/immich/postgres-bootstrap-verify-job.yaml を追加。空の使い捨て PVC に対し 16.14-1.1.1 で initdb を手動実行（docker-entrypoint.sh 相当を再現: initdb --pwfile → pg_hba.conf に host scram-sha-256 追記 → 一時サーバーで createdb → shared_preload_libraries=vchord.so で再起動 → CREATE EXTENSION vchord）を検証する。事前調査は subagent が GHCR の実イメージレイヤーを直接展開して binary PATH・UID(26)/GID(999)・auth 挙動・vchord 拡張作成順序を裏取り済み。結果は次回起動で kubectl get pod -n immich -l job-name=immich-postgres-bootstrap-verify 経由の termination-log で確認する。"
     }
   ]
 }


### PR DESCRIPTION
## 変更点

T-0111（`ops/backlog.json`）の初動。immich の postgres (`cloudnative-vectorchord`) は 2025-11-12 のベースイメージ変更で `16.10-1.0.0` 以降（T-0029 が上げようとしている `16.14-1.1.1` を含む）が docker-entrypoint.sh 系の自動 initdb ブートストラップを持たない CloudNativePG operand 系イメージに切り替わっている。既存の初期化済み PVC には影響しないが、T-0071 で確立した「新規 PVC 上で immich-postgres を起動して復元する」災害復旧手順がこのイメージ系統では機能しなくなる（新規 PVC からの起動そのものができない）ため、T-0029 は blocked のままにしている。

本 PR は `apps/immich/postgres-bootstrap-verify-job.yaml` を追加し、空の使い捨て PVC に対して実際のターゲットタグ `16.14-1.1.1` で手動 initdb ブートストラップが機能することを検証する。手順は docker-entrypoint.sh の挙動（`initdb --pwfile` → `pg_hba.conf` に `host all all all scram-sha-256` を追記 → 一時サーバーで `createdb` → `shared_preload_libraries=vchord.so` を有効にして再起動 → `CREATE EXTENSION vchord`）を手で再現したもの。

事前調査（subagent が GHCR の実イメージレイヤーを直接展開）で、binary PATH（`/usr/lib/postgresql/16/bin` に `initdb`/`createdb`/`psql`/`pg_ctl` 等が揃っている）・UID/GID（既存の `postgres.yaml` コメントどおり UID 26 / GID 999 で変化なし）・auth 挙動・vchord 拡張の作成順序（`shared_preload_libraries` 有効化後の再起動を経てから `CREATE EXTENSION`）を裏取り済み。

**immich-postgres の本番 Deployment（`apps/immich/postgres.yaml`）は変更していない。** 新規の使い捨て PVC/Job を追加するのみ。

## 検証したこと

- `python3 ops/validate.py` — 0 error（既存の警告のみ、本 PR に起因するものなし）
- YAML の構文（`yaml.safe_load_all`）
- CI（`kustomize build` / `manifest-diff`）は push 後に確認

Job 自体の実行結果（initdb/拡張作成が実際に成功するか）はこの PR の CI では検証できない領域のため、merge・ArgoCD 同期後に `kubectl get pod -n immich -l job-name=immich-postgres-bootstrap-verify` の `terminated.message` で次回起動が確認する。

## ロールバック手順

この PR が追加するのは immich namespace 内の使い捨て PVC (`immich-postgres-bootstrap-verify`) と Job のみで、本番の `immich-postgres-data` PVC・稼働中の immich-postgres Deployment には一切触れない。revert すれば ArgoCD の prune でこの PVC/Job が削除されるだけで、他コンポーネントへの影響は無い（DB スキーマ等の懸念も対象外）。

## backlog task id

T-0111
