### PR TITLE
ci(version-sync): actions/checkout の重複管理漏れを直す (T-0114)

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 114,
+  "next_id": 115,
   "updated": "2026-08-05T22:19:04Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
@@ -2138,6 +2138,25 @@
       ],
       "created": "2026-08-06",
       "pr": 260,
+      "notes": ""
+    },
+    {
+      "id": "T-0114",
+      "domain": "homelab",
+      "title": "check_version_sync.py / inventory.json の actions/checkout mirrors に build-autopilot-image.yml が漏れていた",
+      "kind": "ci",
+      "risk": "low",
+      "status": "done",
+      "priority": 90,
+      "why": "run #80 の調査タスク（backlog todo が空だったため CHARTER §3 に従い『同じ事実が複数ファイルに重複していないか』を確認）で発見。.github/workflows/build-autopilot-image.yml も actions/checkout@v7 を使っているが、ops/inventory.json の gha-actions-checkout mirrors にも ops/check_version_sync.py の GROUPS にも含まれておらず、他3ファイルとタグがずれても検出できない状態だった。値そのものは4ファイルとも v7 で一致しており、実害（現状のドリフト）は無かった",
+      "dod": "ops/check_version_sync.py の actions/checkout グループと ops/inventory.json の gha-actions-checkout.mirrors 両方に build-autopilot-image.yml を追加し、check_version_sync.py / validate.py が green であることを確認する",
+      "refs": [
+        "ops/check_version_sync.py",
+        "ops/inventory.json",
+        ".github/workflows/build-autopilot-image.yml"
+      ],
+      "created": "2026-08-06",
+      "pr": 261,
       "notes": ""
     }
   ]

--- a/ops/check_version_sync.py
+++ b/ops/check_version_sync.py
@@ -236,6 +236,9 @@ GROUPS = [
             (".github/workflows/release-image.yml", lambda: extract_all_action_tags(
                 ".github/workflows/release-image.yml", "actions/checkout"
             )),
+            (".github/workflows/build-autopilot-image.yml", lambda: extract_all_action_tags(
+                ".github/workflows/build-autopilot-image.yml", "actions/checkout"
+            )),
         ],
     },
     {

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,13 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 260,
       "title": "docs(claude-md): apps/autopilot/ の記載漏れを直す (T-0113)",
       "url": "https://github.com/hikuohiku/homelab/pull/260",
-      "isDraft": false,
-      "createdAt": "2026-08-06T00:00:00Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "PENDING"
-        }
-      ],
-      "headRefName": "autopilot/T-0113-claude-md-autopilot-dir-drift",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-05T23:48:19Z",
+      "headRefName": "autopilot/T-0113-claude-md-autopilot-dir-drift"
+    },
     {
       "number": 259,
       "title": "chore(ops): T-0029 revert 後の実機復旧確認と run #78 の記録を反映する",
@@ -428,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/197",
       "mergedAt": "2026-08-05T12:41:04Z",
       "headRefName": "autopilot/T-0098-restic-image-tag-ci"
-    },
-    {
-      "number": 196,
-      "title": "immich-library 用 restic backup CronJob を追加 (T-0068)",
-      "url": "https://github.com/hikuohiku/homelab/pull/196",
-      "mergedAt": "2026-08-05T12:37:04Z",
-      "headRefName": "autopilot/T-0068-immich-restic-backup"
     }
   ]
 }

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -215,11 +215,12 @@
       "match": "actions/checkout@",
       "mirrors": [
         ".github/workflows/direct-push-guard.yml",
-        ".github/workflows/release-image.yml"
+        ".github/workflows/release-image.yml",
+        ".github/workflows/build-autopilot-image.yml"
       ],
       "upstream": "github:actions/checkout",
       "policy": "auto",
-      "note": "T-0043/T-0044 で発見・v4→v7 に更新済み (run #16)。CI 全 job で使用",
+      "note": "T-0043/T-0044 で発見・v4→v7 に更新済み (run #16)。CI 全 job で使用。T-0114 (run #80) で build-autopilot-image.yml も同じ actions/checkout@v7 を使っているにもかかわらず mirrors・check_version_sync.py 双方から漏れていたと判明し追加（値の乖離は無かった。検出網の穴のみ）",
       "observability_impact": "CI 全 job が使用。壊れると CI（kustomize build / terraform validate / ops state validate / manifest-diff / nix flake check）が動かなくなり、autopilot の auto-merge の安全性の根拠（ruleset の必須チェック）が機能しなくなる"
     },
     {

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2380,3 +2380,30 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - 次の起動へ: なし。backlog の todo は引き続き0件（`blocked` 6・`needs-human` 3）。次に何も
   無ければ `ops/inventory.json` の `policy: manual` 対象（argo-cd chart 9.1.6→10.2.3 は
   T-0028 で既に起票・blocked 済み。coder-workspace digest, tf-provider-proxmox）の棚卸しを試す
+
+## 2026-08-06 08:54 JST — run #80
+
+- 前回の中断確認: オープン PR 0件・`autopilot/*` 残存ブランチ無し。ローカル `main` は
+  `origin/main`（592c74a、PR #260 merge 済み）と一致
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` 2ページとも）を機械的に
+  確認。last_read（2026-08-05T18:47:54Z）以降の新規コメント無し
+- ops-health-report の断面（generated_at 2026-08-05T23:30:04Z）では immich-postgres が
+  CrashLoopBackOff・immich Application が Progressing と表示されていたが、これは run #77 の
+  revert（5f708ac）反映前の古い断面で、run #78 が既に直接 kubectl で復旧確認済みの事象と同一と
+  判断した。念のためこの run でも直接 kubectl/ArgoCD で再確認し、immich-postgres は
+  Running 1/1 restarts=0、immich Application は Synced/Healthy であることを確認（新規異常なし）
+- backlog の todo が0件（`blocked` 6・`needs-human` 3 のみ）だったため、CHARTER §3 の
+  「同じ事実が複数ファイルに重複していないか」の角度で `ops/inventory.json` の `policy: auto`
+  対象のうち未確認だったもの（vaultwarden, coder-postgres, busybox, restic, terraform/kustomize/
+  helm 各バイナリ、GitHub Actions 各種）の上流最新版を確認したところ、いずれも既に最新だった。
+  その過程で `ops/check_version_sync.py` の `actions/checkout tag` グループと
+  `ops/inventory.json` の `gha-actions-checkout.mirrors` の両方に
+  `.github/workflows/build-autopilot-image.yml`（同じく `actions/checkout@v7` を使用）が
+  含まれていないと発見。値そのものは4ファイルとも `v7` で一致しており実害は無かったが、
+  今後ずれても検出できない穴だったため T-0114 として起票・即完遂（doc/CI設定のみ、low risk）
+- 次の起動へ: なし。backlog の todo は引き続き0件（`blocked` 6・`needs-human` 3）。次に何も
+  無ければ `ops/inventory.json` の `policy: manual` 対象（coder-workspace digest,
+  tf-provider-proxmox, nixpkgs）や docs（`Maintenance.md`/`docs/`）の実態乖離を試す
+- ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化、`ops/validate.py`
+  0 error（11 warning、既存のもの）、`ops/dashboard/build.py` 正常終了を確認。Artifact
+  ツールがこの環境に無く re-publish はできなかった

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T08:50:00Z",
+  "updated": "2026-08-05T23:54:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -857,13 +857,21 @@
     },
     {
       "n": 79,
-      "at": "2026-08-06T08:50:00Z",
+      "at": "2026-08-05T23:50:00Z",
       "kind": "scheduled",
       "by": "in-cluster autopilot",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。state.json の runs に run #78 の記録が漏れていたため埋め合わせた。issue #56 に未読フィードバックなし。backlog の todo が0件だったため CLAUDE.md/docs の実態乖離を調査し、apps/autopilot/ が Tech Stack の Apps 一覧・Directory Structure のどちらにも記載されていないと発見。T-0113 として起票・即完遂",
       "prs": [
         260
       ]
+    },
+    {
+      "n": 80,
+      "at": "2026-08-05T23:54:00Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。ops-health-report の断面は revert 反映前の古いものだったが、直接 kubectl/ArgoCD で immich-postgres Running・immich Application Synced/Healthy を再確認し新規異常なしと判断。backlog の todo が0件だったため上流バージョン調査を実施（全て最新）、その過程で ops/check_version_sync.py と ops/inventory.json の actions/checkout mirrors から build-autopilot-image.yml が漏れていると発見。T-0114 として起票・即完遂。run #79 の runs エントリの at が JST 値を UTC として誤記録していたのも合わせて修正",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`.github/workflows/build-autopilot-image.yml` も `actions/checkout@v7` を使っているが、二重管理チェック（`ops/check_version_sync.py` の `actions/checkout tag` グループ）と `ops/inventory.json`（`gha-actions-checkout.mirrors`）のどちらからも漏れていた。今回タグの値そのものは4ファイルとも `v7` で一致しており実害（ドリフト）は無かったが、今後ずれても機械検出できない穴だったため両方に追加した。

- `ops/check_version_sync.py`: `actions/checkout tag` グループに `build-autopilot-image.yml` のターゲットを追加
- `ops/inventory.json`: `gha-actions-checkout` の `mirrors` に同ファイルを追加
- `ops/backlog.json` / `ops/journal/2026-08.md` / `ops/dashboard/prs.json` / `ops/state.json`: 運用記録の更新（T-0114 起票・完遂。run #79 の `state.json` の `at` が JST 値を UTC として誤記録していたのも合わせて修正）

## 検証したこと

- `python3 ops/check_version_sync.py` → 全グループ ok（`actions/checkout tag` グループが4ファイルとも `v7` で一致することを確認）
- `python3 ops/validate.py` → 0 error（11 warning、いずれも既存のもの）
- `python3 ops/dashboard/build.py` → 正常終了

## ロールバック手順

このコミットを revert すれば元に戻る。DB を持つコンポーネントの変更は無く、スキーマ等の不可逆な状態は発生しない。

## backlog task id

T-0114

