### PR TITLE
chore(ops): run #73-75 の journal/state/CHARTER を記録する

### DIFF
--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -214,7 +214,18 @@ backlog が空、または全部 `blocked` のときは**調査タスクを自�
   （issue #56, 2026-08-04 21:38:00。coder-postgres の patch 更新(#92)で、Coder 自身が作業を観測する経路である
   という観点が PR 本文に無かった指摘）
 - 手元で検証できることは push 前に検証する（`kustomize build --enable-helm <dir>`、`terraform fmt -check` 等）。
-  ツールが無ければ CI に任せてよい。**`kubectl` は使わない**（[§5.1](#51-権限プロンプトを踏まない)）
+  ツールが無ければ CI に任せてよい。**この行は §5.1（旧・クラウド定期実行サンドボックス）の記述に基づき
+  `kubectl` 不使用としていたが、§5.5（クラスタ内常駐, 2026-08-05〜）以降は read-only の `kubectl` が
+  実際に動く。** merge・ArgoCD sync 後に Job の実行結果などを直接確認するのに使ってよい。書き込み系
+  操作（`apply`/`delete`/`patch`/`exec`/`cp`）が禁止なのは変わらない（[§5](#5-触ってはいけないもの)）
+- **内容が変わりうる Job リソース（検証用 Job など、同じ名前のまま再実行・再検証するもの）には、
+  最初から `argocd.argoproj.io/sync-options: Force=true,Replace=true` を付けておく。** Job の
+  `.spec.template` は Kubernetes 側で不変フィールドのため、通常の apply では2回目以降の変更が
+  `field is immutable` で失敗し ArgoCD が `OutOfSync` のまま固まる。`Replace=true` 単体は
+  `kubectl replace` の PUT セマンティクスのままで同じ検証に引っかかるため、`Force=true` を
+  併用して delete→re-create させる必要がある（ArgoCD 公式ドキュメント sync-options で確認）。
+  この問題は T-0108 と T-0111（run #75, #250-#254）で2回独立に踏んでおり、後付けで気づくたびに
+  1 起動分の待ち時間（ArgoCD の sync 検出込みで数分）を無駄にしている
 - **PR 本文に「残った不確実性」（実機で確認できていない点）を書いたら、同じ PR で backlog にも軽量な
   確認待ちタスクとして起票する**（`status: needs-human`, `kind: investigate`, risk はその不確実性自体の
   リスクに合わせる）。PR 本文の中に埋もれさせない。実機で確認できた（人間や構築セッションからの報告を

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,55 @@
   "open": [],
   "merged": [
     {
+      "number": 255,
+      "title": "chore(immich): T-0111 完了、検証用 Job/PVC を削除し T-0029 を再開可能にする",
+      "url": "https://github.com/hikuohiku/homelab/pull/255",
+      "mergedAt": "2026-08-05T23:07:06Z",
+      "headRefName": "autopilot/T-0111-cleanup-verify-job"
+    },
+    {
+      "number": 254,
+      "title": "fix(immich): T-0111 検証 Job の createdb スキップ条件を修正",
+      "url": "https://github.com/hikuohiku/homelab/pull/254",
+      "mergedAt": "2026-08-05T23:01:31Z",
+      "headRefName": "autopilot/T-0111-createdb-condition-fix"
+    },
+    {
+      "number": 253,
+      "title": "fix(immich): T-0111 検証 Job で毎回 PGDATA を空にしてから initdb する",
+      "url": "https://github.com/hikuohiku/homelab/pull/253",
+      "mergedAt": "2026-08-05T22:57:43Z",
+      "headRefName": "autopilot/T-0111-clean-pgdata-each-run"
+    },
+    {
+      "number": 252,
+      "title": "fix(immich): T-0111 検証 Job に ArgoCD Force+Replace sync-option を付与",
+      "url": "https://github.com/hikuohiku/homelab/pull/252",
+      "mergedAt": "2026-08-05T22:52:32Z",
+      "headRefName": "autopilot/T-0111-job-replace-sync-option"
+    },
+    {
+      "number": 251,
+      "title": "fix(immich): T-0111 検証 Job の unix socket ディレクトリ不足を修正",
+      "url": "https://github.com/hikuohiku/homelab/pull/251",
+      "mergedAt": "2026-08-05T22:41:13Z",
+      "headRefName": "autopilot/T-0111-socket-dir-fix"
+    },
+    {
+      "number": 250,
+      "title": "feat(immich): T-0111 postgres 手動 initdb ブートストラップの検証 Job (16.14-1.1.1)",
+      "url": "https://github.com/hikuohiku/homelab/pull/250",
+      "mergedAt": "2026-08-05T22:36:31Z",
+      "headRefName": "autopilot/T-0111-postgres-bootstrap-verify"
+    },
+    {
+      "number": 249,
+      "title": "chore(ops): T-0029 の再着手前提を調べ、initdb ブートストラップ消失を T-0111 として起票する（run #73）",
+      "url": "https://github.com/hikuohiku/homelab/pull/249",
+      "mergedAt": "2026-08-05T22:21:21Z",
+      "headRefName": "autopilot/T-0111-records"
+    },
+    {
       "number": 248,
       "title": "chore(ops): T-0029 の障害・revert・復旧確認を記録する（run #72）",
       "url": "https://github.com/hikuohiku/homelab/pull/248",
@@ -371,55 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/192",
       "mergedAt": "2026-08-05T11:54:12Z",
       "headRefName": "autopilot/T-0069-followup-drop-apk-dep"
-    },
-    {
-      "number": 191,
-      "title": "feat: vaultwarden用restic backup CronJobを追加 (T-0069)",
-      "url": "https://github.com/hikuohiku/homelab/pull/191",
-      "mergedAt": "2026-08-05T11:41:15Z",
-      "headRefName": "autopilot/T-0069-vaultwarden-restic-backup"
-    },
-    {
-      "number": 190,
-      "title": "CHARTER: blocked/needs-humanをタスク全体でなく部分で見る (T-0095)",
-      "url": "https://github.com/hikuohiku/homelab/pull/190",
-      "mergedAt": "2026-08-05T11:32:44Z",
-      "headRefName": "autopilot/T-0095-blocked-granularity"
-    },
-    {
-      "number": 188,
-      "title": "ops: run #47 の記録更新（PR番号反映・journal・state・PRキャッシュ）",
-      "url": "https://github.com/hikuohiku/homelab/pull/188",
-      "mergedAt": "2026-08-05T11:23:58Z",
-      "headRefName": "autopilot/run47-record"
-    },
-    {
-      "number": 187,
-      "title": "docs: apps/README.md の ArgoCD Application 出力例を実態に合わせる (T-0094)",
-      "url": "https://github.com/hikuohiku/homelab/pull/187",
-      "mergedAt": "2026-08-05T10:29:02Z",
-      "headRefName": "autopilot/T-0094-apps-readme-app-list"
-    },
-    {
-      "number": 186,
-      "title": "docs: CLAUDE.md の autopilot 定期実行間隔記述を実態に合わせる (T-0093)",
-      "url": "https://github.com/hikuohiku/homelab/pull/186",
-      "mergedAt": "2026-08-05T09:29:57Z",
-      "headRefName": "autopilot/T-0093-claude-md-schedule-interval"
-    },
-    {
-      "number": 183,
-      "title": "docs: README.md の insecure 手順を実態に合わせる (T-0092)",
-      "url": "https://github.com/hikuohiku/homelab/pull/183",
-      "mergedAt": "2026-08-05T09:25:25Z",
-      "headRefName": "autopilot/T-0092-readme-insecure-fix"
-    },
-    {
-      "number": 182,
-      "title": "ops: T-0091 の PR 番号反映、PR キャッシュ最新化 (run #43)",
-      "url": "https://github.com/hikuohiku/homelab/pull/182",
-      "mergedAt": "2026-08-05T09:04:43Z",
-      "headRefName": "autopilot/run43-pr-numbers"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2228,3 +2228,50 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化（open 0 件・merged 60件）、
   `ops/validate.py` 0 error、`ops/dashboard/build.py` 正常終了を確認。Artifact ツールがこの環境に
   無く re-publish はできなかった
+
+## 2026-08-06 07:25 JST — run #74
+
+- 前回の中断確認: なし（run #73 の直後）
+- 読んだフィードバック: なし（last_read 以降新規なし）
+- やったこと: T-0111 の DoD 候補 (a)（initContainer 相当の手動 initdb ブートストラップ）に着手。
+  `apps/immich/postgres-bootstrap-verify-job.yaml`（使い捨て PVC + Job）を新設し、`16.14-1.1.1` で
+  initdb → pg_hba.conf 追記 → 一時起動 → createdb → `shared_preload_libraries=vchord.so` で再起動
+  → `CREATE EXTENSION vchord` を検証する内容を実装（PR #250）
+- 次の起動へ: CI green・PR #250 は open のまま終了。merge 後、ArgoCD sync を待って Job の実行結果を
+  `kubectl get pod -n immich -l job-name=immich-postgres-bootstrap-verify` の termination-log で
+  確認すること
+
+## 2026-08-06 07:50 JST — run #75
+
+- 前回の中断確認: PR #250（T-0111、run #74 が open のまま終了）を拾った。CI green・issue #56 に
+  新しい異議なし（last_read 以降 0 件、102 件を機械的に確認）を確認して merge（777daeb）
+- 読んだフィードバック: なし（last_read 以降、この run の終了時点まで一貫して 0 件）
+- やったこと: PR #250 merge・ArgoCD sync 後に検証 Job を実行したところ、3回連続で異なる原因で失敗し、
+  そのたびに原因を特定して修正 PR を出し直列に完遂した（同一タスク T-0111 の継続のため CHARTER §2
+  の直列化ルールの対象外、都度 CI green を確認して即 merge）。
+  1. PR #251: `pg_ctl start` が `/var/run/postgresql` への書き込み権限不足で失敗
+     （docker-entrypoint.sh を経由しないためディレクトリが無い）→ `unix_socket_directories=/tmp` で回避
+  2. PR #252: merge・sync 後も Job の中身が更新されない → ArgoCD の operationState を見ると
+     Job の `.spec.template` が immutable フィールドのため apply が失敗していた →
+     `argocd.argoproj.io/sync-options: Force=true,Replace=true` を付与（ArgoCD 公式ドキュメントで
+     Job のような再実行前提のリソースへの推奨パターンと確認）。この問題は T-0108 でも一度踏んで
+     いたと後から気づき、再発防止として CHARTER §4 に明記した
+  3. PR #253: Job は正しく delete→re-create されるようになったが、PVC 自体は残るため前回実行分の
+     `PG_VERSION` が残っており、スクリプトが initdb をスキップしてテスト本体ごと素通りしていた不具合
+     を発見 → 毎回 PGDATA を空にしてから initdb するよう修正
+  4. PR #254: `createdb` を `POSTGRES_DB != POSTGRES_USER` の時だけ実行する条件が誤りと判明
+     （initdb は `POSTGRES_USER` と同名のデータベースを自動生成しない）→ `postgres` 以外なら常に
+     `createdb` するよう修正
+  - この4回目の修正で Job が最終的に成功（`initdb_rc=0 boot_start_rc=0 start_rc=0 extension_rc=0
+    vchord_version=1.1.1`、kubectl で直接確認）。`16.14-1.1.1`（CloudNativePG operand 系）でも
+    新規 PVC からの initdb ブートストラップが機能することを実証できたため T-0111 を `done` にし、
+    検証用 PVC/Job を削除する PR（#255、`allow-delete:` 明記）を出して merge・ArgoCD 削除確認まで
+    見届けた。T-0029（vchord メジャー更新）の `blocked_by` を解除して `todo` に戻し、DoD に
+    「再着手時は確立した initdb 手順を postgres.yaml 本体に組み込んでから本題に進む」ことを追記
+  - 副産物: CHARTER §4 の「手元で検証できることは push 前に検証する」の項が §5.1（旧クラウド
+    サンドボックス）時代のまま `kubectl` 不使用と書かれていたが、§5.5（クラスタ内常駐）以降は
+    read-only kubectl が実際に使えると気づき、記述を実態に合わせて修正した
+- 次の起動へ: backlog の todo は T-0029（高リスク、vchord メジャー更新）のみ。着手する場合は
+  CHARTER §4「high を戻せる形に落とす」を厳格に適用し、1 PR 1 コンポーネントを厳守すること
+- ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化、`ops/validate.py` 0 error、
+  `ops/dashboard/build.py` 正常終了を確認。Artifact ツールがこの環境に無く re-publish はできなかった

--- a/ops/state.json
+++ b/ops/state.json
@@ -794,6 +794,40 @@
         246,
         247
       ]
+    },
+    {
+      "n": 73,
+      "at": "2026-08-05T22:19:00Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "T-0029 (immich postgres メジャー更新) 再着手前提の調査。ops-health-report が immich Degraded/immich-postgres CrashLoopBackOff を示していたが、これは直前の revert (PR #247) が ArgoCD に反映される過渡期の断面と kubectl で直接確認し、新規インシデントではないと判断。subagent に GHCR の実イメージ config を直接照合させ、cloudnative-vectorchord 16.10-1.0.0 以降が CloudNativePG operand 系イメージに切り替わり initdb ブートストラップが無いことを確定。T-0029 を blocked のまま、前提条件を T-0111 として起票した（記録は #249 で merge、manifest は今回変更なし）",
+      "prs": [
+        249
+      ]
+    },
+    {
+      "n": 74,
+      "at": "2026-08-05T22:32:00Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "T-0111 の DoD 候補 (a) に着手。immich-postgres の initdb ブートストラップを使い捨て PVC/Job で手動再現する apps/immich/postgres-bootstrap-verify-job.yaml を新設（PR #250）。CI green を確認したが、Job 実行結果の確認は次回起動に持ち越し、PR は open のまま終了",
+      "prs": [
+        250
+      ]
+    },
+    {
+      "n": 75,
+      "at": "2026-08-05T22:41:00Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "前回の中断: PR #250（T-0111, run #74 が open のまま終了）を拾い、CI green・issue #56 に新しい異議が無いことを確認して merge。issue #56 に新規フィードバックなし。検証 Job を実行→失敗→原因特定→修正PRの直列サイクルを4回繰り返し完遂: (1) unix socket ディレクトリ不足 (#251)、(2) Job.spec.template が immutable で ArgoCD sync が固まる問題を Force=true,Replace=true で解消 (#252、T-0108でも既出だった教訓をCHARTER §4に明記)、(3) PVC 再利用時に前回のPG_VERSION残存でテスト本体がスキップされる不具合を修正 (#253)、(4) createdb 実行条件の誤り（POSTGRES_USERと同名DBはinitdbが自動生成しない）を修正 (#254)。最終的にJobが成功（vchord_version=1.1.1）したことをkubectlで確認し、T-0111を done、検証用PVC/Jobを削除するPR（#255、allow-delete明記）をmerge・ArgoCD削除確認まで見届けた。T-0029のblocked_byを解除しtodoに戻した。副産物としてCHARTER §4の kubectl不使用の記述が§5.5移行後は古くなっていた点も修正",
+      "prs": [
+        251,
+        252,
+        253,
+        254,
+        255
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

run #73〜#75 の運用記録（journal / state.json / CHARTER）をまとめて記録する。

- `ops/state.json` の `runs` に run #73（T-0111 起票）・run #74（検証 Job 初版 PR #250）・
  run #75（4回の修正サイクルを経て検証成功、T-0111 done、T-0029 再開）を追記
- `ops/journal/2026-08.md` に run #74/#75 のエントリを追記
- `ops/CHARTER.md` §4 に、内容が変わりうる Job リソースには最初から
  `argocd.argoproj.io/sync-options: Force=true,Replace=true` を付けておくという教訓を追記
  （T-0108・T-0111 で2回独立に踏んだため）。あわせて「`kubectl` は使わない」という §5.1
  （旧クラウドサンドボックス）時代の記述が §5.5（クラスタ内常駐）移行後は古くなっていた点も修正
- `ops/dashboard/prs.json` を GitHub REST API で最新化（open 0 件・merged 60件）

コード（`apps/`）の変更は無い。運用記録のみ。

## 検証したこと

- `python3 ops/validate.py` — 0 error
- `python3 ops/dashboard/build.py` — 正常終了
- CI（`kustomize build` / `terraform validate` / `ops state validate`）は push 後に確認

## ロールバック手順

運用記録のみのため revert しても homelab の実インフラには影響しない。

## backlog task id

T-0111（記録のみ、`ops/backlog.json` 自体の変更は無し）

🤖 Generated with autopilot