### PR TITLE
fix(immich): T-0111 検証 Job の unix socket ディレクトリ不足を修正

### DIFF
--- a/apps/immich/postgres-bootstrap-verify-job.yaml
+++ b/apps/immich/postgres-bootstrap-verify-job.yaml
@@ -83,16 +83,21 @@ spec:
               if [ "$INITDB_RC" -eq 0 ]; then
                 echo "host all all all scram-sha-256" >> "$PGDATA/pg_hba.conf"
 
-                pg_ctl -D "$PGDATA" -o "-c listen_addresses='' -p 5432" -w start >>"$LOGFILE" 2>&1
+                # docker-entrypoint.sh (未使用) は通常 /var/run/postgresql を作成してから postgres を
+                # 起動する。ここでは initdb 相当を手で再現しているためそのディレクトリが無く、既定の
+                # unix socket パスに書き込めず "Permission denied" で起動が失敗する（run #74 で実測、
+                # PR #250 マージ後の初回実行）。イメージ内で常に存在し world-writable な /tmp を
+                # unix_socket_directories に指定して回避する。
+                pg_ctl -D "$PGDATA" -o "-c listen_addresses='' -c unix_socket_directories=/tmp -p 5432" -w start >>"$LOGFILE" 2>&1
                 BOOT_START_RC=$?
 
                 if [ "$BOOT_START_RC" -eq 0 ]; then
                   if [ "$POSTGRES_DB" != "$POSTGRES_USER" ]; then
-                    createdb --username="$POSTGRES_USER" "$POSTGRES_DB" >>"$LOGFILE" 2>&1
+                    createdb --username="$POSTGRES_USER" --host=/tmp "$POSTGRES_DB" >>"$LOGFILE" 2>&1
                   fi
                   pg_ctl -D "$PGDATA" -w stop >>"$LOGFILE" 2>&1
 
-                  pg_ctl -D "$PGDATA" -o "-c listen_addresses=* -c shared_preload_libraries=vchord.so -p 5432" -w start >>"$LOGFILE" 2>&1
+                  pg_ctl -D "$PGDATA" -o "-c listen_addresses=* -c unix_socket_directories=/tmp -c shared_preload_libraries=vchord.so -p 5432" -w start >>"$LOGFILE" 2>&1
                   START_RC=$?
 
                   if [ "$START_RC" -eq 0 ]; then

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2086,8 +2086,8 @@
         "ops/inventory.json"
       ],
       "created": "2026-08-06",
-      "pr": null,
-      "notes": "run #74: apps/immich/postgres-bootstrap-verify-job.yaml を追加。空の使い捨て PVC に対し 16.14-1.1.1 で initdb を手動実行（docker-entrypoint.sh 相当を再現: initdb --pwfile → pg_hba.conf に host scram-sha-256 追記 → 一時サーバーで createdb → shared_preload_libraries=vchord.so で再起動 → CREATE EXTENSION vchord）を検証する。事前調査は subagent が GHCR の実イメージレイヤーを直接展開して binary PATH・UID(26)/GID(999)・auth 挙動・vchord 拡張作成順序を裏取り済み。結果は次回起動で kubectl get pod -n immich -l job-name=immich-postgres-bootstrap-verify 経由の termination-log で確認する。"
+      "pr": 250,
+      "notes": "run #74: apps/immich/postgres-bootstrap-verify-job.yaml を追加。空の使い捨て PVC に対し 16.14-1.1.1 で initdb を手動実行（docker-entrypoint.sh 相当を再現: initdb --pwfile → pg_hba.conf に host scram-sha-256 追記 → 一時サーバーで createdb → shared_preload_libraries=vchord.so で再起動 → CREATE EXTENSION vchord）を検証する。事前調査は subagent が GHCR の実イメージレイヤーを直接展開して binary PATH・UID(26)/GID(999)・auth 挙動・vchord 拡張作成順序を裏取り済み。結果は次回起動で kubectl get pod -n immich -l job-name=immich-postgres-bootstrap-verify 経由の termination-log で確認する。 run #75: PR #250 merge・ArgoCD sync 後に Job を実行したところ初回は失敗（initdb_rc=0 だが boot_start_rc=1: pg_ctl start が \"could not create lock file /var/run/postgresql/.s.PGSQL.5432.lock: Permission denied\" で失敗）。docker-entrypoint.sh を経由しないため /var/run/postgresql が存在せず、既定の unix socket パスに書き込めないのが原因と特定。unix_socket_directories=/tmp を pg_ctl の両起動に指定する修正版を同一ブランチ/PRで用意し、再実行結果を次回確認する。"
     }
   ]
 }


### PR DESCRIPTION
## 変更点

T-0111（`ops/backlog.json`）の続き。PR #250（`apps/immich/postgres-bootstrap-verify-job.yaml` 新設）が
merge・ArgoCD sync された後に検証 Job を実際に実行したところ、初回は失敗した。

termination-log:
```
initdb_rc=0 boot_start_rc=1 start_rc=1 extension_rc=1 vchord_version=none elapsed_seconds=2
```

ログを見ると initdb 自体は成功（`Success. You can now start the database server...`）していたが、
一時サーバーの起動（`pg_ctl start`）が次のエラーで失敗していた。

```
FATAL:  could not create lock file "/var/run/postgresql/.s.PGSQL.5432.lock": Permission denied
```

原因は、本 Job が docker-entrypoint.sh を経由せず initdb〜起動を手で再現しているため、
通常 entrypoint が作成する `/var/run/postgresql`（unix socket ディレクトリ）が存在しない・
書き込めないこと。cloudnative-vectorchord のイメージ切り替え（16.10-1.0.0 以降）自体が原因ではなく、
検証 Job 側の実装漏れだった。

本 PR は Job の起動オプションに `unix_socket_directories=/tmp` を追加し、entrypoint に依存せず
書き込み可能なソケットディレクトリを明示することで回避する。`createdb` にも同じ `--host=/tmp` を
渡し、libpq のデフォルトソケットパス探索に頼らないようにした。

`immich-postgres` の本番 Deployment（`apps/immich/postgres.yaml`）は変更していない。

## 検証したこと

- `python3 -c "import yaml; list(yaml.safe_load_all(open('apps/immich/postgres-bootstrap-verify-job.yaml')))"` — 構文 OK
- `python3 ops/validate.py` — 0 error（既存の警告のみ、本 PR に起因するものなし）
- CI（`kustomize build` / `manifest-diff`）は push 後に確認
- merge・ArgoCD sync 後、Job の再実行結果を次回起動で確認する

## ロールバック手順

この PR が変更するのは immich namespace 内の使い捨て PVC/Job のみで、本番の
`immich-postgres-data` PVC・稼働中の `immich-postgres` Deployment には一切触れない。
revert すれば ArgoCD の prune でこの PVC/Job が削除されるだけで、他コンポーネントへの
影響は無い（DB スキーマ等の懸念も対象外）。

## backlog task id

T-0111

🤖 Generated with autopilot