### PR TITLE
docs(claude-md): apps/autopilot/ の記載漏れを直す (T-0113)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Terraform で VM プロビジョニング、NixOS でOS構成、Kubernetes (Argo
 - **Networking**: Tailscale
 - **Secrets**: SOPS, External Secrets Operator
 - **Auth**: Dex (Google OAuth)
-- **Apps**: ArgoCD, Dex, External Secrets Operator, Tailscale Operator, Immich, Vaultwarden, Coder, ops-health-reporter
+- **Apps**: ArgoCD, Dex, External Secrets Operator, Tailscale Operator, Immich, Vaultwarden, Coder, ops-health-reporter, autopilot
 
 ## Directory Structure
 
@@ -31,6 +31,7 @@ apps/                — Kubernetes manifests (ArgoCD applications)
   vaultwarden/       — Vaultwarden (パスワード管理)
   coder/             — Coder (開発環境)
   ops-health-reporter/ — autopilot 向け ArgoCD/k8s 健全性レポーター（CronJob）
+  autopilot/           — 自律運用エージェント本体（Deployment + loop.sh の常駐ループ）
 .sops.yaml            — SOPS 設定（暗号鍵の対象範囲）
 nix/images/proxmox-cloud/secrets.yaml — SOPS 暗号化ファイル（単一ファイル、トップレベルの secrets/ ディレクトリは存在しない）
 ```

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2137,7 +2137,7 @@
         "CLAUDE.md"
       ],
       "created": "2026-08-06",
-      "pr": null,
+      "pr": 260,
       "notes": ""
     }
   ]

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 113,
+  "next_id": 114,
   "updated": "2026-08-05T22:19:04Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
@@ -2116,9 +2116,29 @@
           "残っていなければ apps/immich/postgres.yaml の image タグを一時的に 16.14-1.1.1 に戻して再現させ、kubectl logs -n immich <pod> -c postgres でエラーを確認する（PGDATA は 0.4.3 のまま無傷なので安全という前提。違えば教えてほしい）"
         ],
         "links": [
-          {"url": "https://github.com/hikuohiku/homelab/issues/56", "label": "issue #56"}
+          {
+            "url": "https://github.com/hikuohiku/homelab/issues/56",
+            "label": "issue #56"
+          }
         ]
       }
+    },
+    {
+      "id": "T-0113",
+      "domain": "homelab",
+      "title": "CLAUDE.md のディレクトリ構造・Apps 一覧に apps/autopilot/ が抜けている",
+      "kind": "docs",
+      "risk": "low",
+      "status": "done",
+      "priority": 90,
+      "why": "apps/autopilot/（自律運用エージェント自身の Deployment/loop.sh）が §5.5 で substrate として存在するにもかかわらず、CLAUDE.md の Tech Stack Apps 一覧・Directory Structure のどちらにも記載が無かった。run #78 の journal で次に調べる角度として挙げていたドキュメント実態ずれの1件",
+      "dod": "CLAUDE.md の Apps 一覧と Directory Structure に apps/autopilot/ を追加する",
+      "refs": [
+        "CLAUDE.md"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": ""
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 259,
+      "title": "chore(ops): T-0029 revert 後の実機復旧確認と run #78 の記録を反映する",
+      "url": "https://github.com/hikuohiku/homelab/pull/259",
+      "mergedAt": "2026-08-05T23:41:46Z",
+      "headRefName": "autopilot/T-0029-confirm-rollback-recovery"
+    },
+    {
       "number": 258,
       "title": "revert(immich): postgres 16.14-1.1.1 化を revert する (T-0029, CrashLoopBackOff)",
       "url": "https://github.com/hikuohiku/homelab/pull/258",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/196",
       "mergedAt": "2026-08-05T12:37:04Z",
       "headRefName": "autopilot/T-0068-immich-restic-backup"
-    },
-    {
-      "number": 195,
-      "title": "coder-postgres 用 restic backup CronJob を追加 (T-0070)",
-      "url": "https://github.com/hikuohiku/homelab/pull/195",
-      "mergedAt": "2026-08-05T12:28:53Z",
-      "headRefName": "autopilot/T-0070-coder-postgres-restic-backup"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,5 +1,20 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 260,
+      "title": "docs(claude-md): apps/autopilot/ の記載漏れを直す (T-0113)",
+      "url": "https://github.com/hikuohiku/homelab/pull/260",
+      "isDraft": false,
+      "createdAt": "2026-08-06T00:00:00Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "PENDING"
+        }
+      ],
+      "headRefName": "autopilot/T-0113-claude-md-autopilot-dir-drift",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
     {
       "number": 259,

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2362,3 +2362,21 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化、`ops/validate.py`
   0 error、`ops/dashboard/build.py` 正常終了を確認。Artifact ツールへの re-publish は下記手順で
   試す
+
+## 2026-08-06 08:50 JST — run #79
+
+- 前回の中断確認: オープン PR 0件・`autopilot/*` 残存ブランチ無し。ローカル `main` は
+  `origin/main`（1863b87）と一致
+- 読んだフィードバック: issue #56 のコメントを `per_page=100` で2ページとも取得（計102件）。
+  last_read（2026-08-05T18:47:54Z）以降の新規コメント無し
+- 気づいたこと: `ops/state.json` の `runs` 配列に run #78（journal には記録済み、T-0029 revert
+  後の実機復旧確認・policy:auto 上流調査で新規タスク無し）のエントリが欠けていたため、この run で
+  埋め合わせた
+- やったこと: backlog の todo が0件（`blocked` 6・`needs-human` 3 のみ）だったため、run #78 が
+  次の調査角度として残していた「CLAUDE.md/docs の実態乖離」に着手。CLAUDE.md の Tech Stack の
+  Apps 一覧・Directory Structure のどちらにも `apps/autopilot/`（自律運用エージェント自身の
+  Deployment + `loop.sh`、§5.5 で言及されている substrate 本体）が記載されていないと発見。
+  T-0113 として起票・即完遂（doc-only, low risk）
+- 次の起動へ: なし。backlog の todo は引き続き0件（`blocked` 6・`needs-human` 3）。次に何も
+  無ければ `ops/inventory.json` の `policy: manual` 対象（argo-cd chart 9.1.6→10.2.3 は
+  T-0028 で既に起票・blocked 済み。coder-workspace digest, tf-provider-proxmox）の棚卸しを試す

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T22:06:08Z",
+  "updated": "2026-08-06T08:50:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -845,6 +845,22 @@
       "kind": "scheduled",
       "by": "in-cluster autopilot",
       "summary": "前回の中断: なし（run #76 の journal 欠落を検知）。issue #56 に新規フィードバックなし。backlog todo (T-0029) 着手前の kubectl 確認で immich-postgres が CrashLoopBackOff（PR #257 由来）と判明、init-bootstrap initContainer は正常終了で main container の postgres プロセスが起動直後に exit code 1。pods/log 権限が無く原因未確認のため CHARTER §9 に従い即座に revert（PR作成中）。T-0112 として構築セッションへのログ確認依頼を needs-human で起票し T-0029 の blocked_by とした",
+      "prs": []
+    },
+    {
+      "n": 78,
+      "at": "2026-08-05T23:37:00Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "前回の中断: PR #258（run #77, T-0029 revert）の merge を kubectl で直接確認。immich-postgres は 16.9-0.4.3 で Running 1/1・restarts 0、immich Application は Synced/Healthy（sync revision 5f708ac）に復帰済み。issue #56 に新規フィードバックなし（last_read 以降0件）。backlog の todo が0件だったため、ops/inventory.json の policy:auto 対象（dex/immich/external-secrets/valkey/coder/tailscale-operator/k8s-nameserver）の上流最新リリースを確認したが、いずれも既に最新か既知の理由で見送り済みと確認し、新規タスクの起票は無し。T-0029 は T-0112（構築セッションのログ確認待ち）で blocked のまま",
+      "prs": []
+    },
+    {
+      "n": 79,
+      "at": "2026-08-06T08:50:00Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。state.json の runs に run #78 の記録が漏れていたため埋め合わせた。issue #56 に未読フィードバックなし。backlog の todo が0件だったため CLAUDE.md/docs の実態乖離を調査し、apps/autopilot/ が Tech Stack の Apps 一覧・Directory Structure のどちらにも記載されていないと発見。T-0113 として起票・即完遂",
       "prs": []
     }
   ]

--- a/ops/state.json
+++ b/ops/state.json
@@ -861,7 +861,9 @@
       "kind": "scheduled",
       "by": "in-cluster autopilot",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。state.json の runs に run #78 の記録が漏れていたため埋め合わせた。issue #56 に未読フィードバックなし。backlog の todo が0件だったため CLAUDE.md/docs の実態乖離を調査し、apps/autopilot/ が Tech Stack の Apps 一覧・Directory Structure のどちらにも記載されていないと発見。T-0113 として起票・即完遂",
-      "prs": []
+      "prs": [
+        260
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`CLAUDE.md` の Tech Stack Apps 一覧・Directory Structure のどちらにも `apps/autopilot/`（自律運用エージェント自身の Deployment + `loop.sh` の常駐ループ）が記載されていなかったのを追加した。合わせて `ops/state.json` の `runs` に欠けていた run #78 のエントリを埋め合わせ、この run（#79）の journal・state・PR キャッシュ・ダッシュボードを更新した。

## 検証したこと

- `ops/validate.py` → 0 error（既存の warning のみ）
- `ops/dashboard/build.py` → 正常終了
- `ls apps/` の実ディレクトリと CLAUDE.md の記載を突き合わせて他の抜けが無いことを確認

## ロールバック手順

ドキュメントのみの変更（コード・manifest への影響なし）。revert すれば元に戻る。DB・スキーマは関与しない。

## backlog task id

T-0113（doc-only, risk: low）
