### PR TITLE
feat(immich): postgres を16.14-1.1.1に上げinitdbブートストラップを組み込む (T-0029)

### DIFF
--- a/apps/immich/postgres.yaml
+++ b/apps/immich/postgres.yaml
@@ -44,9 +44,120 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data
+        - name: init-bootstrap
+          # 16.10-1.0.0 以降の cloudnative-vectorchord イメージは CloudNativePG operand
+          # 系（ENTRYPOINT 無し、CMD bash）に切り替わっており、docker-library postgres の
+          # docker-entrypoint.sh が同梱されず initdb ブートストラップ機能を持たない
+          # （T-0029 run #72: #244 で一度上げた際 immich-postgres が CrashLoopBackOff、
+          # #247 で revert。run #73 で GHCR の実イメージを確認し根本原因を確定）。
+          # この initContainer は docker-entrypoint.sh の初回起動時の挙動を手で再現し、
+          # PGDATA が空のとき（PVC 新規作成 = 災害復旧シナリオ）だけ initdb → createdb →
+          # shared_preload_libraries=vchord.so で再起動 → CREATE EXTENSION vchord まで行う。
+          # 既存の PGDATA（PG_VERSION が既にある = 通常運用時の再起動）には一切触れず即 exit 0
+          # で抜ける。手順自体は T-0111（run #75, #250-#254）で使い捨て PVC/Job を使い
+          # 実機検証済み（このイメージタグそのもので initdb_rc=0 boot_start_rc=0 start_rc=0
+          # extension_rc=0 まで確認済み）。
+          image: ghcr.io/tensorchord/cloudnative-vectorchord:16.14-1.1.1
+          command:
+            - bash
+            - -c
+            - |
+              set -u
+              if [ -s "$PGDATA/PG_VERSION" ]; then
+                echo "PGDATA already initialized, skip bootstrap" > /dev/termination-log
+                exit 0
+              fi
+
+              LOGFILE=/tmp/pg-bootstrap.log
+              : > "$LOGFILE"
+
+              initdb --username="$POSTGRES_USER" --pwfile=<(printf '%s\n' "$POSTGRES_PASSWORD") $POSTGRES_INITDB_ARGS -D "$PGDATA" >>"$LOGFILE" 2>&1
+              INITDB_RC=$?
+              if [ "$INITDB_RC" -ne 0 ]; then
+                echo "bootstrap failed: initdb_rc=$INITDB_RC $(tail -c 1000 "$LOGFILE" | tr '\n' ' ')" > /dev/termination-log
+                exit 1
+              fi
+
+              # docker-entrypoint.sh (未使用) が通常付与する TCP + パスワード認証の許可。
+              # initdb 直後の pg_hba.conf は socket の trust のみで、これを足さないと
+              # immich-server からの TCP 接続（Service 経由）が通らない。
+              echo "host all all all scram-sha-256" >> "$PGDATA/pg_hba.conf"
+
+              pg_ctl -D "$PGDATA" -o "-c listen_addresses='' -c unix_socket_directories=/tmp -p 5432" -w start >>"$LOGFILE" 2>&1
+              BOOT_START_RC=$?
+              if [ "$BOOT_START_RC" -ne 0 ]; then
+                echo "bootstrap failed: boot_start_rc=$BOOT_START_RC $(tail -c 1000 "$LOGFILE" | tr '\n' ' ')" > /dev/termination-log
+                exit 1
+              fi
+
+              # initdb が無条件で作るデータベースは postgres/template0/template1 のみで、
+              # POSTGRES_USER と同名でも自動では作られない（T-0111 run #75 で実測）。
+              CREATEDB_RC=0
+              if [ "$POSTGRES_DB" != "postgres" ]; then
+                createdb --username="$POSTGRES_USER" --host=/tmp "$POSTGRES_DB" >>"$LOGFILE" 2>&1
+                CREATEDB_RC=$?
+              fi
+              pg_ctl -D "$PGDATA" -w stop >>"$LOGFILE" 2>&1
+              if [ "$CREATEDB_RC" -ne 0 ]; then
+                echo "bootstrap failed: createdb_rc=$CREATEDB_RC $(tail -c 1000 "$LOGFILE" | tr '\n' ' ')" > /dev/termination-log
+                exit 1
+              fi
+
+              # vchord は shared_preload_libraries 有効化後の再起動を経てからでないと
+              # CREATE EXTENSION できない（docs.vectorchord.ai 確認済み、T-0111 で検証）。
+              pg_ctl -D "$PGDATA" -o "-c listen_addresses=* -c unix_socket_directories=/tmp -c shared_preload_libraries=vchord.so -p 5432" -w start >>"$LOGFILE" 2>&1
+              START_RC=$?
+              if [ "$START_RC" -ne 0 ]; then
+                echo "bootstrap failed: start_rc=$START_RC $(tail -c 1000 "$LOGFILE" | tr '\n' ' ')" > /dev/termination-log
+                exit 1
+              fi
+
+              PGPASSWORD="$POSTGRES_PASSWORD" psql -h 127.0.0.1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "CREATE EXTENSION IF NOT EXISTS vchord CASCADE;" >>"$LOGFILE" 2>&1
+              EXT_RC=$?
+              pg_ctl -D "$PGDATA" -w stop >>"$LOGFILE" 2>&1
+              if [ "$EXT_RC" -ne 0 ]; then
+                echo "bootstrap failed: extension_rc=$EXT_RC $(tail -c 1000 "$LOGFILE" | tr '\n' ' ')" > /dev/termination-log
+                exit 1
+              fi
+
+              echo "bootstrap succeeded" > /dev/termination-log
+              exit 0
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 26
+            runAsGroup: 999
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: POSTGRES_USER
+              value: immich
+            - name: POSTGRES_DB
+              value: immich
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: immich-postgres-credentials
+                  key: password
+            - name: POSTGRES_INITDB_ARGS
+              value: "--data-checksums"
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
       containers:
         - name: postgres
-          image: ghcr.io/tensorchord/cloudnative-vectorchord:16.9-0.4.3
+          image: ghcr.io/tensorchord/cloudnative-vectorchord:16.14-1.1.1
           # このイメージは CloudNativePG operand イメージ (postgres-containers)
           # を継承しており、ベースの Debian postgres ユーザー (UID/GID 999) に
           # usermod -u 26 postgres で UID のみ 26 に変更している (GID は 999 のまま)。
@@ -58,6 +169,12 @@ spec:
             allowPrivilegeEscalation: false
             seccompProfile:
               type: RuntimeDefault
+          # 16.10-1.0.0 以降このイメージに ENTRYPOINT が無く CMD は bash のため、
+          # postgres バイナリを明示しないと args の先頭 "-c" がコマンド名として解釈され
+          # 起動に失敗する（T-0029 run #72 で実際に踏んだ障害: CrashLoopBackOff,
+          # exec: "-c": executable file not found in $PATH）。
+          command:
+            - postgres
           args:
             - -c
             - shared_preload_libraries=vchord.so

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 112,
+  "next_id": 113,
   "updated": "2026-08-05T22:19:04Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
@@ -553,13 +553,13 @@
     {
       "id": "T-0029",
       "domain": "homelab",
-      "title": "immich の postgres (cloudnative-vectorchord) を 16.9-0.4.3 → 16.14-1.1.1 に上げる（vchord 拡張のメジャー更新）",
+      "title": "immich の postgres (cloudnative-vectorchord) を 16.9-0.4.3 → 16.14-1.1.1 に上げ、postgres.yaml に initdb ブートストラップ経路（PGDATA が空のときのみ動く initContainer）を組み込む",
       "kind": "upgrade",
       "risk": "high",
       "status": "todo",
       "priority": 21,
       "why": "T-0005 の調査 (run #6) で判明。postgres 本体は 16.9→16.14 の minor で問題ないが、vchord 拡張が 0.4.3→1.1.1 とメジャー相当の飛びで、ベクタ DB の実データに影響しうる（ops/inventory.json の policy=manual の理由）",
-      "dod": "vchord 0.4→1.x の互換性・移行手順を確認する。CHARTER §4『データを失いうる変更』の手順どおり、着手前に immich のバックアップが実際に存在し復元できることを確認する。ENTRYPOINT/CMD 差異は run #73 で根本原因を確定済み（下記 notes）。T-0111（run #75, #250-#254）で新規 PVC からの initdb ブートストラップ手順（initContainer 相当、unix_socket_directories=/tmp を明示 → createdb → shared_preload_libraries=vchord.so で再起動 → CREATE EXTENSION）を確立・検証済み。**再着手時は postgres.yaml 側にもこの手順（PGDATA が空のときだけ実行する initContainer 等）を組み込み、DR 経路が実際に機能する状態にしてから ALTER EXTENSION UPDATE/REINDEX の本題に進むこと**",
+      "dod": "T-0111（run #75, #250-#254）で使い捨て PVC/Job を使い実機検証した initdb ブートストラップ手順（unix_socket_directories=/tmp を明示 → createdb → shared_preload_libraries=vchord.so で再起動 → CREATE EXTENSION）を postgres.yaml 本体の initContainer として組み込む。PGDATA が既に存在する（PG_VERSION ファイルあり）場合は一切変更を加えず即 exit 0 で抜けること。あわせて main container に `command: [\"postgres\"]` を明示し、run #72 で踏んだ CrashLoopBackOff（ENTRYPOINT 無しのイメージで `-c` がコマンド名として解釈される）を再発させないこと。merge・ArgoCD sync 後、kubectl で immich-postgres Pod が Running/Ready になること、init-bootstrap initContainer が「PGDATA already initialized」で即終了していること（termination-log で確認）、immich アプリが Synced/Healthy のままであることを同一起動内で確認する。ALTER EXTENSION UPDATE / REINDEX（vchord 拡張の実データ移行）はこのタスクのスコープ外とし、別タスク（T-0112）に分離する。",
       "blocked_by": null,
       "refs": [
         "apps/immich/postgres.yaml",
@@ -567,7 +567,26 @@
       ],
       "created": "2026-08-04",
       "pr": null,
-      "notes": " | run #68: T-0071（restic 復元試験）が3コンポーネント全て完了したため blocked_by を解消し todo に戻した。メジャーバージョン更新であることに変わりはないため、着手時は CHARTER §4「high を戻せる形に落とす」（1 PR 1 コンポーネント、変更点を全部読む）を引き続き適用する。 | run #70: subagent に VectorChord 0.4.3→1.1.1 の release notes / immich 公式ドキュメント / immich PR #23845 を一次情報源で確認させた。ベアなイメージタグ差し替えだけでは不十分で、`ALTER EXTENSION vchord UPDATE;`（sql/upgrade/ の連鎖スクリプトを1コマンドで適用、immich公式も手動作業と明記）と、オンディスク形式が変わるインデックスの REINDEX が別途必要と判明。postgres.yaml の image タグ更新と同じ PR で `apps/immich/vchord-upgrade-job.yaml`（ALTER EXTENSION UPDATE→バージョン確認→vchord系インデックスを動的検出しREINDEX、接続リトライ付きで Deployment の Recreate ロールアウトと順序非依存に設計）を追加した。戻し方: ALTER EXTENSION UPDATE は単一トランザクションでアトミック、失敗時は image タグを16.9-0.4.3 に戻せば catalog と .so の整合が復元する。REINDEX 個別失敗はテーブル本体データに触れないため再実行で復旧可。T-0071 でバックアップ復元は確認済み。CI green を確認のうえ、high risk のため縛る変更同様に慎重を期し、Job の termination-log 結果を次回起動でkubectl get pod 経由で確認してから最終的に done とする。 | run #72: PR #244 の CI 6件全て green・mergeable_state: clean を確認し merge した（91243f1）。ArgoCD 同期後、**immich-postgres が CrashLoopBackOff に入った**（コンテナ起動自体が失敗: `exec: \"-c\": executable file not found in $PATH`、exitCode 128、runc create failed 段階のエラーで postgres バイナリは一度も実行されていない）。manifest は `command:` を指定せず `args: [-c, shared_preload_libraries=vchord.so]` のみを渡しており、16.9-0.4.3 では動いていたこの形が 16.14-1.1.1 の ENTRYPOINT では通らなくなっていた（CI の kustomize build はレンダリングされたマニフェストの構文しか見ておらず、コンテナが実際に起動するかは検証できない領域）。postgres バイナリが起動していないため ALTER EXTENSION UPDATE も REINDEX も未実行、ディスク上の拡張カタログ・データは 0.4.3 のまま無傷と判断し、image タグ・`vchord-upgrade-job.yaml`・`ops/inventory.json` を全て 16.9-0.4.3 側に revert する PR #247 を即座に出した（CHARTER §9「auto-merge した変更の後に不具合の兆候が出たら即ロールバック」）。次に着手するときは、まずこのイメージの Dockerfile/entrypoint スクリプトの実体を読み、`command:` を明示すべきかを事前に確認する。 | run #72 続き: PR #247 merge 後、ArgoCD 再同期を確認（sync revision a43b475）。immich-postgres が Running/Ready に復帰し、immich Application が Synced/Healthy に戻ったことを kubectl で直接確認した。障害発生（#244 merge）から復旧確認まで約25分。 | run #73: subagent に GHCR の実イメージ config（OCI manifest/config blob、changelog ではなく実際のビルド成果物）を直接確認させ、CrashLoopBackOff の根本原因を確定した。2025-11-12 のベースイメージ変更（`ghcr.io/cloudnative-pg/postgresql:$CNPG_TAG-bookworm` → `-system-bookworm`）を境に、`16.10-1.0.0` 以降（`16.14-1.1.1` を含む全タグ）は docker-library postgres（`ENTRYPOINT docker-entrypoint.sh`/`CMD postgres`）ではなく CloudNativePG operand 系イメージ（`cloudnative-pg/postgres-containers` の Dockerfile、`FROM debian:trixie-slim` 直系、ENTRYPOINT 無し・`CMD bash`）に切り替わっていた。`command: [\"postgres\"]` を明示すれば args の `-c shared_preload_libraries=...` は通る（PATH に `postgres` バイナリあり）が、**この系統のイメージには docker-entrypoint.sh 由来の initdb/createuser/createdb ブートストラップが一切無い**。既存の初期化済み PGDATA に対する in-place upgrade（今回の目的）には無関係だが、T-0071 で確立した復元手順（immich-library PVC 復元後、稼働中の immich-postgres へ psql でダンプ流し込み）は『新規 PVC 上で immich-postgres をどう初期化するか』を暗黙に docker-entrypoint.sh の自動 initdb に依存しており、この系統へ上げた後に PVC 消失（真の災害復旧）が起きると復元手順そのものが機能しなくなる。CHARTER §4「データを失いうる変更」の『戻せることを確かめる』は平常運用の revert だけでなく DR 経路も含むと判断し、T-0111（initdb 相当のブートストラップ経路を用意する）を新規起票し blocked に変更した。ops/inventory.json の note も同じ内容で更新した"
+      "notes": " | run #68: T-0071（restic 復元試験）が3コンポーネント全て完了したため blocked_by を解消し todo に戻した。メジャーバージョン更新であることに変わりはないため、着手時は CHARTER §4「high を戻せる形に落とす」（1 PR 1 コンポーネント、変更点を全部読む）を引き続き適用する。 | run #70: subagent に VectorChord 0.4.3→1.1.1 の release notes / immich 公式ドキュメント / immich PR #23845 を一次情報源で確認させた。ベアなイメージタグ差し替えだけでは不十分で、`ALTER EXTENSION vchord UPDATE;`（sql/upgrade/ の連鎖スクリプトを1コマンドで適用、immich公式も手動作業と明記）と、オンディスク形式が変わるインデックスの REINDEX が別途必要と判明。postgres.yaml の image タグ更新と同じ PR で `apps/immich/vchord-upgrade-job.yaml`（ALTER EXTENSION UPDATE→バージョン確認→vchord系インデックスを動的検出しREINDEX、接続リトライ付きで Deployment の Recreate ロールアウトと順序非依存に設計）を追加した。戻し方: ALTER EXTENSION UPDATE は単一トランザクションでアトミック、失敗時は image タグを16.9-0.4.3 に戻せば catalog と .so の整合が復元する。REINDEX 個別失敗はテーブル本体データに触れないため再実行で復旧可。T-0071 でバックアップ復元は確認済み。CI green を確認のうえ、high risk のため縛る変更同様に慎重を期し、Job の termination-log 結果を次回起動でkubectl get pod 経由で確認してから最終的に done とする。 | run #72: PR #244 の CI 6件全て green・mergeable_state: clean を確認し merge した（91243f1）。ArgoCD 同期後、**immich-postgres が CrashLoopBackOff に入った**（コンテナ起動自体が失敗: `exec: \"-c\": executable file not found in $PATH`、exitCode 128、runc create failed 段階のエラーで postgres バイナリは一度も実行されていない）。manifest は `command:` を指定せず `args: [-c, shared_preload_libraries=vchord.so]` のみを渡しており、16.9-0.4.3 では動いていたこの形が 16.14-1.1.1 の ENTRYPOINT では通らなくなっていた（CI の kustomize build はレンダリングされたマニフェストの構文しか見ておらず、コンテナが実際に起動するかは検証できない領域）。postgres バイナリが起動していないため ALTER EXTENSION UPDATE も REINDEX も未実行、ディスク上の拡張カタログ・データは 0.4.3 のまま無傷と判断し、image タグ・`vchord-upgrade-job.yaml`・`ops/inventory.json` を全て 16.9-0.4.3 側に revert する PR #247 を即座に出した（CHARTER §9「auto-merge した変更の後に不具合の兆候が出たら即ロールバック」）。次に着手するときは、まずこのイメージの Dockerfile/entrypoint スクリプトの実体を読み、`command:` を明示すべきかを事前に確認する。 | run #72 続き: PR #247 merge 後、ArgoCD 再同期を確認（sync revision a43b475）。immich-postgres が Running/Ready に復帰し、immich Application が Synced/Healthy に戻ったことを kubectl で直接確認した。障害発生（#244 merge）から復旧確認まで約25分。 | run #73: subagent に GHCR の実イメージ config（OCI manifest/config blob、changelog ではなく実際のビルド成果物）を直接確認させ、CrashLoopBackOff の根本原因を確定した。2025-11-12 のベースイメージ変更（`ghcr.io/cloudnative-pg/postgresql:$CNPG_TAG-bookworm` → `-system-bookworm`）を境に、`16.10-1.0.0` 以降（`16.14-1.1.1` を含む全タグ）は docker-library postgres（`ENTRYPOINT docker-entrypoint.sh`/`CMD postgres`）ではなく CloudNativePG operand 系イメージ（`cloudnative-pg/postgres-containers` の Dockerfile、`FROM debian:trixie-slim` 直系、ENTRYPOINT 無し・`CMD bash`）に切り替わっていた。`command: [\"postgres\"]` を明示すれば args の `-c shared_preload_libraries=...` は通る（PATH に `postgres` バイナリあり）が、**この系統のイメージには docker-entrypoint.sh 由来の initdb/createuser/createdb ブートストラップが一切無い**。既存の初期化済み PGDATA に対する in-place upgrade（今回の目的）には無関係だが、T-0071 で確立した復元手順（immich-library PVC 復元後、稼働中の immich-postgres へ psql でダンプ流し込み）は『新規 PVC 上で immich-postgres をどう初期化するか』を暗黙に docker-entrypoint.sh の自動 initdb に依存しており、この系統へ上げた後に PVC 消失（真の災害復旧）が起きると復元手順そのものが機能しなくなる。CHARTER §4「データを失いうる変更」の『戻せることを確かめる』は平常運用の revert だけでなく DR 経路も含むと判断し、T-0111（initdb 相当のブートストラップ経路を用意する）を新規起票し blocked に変更した。ops/inventory.json の note も同じ内容で更新した | run #76: DoD 通り postgres.yaml への組み込みのみを本タスクのスコープにした。ALTER EXTENSION UPDATE/REINDEX は新規タスク T-0112 に分離し blocked_by とした（1タスク1論点、前回 #244 の CrashLoopBackOff 事故の教訓を踏まえ、起動確認とデータ移行を同じ PR に混ぜない）。"
+    },
+    {
+      "id": "T-0112",
+      "domain": "homelab",
+      "title": "immich の vchord 拡張を ALTER EXTENSION UPDATE + REINDEX で 0.4.3 → 1.1.1 に移行する",
+      "kind": "upgrade",
+      "risk": "high",
+      "status": "blocked",
+      "priority": 21,
+      "why": "T-0029 で postgres 本体・イメージを 16.14-1.1.1 に上げた後、拡張バイナリは新しくなるがカタログ上の vchord は 0.4.3 のままで、実際にベクタ検索を使う経路（immich の類似画像検索等）が不整合になりうる。run #70 の調査で ALTER EXTENSION UPDATE と、オンディスク形式が変わるインデックスの REINDEX が別途必要と判明済み（immich公式ドキュメント・VectorChord release notes で確認、手動作業と明記）。",
+      "dod": "apps/immich/vchord-upgrade-job.yaml（run #70 で一度用意した設計: ALTER EXTENSION vchord UPDATE → バージョン確認 → vchord系インデックスを動的検出しREINDEX、接続リトライ付き）を T-0029 merge・immich-postgres Running 確認後に適用する。CI green を確認し、high risk のため Job の termination-log 結果を次回起動で kubectl 経由で確認してから done とする。失敗時のロールバック: ALTER EXTENSION UPDATE は単一トランザクションでアトミックなので失敗時は影響なし。REINDEX 個別失敗はテーブル本体データに触れないため再実行で復旧可能。万一 postgres 自体が起動しなくなった場合は image タグを 16.9-0.4.3 に戻す（T-0029 のロールバック手順を参照、ただし T-0029 が正常に完了していればこの手順で戻す必要は生じない想定）。",
+      "blocked_by": "T-0029",
+      "refs": [
+        "apps/immich/postgres.yaml",
+        "ops/inventory.json"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "T-0029 から分離（1タスク1論点。前回 #244/#247 の CrashLoopBackOff 事故で『起動確認』と『データ移行』を混ぜると切り分けが難しくなると学んだため、postgres.yaml の起動確認が済むまでこのタスクは着手しない）。"
     },
     {
       "id": "T-0030",

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -139,12 +139,12 @@
       "id": "immich-postgres",
       "kind": "image",
       "name": "cloudnative-vectorchord",
-      "current": "16.9-0.4.3",
+      "current": "16.14-1.1.1",
       "file": "apps/immich/postgres.yaml",
       "match": "vectorchord",
       "upstream": "github:tensorchord/VectorChord-images",
       "policy": "manual",
-      "note": "Immich のベクタ DB。データを持つため拡張のメジャー更新は自動追随せず、都度 CHARTER §4 の高リスク手順（バックアップ復元確認 + ALTER EXTENSION UPDATE/REINDEX を伴う専用 Job）を踏む（T-0029）。16.14-1.1.1 は #244 で一度 merge したが immich-postgres が CrashLoopBackOff（コンテナ起動時に `exec: \"-c\": executable file not found in $PATH`）になり #247 で revert した（run #72 続き）。run #73 で GHCR の実イメージ config を確認し根本原因を確定: 2025-11-12 のベースイメージ変更（`postgresql:$CNPG_TAG-bookworm` → `-system-bookworm`）で `16.10-1.0.0` 以降（`16.14-1.1.1` を含む）は docker-library 系 postgres（`ENTRYPOINT docker-entrypoint.sh` / `CMD postgres`）ではなく CloudNativePG operand 系イメージ（ENTRYPOINT 無し、`CMD bash`）に切り替わっており、`docker-entrypoint.sh` 自体が同梱されなくなった。`command: [\"postgres\"]` を明示すれば既存の初期化済み PGDATA に対する起動は通る見込みだが、**initdb によるブートストラップ機能が丸ごと無くなっている**ため、PVC を新規作成し直す（災害復旧）シナリオでは `postgres` コマンドだけでは空の PGDATA を初期化できず起動しない。T-0071 で確立した復元手順（immich-library PVC 復元後、稼働中の immich-postgres へ psql でダンプを流し込む）はこの『稼働中の postgres』を新規 PVC 上でどう用意するかに暗黙に依存しており、16.10-1.0.0 系以降ではこの前提が崩れる。T-0111（initdb 相当のブートストラップ経路を用意する）が解決してから再着手する T-0111（run #75, #250-#254）で initdb ブートストラップ経路（unix_socket_directories=/tmp を明示 → createdb → shared_preload_libraries=vchord.so で再起動 → CREATE EXTENSION）を使い捨て PVC/Job で検証・確立済み。T-0029 の blocked_by は解除したが、postgres.yaml 本体にこの手順を組み込むところまでは未実装"
+      "note": "Immich のベクタ DB。データを持つため拡張のメジャー更新は自動追随せず、都度 CHARTER §4 の高リスク手順（バックアップ復元確認 + ALTER EXTENSION UPDATE/REINDEX を伴う専用 Job）を踏む（T-0029/T-0112）。16.14-1.1.1 は #244 で一度 merge したが immich-postgres が CrashLoopBackOff（コンテナ起動時に `exec: \"-c\": executable file not found in $PATH`）になり #247 で revert した（run #72 続き）。run #73 で GHCR の実イメージ config を確認し根本原因を確定: 2025-11-12 のベースイメージ変更（`postgresql:$CNPG_TAG-bookworm` → `-system-bookworm`）で `16.10-1.0.0` 以降（`16.14-1.1.1` を含む）は docker-library 系 postgres（`ENTRYPOINT docker-entrypoint.sh` / `CMD postgres`）ではなく CloudNativePG operand 系イメージ（ENTRYPOINT 無し、`CMD bash`）に切り替わっており、`docker-entrypoint.sh` 自体が同梱されなくなった。T-0111（run #75, #250-#254）で initdb 相当のブートストラップ経路を使い捨て PVC/Job で検証・確立し、T-0029（run #76）で postgres.yaml 本体に「PGDATA が空のときのみ動く initContainer」として組み込み、image を 16.14-1.1.1 に上げ、main container に `command: [\"postgres\"]` を明示した（CrashLoopBackOff の再発防止）。ALTER EXTENSION UPDATE / REINDEX による実データの vchord 拡張移行は T-0112 として分離済み、未着手。"
     },
     {
       "id": "busybox",


### PR DESCRIPTION
## 変更点

immich の postgres (cloudnative-vectorchord) を `16.9-0.4.3` → `16.14-1.1.1` に上げ、`apps/immich/postgres.yaml` に initdb ブートストラップ経路を組み込みました（T-0029）。

- main container の image を `16.14-1.1.1` に更新し、`command: ["postgres"]` を明示しました。このイメージは 16.10-1.0.0 以降 CloudNativePG operand 系（ENTRYPOINT 無し、`CMD bash`）に切り替わっており、`command` を明示しないと `args` の `-c` がコマンド名として解釈されて起動に失敗します（前回 #244 merge 時に実際に CrashLoopBackOff、#247 で revert 済みの障害と同型）。
- `init-bootstrap` という initContainer を追加しました。**PGDATA が既に存在する場合（今回の本番環境がこれに該当）は何もせず即終了します。** PGDATA が空の場合（PVC を新規作成し直す災害復旧シナリオ）のみ、T-0111（#250-#254）で使い捨て PVC/Job を使い実機検証済みの手順（initdb → pg_hba.conf に TCP 認証を追記 → 一時起動 → createdb → `shared_preload_libraries=vchord.so` で再起動 → `CREATE EXTENSION vchord`）を実行します。このイメージ系統には docker-entrypoint.sh 由来の自動初期化が丸ごと無いため、この initContainer が無いと新規 PVC からは二度と起動できません。
- vchord 拡張のカタログ移行（`ALTER EXTENSION UPDATE` / `REINDEX`）は今回のスコープ外です。バイナリは新しくなりますが拡張カタログは 0.4.3 のままなので、実データのベクタ検索は別タスク T-0112（blocked_by: このタスク）で対応します。

## 検証したこと

- `python3 -c "import yaml; ...` で `apps/immich/postgres.yaml` の YAML 構文を確認（3ドキュメントとも正しくパースできる）。
- initContainer に埋め込んだシェルスクリプトを `bash -n` で構文チェック。
- `python3 ops/validate.py` で `ops/backlog.json` の整合性を確認（0 error）。
- ブートストラップ手順そのものは T-0111（#250-#254）で使い捨て PVC/Job を使い、この同じイメージタグ (`16.14-1.1.1`) で `initdb_rc=0 boot_start_rc=0 start_rc=0 extension_rc=0 vchord_version=1.1.1` まで実機検証済みです。
- merge・ArgoCD sync 後、この起動の中で `kubectl` を使い immich-postgres Pod が Running/Ready になること、init-bootstrap initContainer が既存データを検知して即終了していること（termination-log）、immich Application が Synced/Healthy のままであることを確認する予定です（この substrate は read-only kubectl が使えるため、次の起動を待たずに同一起動内で見届けられます）。

## ロールバック手順

- **コード**: このコミットを revert すれば image タグは `16.9-0.4.3` に戻り、`command`/initContainer の追加も無くなります。`16.9-0.4.3` は docker-entrypoint.sh を含む従来のイメージ系統なので、revert 後の起動は従来通り機能します。
- **データ**: 今回のスコープでは `ALTER EXTENSION UPDATE`/`REINDEX` を実行しないため、拡張カタログ・実データは 0.4.3 のまま変更されません。**revert してもスキーマ・拡張カタログは何も進んでいないため、データ不整合は生じません**（vchord のバージョン移行を伴う T-0112 とは異なり、このタスクはイメージと起動経路のみの変更です）。
- 万一 immich-postgres が起動しなくなった場合、CHARTER §9 の方針（auto-merge した変更の後に不具合の兆候が出たら即ロールバック）に従い、この起動内で即座に revert PR を出します。

## backlog task id

T-0029（分離した後続タスク: T-0112, blocked_by T-0029）
