### PR TITLE
docs(backup): PBS 退役判断を記録し、stale blocked を解消 (T-0072)

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -287,6 +287,39 @@ Failed になっていないことを確認できれば実際に動作したと�
 
 PBS の現況確認自体が要るなら T-0072（PBS 退役判断）の中で必要な分だけ見る。
 
+## PBS 退役判断 (T-0072, 2026-08-06)
+
+T-0071（復元試験）が immich・vaultwarden・coder-postgres の3コンポーネント全てで完了し、
+いずれも数秒〜十数秒で復元できることを実測した（上記各節参照）。この結果と T-0065（IaC
+完全性の棚卸し）を突き合わせて判断する。
+
+**結論: 今はまだ PBS を退役しない。T-0078（coder workspace home PVC の backup）が
+実装されるまで維持する。**
+
+理由:
+
+- T-0065 が確定した実データを持つ対象は5つ（`immich-library` / `immich-postgres-data`
+  [immich 内蔵ダンプで代替] / `vaultwarden-data` / `coder-postgres-data` /
+  `coder-<workspace-id>-home`）。このうち restic ベースの backup CronJob が実装・復元試験
+  まで完了しているのは前者4つのみで、最後の1つ（コーダー workspace ごとの home PVC）は
+  T-0078 がまだ `blocked` のまま未実装
+- PBS が実際に node01 を対象にしたバックアップジョブを持っているか、workspace home の
+  データを（意図せずであれ）保護しているかは「わからないこと」節のとおり未確認のまま。
+  restic 側の代替が全データ対象に揃っていない状態で PBS を止めると、workspace home だけ
+  バックアップが無い期間が生まれるリスクがある（確認していないものを「無い」とみなして
+  安全側の判断をしない、CHARTER §4「high を戻せる形に落とす」と同じ理由）
+- node01 VM 自体（VM イメージ全体）は Terraform（`terraform/proxmox`）+ NixOS image が
+  完全に宣言的なため、VM 単位の復元は IaC の再適用で代替できる。PBS の VM 単位バックアップは
+  この観点では既に冗長。残る唯一の価値は「T-0078 が塞ぐまでの workspace home の暫定的な
+  保険」だけである
+
+**T-0078 が完了し、workspace home も restic で復元試験まで確認できたら、5対象すべてが
+アプリレベルの restic backup（復元 8〜16 秒、B2 の無料枠内）でカバーされる。その時点で
+PBS の VM 単位バックアップは完全に冗長になり、退役してよい。** この退役の実行手順は
+T-0116 として別途起票した（`blocked_by: T-0078`）。PBS VM 自体の停止・削除は Proxmox
+管理コンソールでの操作が要り、autopilot の Proxmox credential は PVEAuditor（読み取り専用）
+のため実行できない。人間の物理操作が要る点は T-0116 側で明記する。
+
 ## これに依存しているタスク
 
 - T-0029（immich postgres/vchord のメジャー更新、データを失いうる変更）・T-0023（coder

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1347,7 +1347,7 @@
         "terraform/proxmox/pbs.tf.ignore"
       ],
       "created": "2026-08-05",
-      "pr": null,
+      "pr": 263,
       "notes": "run #82: blocked_by（T-0071）が run #68 時点で既に done になっていたにも関わらず run #69〜#81 の間 blocked のまま放置されていたのに気づき着手。T-0065（IaC完全性の棚卸し）の実データ対象5つのうち、restic backup が復元試験まで完了しているのは4つ（immich/vaultwarden/coder-postgres 系）のみで、残る `coder-<workspace-id>-home`（T-0078）が未実装だったため、判断は『今は維持、T-0078 完了後に退役』とした（docs/backup.md『PBS 退役判断』節に記録）。退役の実行タスクは T-0116（blocked_by: T-0078）として分離起票。同じ run で T-0078 も blocked_by（T-0067）が既に done だったため todo に戻した"
     },
     {

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 116,
+  "next_id": 117,
   "updated": "2026-08-06T00:05:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
@@ -1337,17 +1337,18 @@
       "title": "PBS の退役を判断する",
       "kind": "investigate",
       "risk": "medium",
-      "status": "blocked",
+      "status": "done",
       "priority": 42,
       "why": "issue #56 (2026-08-05 04:40:59) の人間の新方針。構築セッションの調査は『PBS を残す 2 層構成』を推奨していたが、人間の方針は『PBS は必要以上に重い、軽くしたい』。人間の方針を優先する。T-0071 の復元試験が通れば restic 単層で要件は満たす（遅いだけ）。順序を守ること: 復元試験が通ってから判断する",
       "dod": "T-0071 の復元試験結果（成功可否・所要時間）を踏まえ、PBS の VM バックアップジョブ（terraform/proxmox/pbs.tf.ignore の手動管理分）を維持するか退役するかを判断し、記録する。退役する場合は手順を別途 PR にする",
-      "blocked_by": "T-0071（restic 復元試験が通ってから判断する）",
+      "blocked_by": null,
       "refs": [
         "docs/backup.md",
         "terraform/proxmox/pbs.tf.ignore"
       ],
       "created": "2026-08-05",
-      "pr": null
+      "pr": null,
+      "notes": "run #82: blocked_by（T-0071）が run #68 時点で既に done になっていたにも関わらず run #69〜#81 の間 blocked のまま放置されていたのに気づき着手。T-0065（IaC完全性の棚卸し）の実データ対象5つのうち、restic backup が復元試験まで完了しているのは4つ（immich/vaultwarden/coder-postgres 系）のみで、残る `coder-<workspace-id>-home`（T-0078）が未実装だったため、判断は『今は維持、T-0078 完了後に退役』とした（docs/backup.md『PBS 退役判断』節に記録）。退役の実行タスクは T-0116（blocked_by: T-0078）として分離起票。同じ run で T-0078 も blocked_by（T-0067）が既に done だったため todo に戻した"
     },
     {
       "id": "T-0073",
@@ -1436,17 +1437,18 @@
       "title": "Coder workspace ごとの home PVC (`coder-<workspace-id>-home`) 用の backup CronJob を追加する",
       "kind": "feature",
       "risk": "medium",
-      "status": "blocked",
+      "status": "todo",
       "priority": 40,
       "why": "T-0065（run #30）の調査で発見。`apps/coder/templates/personal/main.tf` が Coder の Terraform プロビジョナー経由で workspace 作成のたびに `coder-<workspace-id>-home` という PVC を動的作成しており（`/home/coder` にマウント、dotfiles・`ghq` clone・code-server 設定等のユーザーデータが載る）、これは `apps/coder/*.yaml` の静的マニフェストには現れないため T-0070（coder-postgres の backup）ではカバーされない。node01 揮発時に失われる実データの5つ目の対象",
       "dod": "workspace ごとに動的作成される `coder-<workspace-id>-home` PVC を列挙し（PVC 名は `coder-<workspace-id>-home` の命名規則で特定可能）、pg_dump 同様の考え方でファイルシステムスナップショット（tar もしくは直接 restic でファイルシステムを対象にする、DB とは異なりファイルなのでオンライン中でも整合性の問題は薄い）を restic で T-0067 の保存先へ push する CronJob を追加する。workspace は増減するため、対象 PVC の列挙は動的（`kubectl get pvc -l` 相当のラベルセレクタ、または命名パターンでのマッチ）にする",
-      "blocked_by": "T-0067（restic 保存先・credential）",
+      "blocked_by": null,
       "refs": [
         "apps/coder/templates/personal/main.tf",
         "docs/backup.md"
       ],
       "created": "2026-08-05",
-      "pr": null
+      "pr": null,
+      "notes": "run #82: blocked_by（T-0067）が run #53 時点で既に done になっていたにも関わらず放置されていたのに気づき todo に戻した（T-0072 の判断作業の副産物）"
     },
     {
       "id": "T-0079",
@@ -2175,6 +2177,25 @@
       "created": "2026-08-06",
       "pr": 262,
       "notes": ""
+    },
+    {
+      "id": "T-0116",
+      "domain": "homelab",
+      "title": "PBS VM (qemu/112) を退役する",
+      "kind": "chore",
+      "risk": "medium",
+      "status": "blocked",
+      "priority": 43,
+      "why": "T-0072（run #82）の判断: T-0065 が挙げた実データ5対象のうち、restic backup + 復元試験まで完了しているのは immich/vaultwarden/coder-postgres 系の4対象のみで、`coder-<workspace-id>-home`（T-0078）が未実装の間は PBS の VM 単位バックアップが唯一の（未確認だが）保険になっている。T-0078 が完了し、workspace home も復元試験まで確認できたら、node01 の全実データがアプリレベルの restic backup でカバーされ、PBS の VM 単位バックアップは完全に冗長になる（node01 VM 自体は Terraform+NixOS で宣言的に再現可能なため）",
+      "dod": "T-0078 が done になった後、(1) workspace home の restic backup が実際に成功し復元試験も通ることを確認する、(2) PBS 上に他に依存しているジョブ・データが無いか最終確認する、(3) `terraform/proxmox/pbs.tf.ignore` にこの記録を残しつつ PBS VM (qemu/112) の停止・削除手順を明記する。実際の VM 停止・削除は Proxmox 管理コンソールでの操作が要り、autopilot の Proxmox credential（PVEAuditor、読み取り専用）では実行できないため、この最終手順は needs-human として人間に引き継ぐ",
+      "blocked_by": "T-0078（coder workspace home PVC の backup 実装・復元試験）",
+      "refs": [
+        "docs/backup.md",
+        "terraform/proxmox/pbs.tf.ignore"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #82: T-0072（PBS 退役判断）から実行タスクとして分離起票"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 262,
+      "title": "docs(backup): immich restore-verify Job の削除記述を過去形に直す (T-0115)",
+      "url": "https://github.com/hikuohiku/homelab/pull/262",
+      "mergedAt": "2026-08-06T00:03:45Z",
+      "headRefName": "autopilot/T-0115-backup-doc-verify-job-stale"
+    },
+    {
       "number": 261,
       "title": "ci(version-sync): actions/checkout の重複管理漏れを直す (T-0114)",
       "url": "https://github.com/hikuohiku/homelab/pull/261",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/199",
       "mergedAt": "2026-08-05T13:41:09Z",
       "headRefName": "autopilot/T-0096-doc-just-recipe-check"
-    },
-    {
-      "number": 198,
-      "title": "immich 内蔵バックアップの実在検証を pvc-usage-reporter に追加 (T-0068 follow-up)",
-      "url": "https://github.com/hikuohiku/homelab/pull/198",
-      "mergedAt": "2026-08-05T12:49:06Z",
-      "headRefName": "autopilot/T-0068-followup-verify-immich-backup-dump"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2426,3 +2426,27 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - 次の起動へ: なし。backlog の todo は引き続き0件（`blocked` 6・`needs-human` 3）。次に
   何も無ければ `ops/inventory.json` の `policy: manual` 対象（coder-workspace digest,
   tf-provider-proxmox, nixpkgs）の棚卸しを試す
+
+## 2026-08-06 09:11 JST — run #82
+
+- 前回の中断確認: オープン PR 0件・`autopilot/*` 残存ブランチ無し。ローカル `main` は
+  `origin/main`（592c74a）と一致
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` で2ページとも）を
+  機械的に確認。last_read（2026-08-05T18:47:54Z）以降の新規コメント無し
+- ops-health-report（generated_at 2026-08-06T00:00:04Z）で Application 全件 Synced/Healthy、
+  pod_issues は常連の再起動カウントのみで新規異常なし、immich の backup_listing も最新
+  mtime が 2026-08-05T02:00:03Z（24時間以内）で正常、autopilot 自身の heartbeat（iteration
+  #26 exit_code 0、#27 開始直後）も正常と確認
+- やったこと: backlog の `blocked`/`needs-human` を「タスク全体ではなくどの部分か」の観点
+  （CHARTER §3）で洗い直したところ、T-0072（PBS 退役判断）の `blocked_by`（T-0071）が
+  run #68 時点で既に `done` になっていたにも関わらず run #69〜#81 の間 blocked のまま
+  放置されていたと判明。同様に T-0078（coder workspace home PVC backup）の `blocked_by`
+  （T-0067）も run #53 時点で既に done だったのに放置されていた。T-0072 に着手し、
+  T-0071 の復元試験結果（immich/vaultwarden/coder-postgres いずれも8〜16秒で復元成功）と
+  T-0065（IaC完全性の棚卸し）を突き合わせて判断: 実データ5対象のうち4つは restic backup +
+  復元試験まで完了しているが、残る `coder-<workspace-id>-home`（T-0078）が未実装のため、
+  **今は PBS を維持し、T-0078 完了後に退役する**という条件付き判断を下した
+  （docs/backup.md『PBS 退役判断』節に記録）。T-0072 を done、T-0078 を todo に戻し、
+  退役の実行タスクを T-0116（blocked_by: T-0078、実VM停止はneeds-human見込み）として分離起票
+- 次の起動へ: backlog の todo に T-0078（coder workspace home PVC backup）が乗った。
+  次の起動はこれに着手してよい。T-0116 は T-0078 完了まで着手しない

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-05T23:54:00Z",
+  "updated": "2026-08-06T00:11:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -871,6 +871,24 @@
       "kind": "scheduled",
       "by": "in-cluster autopilot",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。ops-health-report の断面は revert 反映前の古いものだったが、直接 kubectl/ArgoCD で immich-postgres Running・immich Application Synced/Healthy を再確認し新規異常なしと判断。backlog の todo が0件だったため上流バージョン調査を実施（全て最新）、その過程で ops/check_version_sync.py と ops/inventory.json の actions/checkout mirrors から build-autopilot-image.yml が漏れていると発見。T-0114 として起票・即完遂。run #79 の runs エントリの at が JST 値を UTC として誤記録していたのも合わせて修正",
+      "prs": []
+    },
+    {
+      "n": 81,
+      "at": "2026-08-06T00:05:00Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。ops-health-report で Application 全件 Synced/Healthy・新規異常なしと確認。backlog の todo が0件だったため docs/ の実態乖離を確認し、docs/backup.md の immich restore-verify Job 削除記述が未来形のまま残っていたと発見。T-0115 として起票・即完遂",
+      "prs": [
+        262
+      ]
+    },
+    {
+      "n": 82,
+      "at": "2026-08-06T00:11:00Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。ops-health-report で新規異常なし、immich backup_listing も直近24時間以内で正常。backlog の blocked/needs-human をタスク単位ではなく部分単位で洗い直し、T-0072（PBS退役判断）・T-0078（coder workspace home backup）の blocked_by がそれぞれ run #68・#53 時点で解消済みなのに放置されていたと発見。T-0072 に着手し『今は PBS を維持、T-0078 完了後に退役』と判断（docs/backup.md に記録）、T-0078 を todo に戻し、退役実行タスク T-0116（blocked_by: T-0078）を分離起票",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

T-0072（PBS 退役の判断）に着手し、T-0071 の復元試験結果を踏まえて判断した。

**結論: 今は PBS を退役しない。** coder workspace home PVC（`coder-<workspace-id>-home`）の backup（T-0078）がまだ未実装で、実データ5対象のうち4対象（immich/vaultwarden/coder-postgres系）しか restic backup + 復元試験が完了していないため。T-0078 が完了し workspace home も復元試験まで確認できたら、node01 の全実データがアプリレベルの restic backup でカバーされ、PBS の VM 単位バックアップ（node01 VM 自体は Terraform+NixOS で宣言的に再現可能）は完全に冗長になる。

判断の詳細は `docs/backup.md` の「PBS 退役判断」節に記録した。

併せて、backlog の stale な blocked 状態を修正した:

- **T-0072**: blocked_by（T-0071）が run #68 時点で既に done だったのに、run #69〜#81 の間 blocked のまま放置されていた。今回 done にした
- **T-0078**（coder workspace home backup）: blocked_by（T-0067）が run #53 時点で既に done だったのに放置されていた。todo に戻し、次の起動で着手できるようにした
- **T-0116**（新規）: PBS 退役の実行タスクを分離起票。blocked_by: T-0078。実際の VM 停止・削除は Proxmox 管理コンソールでの操作が要り、autopilot の Proxmox credential（PVEAuditor、読み取り専用）では実行できないため、最終ステップは人間への引き継ぎ（needs-human）を予定している

## 検証したこと

- `python3 ops/validate.py` で 0 error（11 warning、うち T-0072 分は既存パターンと同型で新規ではない）
- `ops-health-report`（generated_at 2026-08-06T00:00:04Z）で ArgoCD Application 全件 Synced/Healthy、新規異常なしを確認済み
- リポジトリ内のドキュメント・backlog 変更のみ（アプリの manifest やインフラ設定には触れていない）

## ロールバック手順

この PR は `docs/backup.md`・`ops/backlog.json`・`ops/journal/`・`ops/state.json` のみの変更で、実インフラ・アプリには一切触れていない。revert すれば完全に元に戻る（データ・スキーマへの影響なし）。

## backlog task id

T-0072（done）、副産物として T-0078（blocked→todo）、T-0116（新規起票）
