### PR TITLE
docs(backup): immich restore-verify Job の削除記述を過去形に直す (T-0115)

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -192,7 +192,7 @@ Git → ArgoCD 経由で apply し、`kubectl get pod`（`autopilot-reader` で�
 前回の残留状態（chown 済みディレクトリ等）が新たな権限エラーの原因になりうるため、
 restore 前のクリーンアップを常に入れる。
 
-検証専用の `immich-restore-verify` PVC/Job は確認が取れ次第、削除する PR を別途出す
+検証専用の `immich-restore-verify` PVC/Job は確認が取れたため削除した
 （このファイルの冒頭コメントに書いた運用どおり）。
 
 ### vaultwarden（完了、2026-08-06）

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 115,
-  "updated": "2026-08-05T22:19:04Z",
+  "next_id": 116,
+  "updated": "2026-08-06T00:05:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2157,6 +2157,23 @@
       ],
       "created": "2026-08-06",
       "pr": 261,
+      "notes": ""
+    },
+    {
+      "id": "T-0115",
+      "domain": "homelab",
+      "title": "docs/backup.md の immich restore-verify Job 削除記述が「削除する予定」のまま残っていた",
+      "kind": "docs",
+      "risk": "low",
+      "status": "done",
+      "priority": 90,
+      "why": "run #81 の調査タスク（backlog todo が空だったため CHARTER §3 に従いドキュメントの実態乖離を確認）で発見。T-0071 の immich 復元試験を記録した commit 229735e で `immich-restore-verify` PVC/Job 自体は既に同じ commit 内で削除済みだったが、docs/backup.md の文章は「確認が取れ次第、削除する PR を別途出す」という未来形のまま取り残されていた。vaultwarden/coder-postgres の節は正しく「削除した」と過去形で書かれており、immich の節だけ表現がずれていた",
+      "dod": "docs/backup.md の immich 節を vaultwarden/coder-postgres と同じ過去形（削除した）に揃える",
+      "refs": [
+        "docs/backup.md"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
       "notes": ""
     }
   ]

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2173,7 +2173,7 @@
         "docs/backup.md"
       ],
       "created": "2026-08-06",
-      "pr": null,
+      "pr": 262,
       "notes": ""
     }
   ]

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 261,
+      "title": "ci(version-sync): actions/checkout の重複管理漏れを直す (T-0114)",
+      "url": "https://github.com/hikuohiku/homelab/pull/261",
+      "mergedAt": "2026-08-05T23:56:56Z",
+      "headRefName": "autopilot/T-0114-checkout-sync-build-autopilot-image"
+    },
+    {
       "number": 260,
       "title": "docs(claude-md): apps/autopilot/ の記載漏れを直す (T-0113)",
       "url": "https://github.com/hikuohiku/homelab/pull/260",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/198",
       "mergedAt": "2026-08-05T12:49:06Z",
       "headRefName": "autopilot/T-0068-followup-verify-immich-backup-dump"
-    },
-    {
-      "number": 197,
-      "title": "restic/restic イメージタグの重複を check_version_sync.py の監視対象に追加 (T-0098)",
-      "url": "https://github.com/hikuohiku/homelab/pull/197",
-      "mergedAt": "2026-08-05T12:41:04Z",
-      "headRefName": "autopilot/T-0098-restic-image-tag-ci"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2407,3 +2407,22 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化、`ops/validate.py`
   0 error（11 warning、既存のもの）、`ops/dashboard/build.py` 正常終了を確認。Artifact
   ツールがこの環境に無く re-publish はできなかった
+
+## 2026-08-06 09:05 JST — run #81
+
+- 前回の中断確認: オープン PR 0件・`autopilot/*` 残存ブランチ無し。ローカル `main` は
+  `origin/main`（592c74a）と一致
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` で2ページとも）を
+  機械的に確認。last_read（2026-08-05T18:47:54Z）以降の新規コメント無し
+- ops-health-report（generated_at 2026-08-06T00:00:04Z）で Application 全件 Synced/Healthy、
+  pod_issues は常連の再起動カウントのみで新規異常なし、autopilot 自身の heartbeat（iteration
+  #27 実行中、#26 は exit_code 0）も正常と確認
+- backlog の todo が0件（`blocked` 6・`needs-human` 3）だったため、CHARTER §3 の
+  「ドキュメントが実態とずれていないか」の角度で docs/ を確認。docs/backup.md の immich
+  restore-verify Job の節が「確認が取れ次第、削除する PR を別途出す」という未来形のまま
+  残っていたが、実際は T-0071 の commit 229735e で同じ commit 内に既に削除済みだった
+  （vaultwarden/coder-postgres の節は正しく過去形）。T-0115 として起票・即完遂（docs のみ、
+  low risk）
+- 次の起動へ: なし。backlog の todo は引き続き0件（`blocked` 6・`needs-human` 3）。次に
+  何も無ければ `ops/inventory.json` の `policy: manual` 対象（coder-workspace digest,
+  tf-provider-proxmox, nixpkgs）の棚卸しを試す


### PR DESCRIPTION
## 変更点

`docs/backup.md` の immich restore-verify Job についての記述が、実態とずれていた。

T-0071（restic 復元試験）の immich 節を記録した commit `229735e` で、検証用の
`immich-restore-verify` PVC/Job は同じ commit 内で既に削除済みだったが、文章は
「確認が取れ次第、削除する PR を別途出す」という未来形のまま残っていた。同じファイル内の
vaultwarden/coder-postgres の節は「確認が取れたため削除した」と正しく過去形で書かれており、
immich の節だけ表現がずれていた。文言を過去形に揃えた。**設定・manifest の変更は無い。**

合わせて `ops/journal/2026-08.md`・`ops/backlog.json`（T-0115 起票・完了）・
`ops/dashboard/prs.json`（GitHub REST API から最新化）を更新した。

## 検証したこと

- `git log --diff-filter=D -- apps/immich/restic-restore-verify-job.yaml` で、当該 Job が
  commit `229735e`（今回文言を直した節と同じ commit）で削除されていることを確認
- `find apps -iname '*restore-verify*'` で現在のリポジトリに該当ファイルが存在しないことを確認
- `python3 ops/validate.py` → 0 error（12 warning、いずれも既存または今回の pr フィールド空
  警告で想定内）
- `python3 ops/dashboard/build.py` → 正常終了

## ロールバック手順

このコミットを revert すれば文言は元に戻る。manifest・スキーマの変更は無いため、revert に
伴うデータ不整合や副作用は無い。

## backlog task id

T-0115（doc-only, risk: low）