### PR TITLE
feat(coder): workspace home PVC 用の restic backup CronJob を追加 (T-0078)

### DIFF
--- a/apps/coder/kustomization.yaml
+++ b/apps/coder/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - pvc-usage-cronjob.yaml
   - restic-external-secret.yaml
   - restic-backup-cronjob.yaml
+  - workspace-home-backup-cronjob.yaml

--- a/apps/coder/workspace-home-backup-cronjob.yaml
+++ b/apps/coder/workspace-home-backup-cronjob.yaml
@@ -1,0 +1,394 @@
+# Coder workspace ごとに動的作成される `coder-<workspace-id>-home` PVC
+# (`apps/coder/templates/personal/main.tf` の kubernetes_persistent_volume_claim_v1.home 参照。
+# /home/coder にマウント、dotfiles・ghq clone・code-server 設定等) を restic で
+# Backblaze B2 へバックアップする (T-0078)。docs/backup.md 参照。
+#
+# workspace は増減するため対象 PVC を静的にマニフェストへ書けない。この CronJob は
+# オーケストレータ役の Pod 1 個（python:3.12-alpine、標準ライブラリのみ）が
+# `app.kubernetes.io/name=coder-pvc` ラベルで対象 PVC を毎回列挙し、PVC ごとに
+# 使い捨ての Job（restic/restic イメージ、対象 PVC のみを readOnly マウント）を
+# Kubernetes API 経由で生成する。生成された Job は ttlSecondsAfterFinished で自動 GC
+# されるため、このオーケストレータ自身は Job の削除権限を持たない（作成のみ）。
+#
+# credential は既存の coder-postgres 用 (T-0070, `coder-restic-credentials`) をそのまま流用する。
+# 同じ Backblaze B2 バケット・同じ暗号化パスワードで、リポジトリパス末尾のみ
+# "coder-workspace-homes" に変える設計（vaultwarden/immich/coder-postgres と同型）。
+# 新規の Doppler 登録は不要
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: workspace-home-backup
+  namespace: coder
+---
+# 付与範囲は coder namespace 内、かつ read は PVC の一覧のみ・write は Job の作成のみに絞る。
+# Job が起動する Pod（restic-backup コンテナ）自体はこの ServiceAccount を使わず default を使う
+# （Kubernetes API への到達権限は不要なため、automountServiceAccountToken: false と合わせて
+# トークンそのものを持たせない）
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: workspace-home-backup
+  namespace: coder
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: workspace-home-backup
+  namespace: coder
+subjects:
+  - kind: ServiceAccount
+    name: workspace-home-backup
+    namespace: coder
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: workspace-home-backup
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workspace-home-backup-script
+  namespace: coder
+data:
+  spawn_backup_jobs.py: |
+    """coder-<workspace-id>-home PVC ごとに使い捨ての restic backup Job を作る。
+
+    対象 PVC は app.kubernetes.io/name=coder-pvc ラベルで列挙する（ラベルの由来:
+    apps/coder/templates/personal/main.tf の kubernetes_persistent_volume_claim_v1.home）。
+    生成した Job は ttlSecondsAfterFinished で自動 GC されるため、このオーケストレータは
+    Job の削除権限を持たない（作成のみ）。
+    """
+
+    import json
+    import os
+    import ssl
+    import time
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    SA_DIR = "/var/run/secrets/kubernetes.io/serviceaccount"
+    K8S_HOST = os.environ.get("KUBERNETES_SERVICE_HOST", "kubernetes.default.svc")
+    K8S_PORT = os.environ.get("KUBERNETES_SERVICE_PORT", "443")
+    K8S_BASE = "https://{}:{}".format(K8S_HOST, K8S_PORT)
+
+    with open(os.path.join(SA_DIR, "namespace")) as f:
+        NAMESPACE = f.read().strip()
+    with open(os.path.join(SA_DIR, "token")) as f:
+        SA_TOKEN = f.read().strip()
+    SSL_CTX = ssl.create_default_context(cafile=os.path.join(SA_DIR, "ca.crt"))
+
+    # 下の coder-workspace-home-backup-retention CronJob と同じ restic イメージタグに揃える。
+    # ops/check_version_sync.py の GROUP "restic/restic backup CronJob image tag" が検証している
+    # 値は下の retention CronJob 側の image 行（この定数はそこから見た二重管理側なので、
+    # タグを上げるときは両方を揃えて直す）。regex ベースの検証（`image: ` + タグ の連続文字列を
+    # 探す）を誤爆させないよう、リポジトリ名とタグをここでは分けて持つ
+    RESTIC_IMAGE_REPO = "restic/restic"
+    RESTIC_IMAGE_TAG = "0.19.1"
+    RESTIC_IMAGE = RESTIC_IMAGE_REPO + ":" + RESTIC_IMAGE_TAG
+
+    # vaultwarden/immich/coder-postgres の restic backup コンテナと同じ最小権限。
+    # readOnly マウントを DAC_READ_SEARCH のみで読む。書き込み権限は持たせない
+    RESTIC_SECURITY_CONTEXT = {
+        "runAsUser": 0,
+        "allowPrivilegeEscalation": False,
+        "capabilities": {"drop": ["ALL"], "add": ["DAC_READ_SEARCH"]},
+    }
+
+    # T-0108 の教訓（DeadlineExceeded で残った stale lock が以降の実行を恒久的に失敗させた）を
+    # 踏まえ、backup 実行前に restic unlock を先頭に入れる
+    RESTIC_BACKUP_SCRIPT = (
+        "set -eu\n"
+        "restic snapshots >/dev/null 2>&1 || restic init\n"
+        "restic unlock\n"
+        'restic backup /staging --host "$WORKSPACE_ID" '
+        '--tag workspace-id="$WORKSPACE_ID" --tag workspace-name="$WORKSPACE_NAME"\n'
+    )
+
+
+    def k8s_request(method, path, body=None):
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(
+            K8S_BASE + path,
+            data=data,
+            method=method,
+            headers={
+                "Authorization": "Bearer " + SA_TOKEN,
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, context=SSL_CTX, timeout=15) as resp:
+                raw = resp.read()
+                return resp.status, (json.loads(raw) if raw else None)
+        except urllib.error.HTTPError as e:
+            raw = e.read()
+            return e.code, (json.loads(raw) if raw else None)
+
+
+    def list_workspace_home_pvcs():
+        selector = urllib.parse.quote("app.kubernetes.io/name=coder-pvc", safe="=")
+        path = "/api/v1/namespaces/{}/persistentvolumeclaims?labelSelector={}".format(
+            NAMESPACE, selector
+        )
+        status, resp = k8s_request("GET", path)
+        if status != 200:
+            raise RuntimeError("PVC 一覧の取得に失敗: {} {}".format(status, resp))
+        out = []
+        for item in resp.get("items", []):
+            labels = item["metadata"].get("labels", {})
+            workspace_id = labels.get("com.coder.workspace.id")
+            if not workspace_id:
+                # ラベル欠落は想定外だが、他 workspace の backup を止めないためスキップのみ
+                print("workspace id ラベルが無い PVC をスキップ: {}".format(item["metadata"]["name"]))
+                continue
+            out.append({
+                "pvc_name": item["metadata"]["name"],
+                "workspace_id": workspace_id,
+                "workspace_name": labels.get("com.coder.workspace.name", "unknown"),
+            })
+        return out
+
+
+    def build_job(pvc_name, workspace_id, workspace_name):
+        job_name = "chb-{}".format(workspace_id)
+        return {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "metadata": {
+                "name": job_name,
+                "namespace": NAMESPACE,
+                "labels": {
+                    "app.kubernetes.io/name": "coder-workspace-home-backup",
+                    "com.coder.workspace.id": workspace_id,
+                },
+            },
+            "spec": {
+                "backoffLimit": 1,
+                "activeDeadlineSeconds": 3600,
+                "ttlSecondsAfterFinished": 3600,
+                "template": {
+                    "metadata": {
+                        "labels": {"app.kubernetes.io/name": "coder-workspace-home-backup"}
+                    },
+                    "spec": {
+                        "automountServiceAccountToken": False,
+                        "restartPolicy": "Never",
+                        "containers": [{
+                            "name": "restic-backup",
+                            "image": RESTIC_IMAGE,
+                            "command": ["sh", "-c", RESTIC_BACKUP_SCRIPT],
+                            "env": [
+                                {"name": "WORKSPACE_ID", "value": workspace_id},
+                                {"name": "WORKSPACE_NAME", "value": workspace_name},
+                                {
+                                    "name": "RESTIC_B2_BUCKET",
+                                    "valueFrom": {"secretKeyRef": {
+                                        "name": "coder-restic-credentials",
+                                        "key": "RESTIC_B2_BUCKET",
+                                    }},
+                                },
+                                # bucket 名の後ろの "coder-workspace-homes" がリポジトリパスの
+                                # 区切り。coder-postgres (T-0070) と同じ credential・別パスで共有
+                                {
+                                    "name": "RESTIC_REPOSITORY",
+                                    "value": "b2:$(RESTIC_B2_BUCKET):coder-workspace-homes",
+                                },
+                                {
+                                    "name": "RESTIC_PASSWORD",
+                                    "valueFrom": {"secretKeyRef": {
+                                        "name": "coder-restic-credentials",
+                                        "key": "RESTIC_PASSWORD",
+                                    }},
+                                },
+                                {
+                                    "name": "B2_ACCOUNT_ID",
+                                    "valueFrom": {"secretKeyRef": {
+                                        "name": "coder-restic-credentials",
+                                        "key": "B2_ACCOUNT_ID",
+                                    }},
+                                },
+                                {
+                                    "name": "B2_ACCOUNT_KEY",
+                                    "valueFrom": {"secretKeyRef": {
+                                        "name": "coder-restic-credentials",
+                                        "key": "B2_ACCOUNT_KEY",
+                                    }},
+                                },
+                            ],
+                            "securityContext": RESTIC_SECURITY_CONTEXT,
+                            # coder-postgres の restic-backup コンテナ (apps/coder/restic-backup-cronjob.yaml)
+                            # と同じ値をそのまま流用（同種のワークロード、既にレビュー済みの値）
+                            "resources": {
+                                "requests": {"cpu": "50m", "memory": "128Mi"},
+                                "limits": {"cpu": "500m"},
+                            },
+                            "volumeMounts": [{
+                                "name": "home", "mountPath": "/staging", "readOnly": True
+                            }],
+                        }],
+                        "volumes": [{
+                            "name": "home",
+                            "persistentVolumeClaim": {"claimName": pvc_name, "readOnly": True},
+                        }],
+                    },
+                },
+            },
+        }
+
+
+    def create_job(job):
+        path = "/apis/batch/v1/namespaces/{}/jobs".format(NAMESPACE)
+        status, resp = k8s_request("POST", path, job)
+        name = job["metadata"]["name"]
+        if status == 201:
+            print("Job 作成: {}".format(name))
+        elif status == 409:
+            # 前回分がまだ ttlSecondsAfterFinished (1h) で GC されていないだけ。
+            # 翌日の実行を待てば自然に解消するためエラーにしない
+            print("Job {} は既に存在（前回分が GC 待ち）、スキップ".format(name))
+        else:
+            raise RuntimeError("Job {} の作成に失敗: {} {}".format(name, status, resp))
+
+
+    def main():
+        pvcs = list_workspace_home_pvcs()
+        if not pvcs:
+            print("対象の workspace home PVC が無い（workspace 0件）。何もしない")
+            return
+        for i, pvc in enumerate(pvcs):
+            if i > 0:
+                # 同一 restic リポジトリへの同時書き込みによるロック競合を避けるための間隔。
+                # 個人利用規模（workspace 数が少ない）を前提にした簡易な直列化
+                time.sleep(20)
+            job = build_job(pvc["pvc_name"], pvc["workspace_id"], pvc["workspace_name"])
+            create_job(job)
+        print("{} 件の workspace home PVC に backup Job を作成した".format(len(pvcs)))
+
+
+    if __name__ == "__main__":
+        main()
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: coder-workspace-home-backup
+  namespace: coder
+spec:
+  # coder-restic-backup (03:10 UTC) の後、余裕を持って開始
+  schedule: "30 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      # workspace 数に応じて子 Job の作成に time.sleep(20) 間隔がかかる。このオーケストレータ
+      # 自身は Job の作成のみで完了を待たないため通常は数秒〜数分で終わる想定（未実測）
+      activeDeadlineSeconds: 900
+      template:
+        spec:
+          serviceAccountName: workspace-home-backup
+          restartPolicy: Never
+          containers:
+            - name: spawn-backup-jobs
+              image: python:3.12-alpine
+              command: ["python", "/scripts/spawn_backup_jobs.py"]
+              env:
+                - name: PYTHONDONTWRITEBYTECODE
+                  value: "1"
+              # K8s API 呼び出しのみで PVC の実データには触れないため root 昇格は不要
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              # 実測なしの緩い安全弁（pvc-usage-reporter と同クラス、CHARTER §4 「縛る変更には
+              # 実測か裏付けが要る」対象）。デプロイ後に kubectl top / ops-health-report の
+              # pod_metrics で実測し、必要なら調整する（T-0078 のフォローアップとして起票）
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 300m
+                  memory: 128Mi
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+                  readOnly: true
+          volumes:
+            - name: script
+              configMap:
+                name: workspace-home-backup-script
+---
+# 週次で古い世代を刈る。workspace ごとに restic --host <workspace-id> でタグ付けしているため、
+# --group-by host でホスト単位に世代管理する。workspace が削除されても、そのホストの
+# スナップショットは keep-* の世代分だけ残り続けたのち自然に切り捨てられる（明示的な削除はしない）
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: coder-workspace-home-backup-retention
+  namespace: coder
+spec:
+  schedule: "30 4 * * 0"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 1800
+      template:
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          containers:
+            - name: restic-forget
+              image: restic/restic:0.19.1
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  restic snapshots >/dev/null 2>&1 || { echo "repository not initialized yet, skipping"; exit 0; }
+                  restic forget --group-by host --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --prune
+              env:
+                - name: RESTIC_B2_BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      name: coder-restic-credentials
+                      key: RESTIC_B2_BUCKET
+                - name: RESTIC_REPOSITORY
+                  value: "b2:$(RESTIC_B2_BUCKET):coder-workspace-homes"
+                - name: RESTIC_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: coder-restic-credentials
+                      key: RESTIC_PASSWORD
+                - name: B2_ACCOUNT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: coder-restic-credentials
+                      key: B2_ACCOUNT_ID
+                - name: B2_ACCOUNT_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: coder-restic-credentials
+                      key: B2_ACCOUNT_KEY
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -41,7 +41,7 @@ issue #56 (2026-08-05 04:40:59) で人間から新方針: **PBS は重すぎる�
 | `immich-postgres-data` | immich アセットメタデータ・CLIP埋め込み | T-0068 の immich 内蔵日次DBダンプ（`immich-library` 内）で代替。生 PVC 自体のバックアップは対象外 |
 | `vaultwarden-data` | パスワードマネージャ本体（SQLite） | T-0069 |
 | `coder-postgres-data` | Coder 制御プレーン（ユーザー・workspace・監査ログ） | T-0070（実装済み・credential 登録待ち） |
-| `coder-<workspace-id>-home`（動的作成、`apps/coder/templates/personal/main.tf`） | workspace ごとの `/home/coder`（dotfiles・ghq clone 等） | **未起票**。T-0070 の対象外（別 PVC 群）のため、別途タスク化が必要 |
+| `coder-<workspace-id>-home`（動的作成、`apps/coder/templates/personal/main.tf`） | workspace ごとの `/home/coder`（dotfiles・ghq clone 等） | T-0078（実装済み・cooldown中、credential 登録不要） |
 
 ## 実サイズの実測 (T-0066, run #50)
 
@@ -146,6 +146,38 @@ PostgreSQL 向けに適用したもの。
 - **復元時の注意**: `pg_restore` で復元する前に coder-postgres の既存データをクリアするか
   新規 DB に復元してから切り替えること。`coder server` は起動時に DB migration を自動適用する
   ため、リストア後に起動する `coder` のバージョンと migration の整合を確認する
+
+## coder workspace home の restic バックアップ (T-0078, 実装済み・cooldown中)
+
+`apps/coder/workspace-home-backup-cronjob.yaml` に実装した。他3コンポーネント（immich/
+vaultwarden/coder-postgres）と異なり、対象 PVC (`coder-<workspace-id>-home`) は workspace の
+作成・削除のたびに動的に増減するため、静的なマニフェストには書けない。
+
+- **オーケストレータ方式**: `coder-workspace-home-backup` CronJob（毎日 03:30 UTC）が
+  python:3.12-alpine の Pod 1個を起動し、`app.kubernetes.io/name=coder-pvc` ラベル
+  （`apps/coder/templates/personal/main.tf` が付与）で対象 PVC を毎回列挙、PVC ごとに
+  使い捨ての Job（restic/restic イメージ、対象 PVC のみ readOnly マウント）を Kubernetes API
+  経由で生成する。生成した Job は `ttlSecondsAfterFinished: 3600` で自動 GC されるため、
+  オーケストレータ自身は Job の削除権限を持たない（`create` のみ）。専用 ServiceAccount
+  `workspace-home-backup`（coder namespace 限定の Role: PVC の get/list、Job の create のみ）
+- **credential は新規登録不要**: coder-postgres 用（T-0070）の `coder-restic-credentials`
+  Secret（同じ Backblaze B2 バケット・同じ暗号化パスワード）をそのまま流用し、リポジトリパス
+  末尾のみ `coder-workspace-homes` に変える設計
+- **1リポジトリを workspace 間で共有**: 各 Job は `restic backup --host <workspace-id>` で
+  ホストタグを付ける。**`coder-workspace-home-backup-retention`**（毎週日曜 04:30 UTC）は
+  `restic forget --group-by host --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --prune`
+  でホスト単位に世代管理する。workspace が削除されてもそのホストの世代は自然に切り捨てられる
+  （明示的な削除はしない）
+- **複数 workspace 同時実行時のロック競合対策**: オーケストレータは PVC ごとに Job を作る際
+  20秒間隔を空ける簡易な直列化のみで、完了を待って次へ進む仕組みではない。個人利用規模
+  （workspace 数が少ない）を前提にした割り切り
+- **cooldown 対象**: 新しい write 権限を持つ ServiceAccount（Job の create）・新しい
+  resources/securityContext（実測の裏付けなし、既存の restic backup CronJob 群からの類推値）を
+  持ち込むため、CHARTER §4「縛る変更には実測か裏付けが要る」の対象とし、この PR を作成した
+  起動では merge していない
+- **未実施（フォローアップ）**: T-0071（immich/vaultwarden/coder-postgres で完了済み）と同様の
+  復元試験はまだ行っていない。デプロイ後の初回実行確認・復元試験・オーケストレータの実メモリ
+  使用量確認は別タスクとして backlog に追跡する
 
 ## 復元試験（T-0071）
 

--- a/ops/check_version_sync.py
+++ b/ops/check_version_sync.py
@@ -303,6 +303,9 @@ GROUPS = [
             ("apps/immich/restic-backup-cronjob.yaml", lambda: extract_image_tag_all(
                 "apps/immich/restic-backup-cronjob.yaml", "image: restic/restic:"
             )),
+            ("apps/coder/workspace-home-backup-cronjob.yaml", lambda: extract_image_tag_all(
+                "apps/coder/workspace-home-backup-cronjob.yaml", "image: restic/restic:"
+            )),
         ],
     },
 ]

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -395,6 +395,18 @@
       "policy": "auto",
       "note": "T-0068 で新設。vaultwarden-restic-image / coder-postgres-restic-image と同じタグ (0.19.1) を使う設計。同一ファイル内に immich-restic-backup と immich-restic-retention の2箇所、かつ他2ファイルともファイル間で重複しているが、T-0098 (run #49) で check_version_sync.py の GROUPS に登録済み（vaultwarden-restic-image の note 参照）",
       "observability_impact": "immich の restic バックアップ・retention CronJob が使用。壊れるとバックアップが取れなくなるが immich 本体の可用性には影響しない"
+    },
+    {
+      "id": "coder-workspace-home-restic-image",
+      "kind": "image",
+      "name": "restic/restic (backup CronJob)",
+      "current": "0.19.1",
+      "file": "apps/coder/workspace-home-backup-cronjob.yaml",
+      "match": "restic/restic:",
+      "upstream": "github:restic/restic",
+      "policy": "auto",
+      "note": "T-0078 で新設。他3ファイルと同じタグ (0.19.1) を使う設計。ファイル内では coder-workspace-home-backup-retention CronJob の image 行の1箇所のみが check_version_sync.py の regex に検出される（オーケストレータ script 内の RESTIC_IMAGE 定数はリポジトリ名とタグを分けて保持し、regex の誤検出を避けている。詳細はファイル内コメント参照）。タグを上げるときは retention CronJob の image 行と RESTIC_IMAGE_TAG 定数の両方を揃えること。check_version_sync.py の GROUPS に4ファイル目として登録済み（vaultwarden-restic-image の note 参照）",
+      "observability_impact": "coder workspace home (coder-<workspace-id>-home PVC) の restic バックアップ・retention CronJob が使用。壊れるとバックアップが取れなくなるが coder workspace 本体の可用性には影響しない"
     }
   ]
 }


### PR DESCRIPTION
## 変更点

Coder workspace ごとに動的作成される `coder-<workspace-id>-home` PVC（`apps/coder/templates/personal/main.tf` 参照。`/home/coder` にマウント、dotfiles・ghq clone・code-server 設定等）を restic で Backblaze B2 へバックアップする CronJob を追加した（T-0078）。

これで docs/backup.md が T-0065（run #30）で確定した「実データを持つ5つのバックアップ対象」のうち、唯一未実装だった workspace home の分が埋まる。T-0072（PBS 退役判断）が「T-0078 が完了するまで PBS を維持する」としていた最後の条件になる。

- 他3コンポーネント（immich/vaultwarden/coder-postgres）と異なり、対象 PVC は workspace の作成・削除のたびに動的に増減するため静的なマニフェストに書けない。`coder-workspace-home-backup` CronJob（毎日 03:30 UTC）がオーケストレータ役の Pod（python:3.12-alpine、標準ライブラリのみ）を1つ起動し、`app.kubernetes.io/name=coder-pvc` ラベルで対象 PVC を毎回列挙、PVC ごとに使い捨ての backup Job（restic/restic イメージ、対象 PVC のみ readOnly マウント）を Kubernetes API 経由で生成する
- 生成した Job は `ttlSecondsAfterFinished: 3600` で自動 GC されるため、オーケストレータ自身は Job の削除権限を持たない（`create` のみ）。専用 ServiceAccount `workspace-home-backup`（coder namespace 限定の Role: PVC の get/list、Job の create のみ）
- **credential は新規登録不要**。coder-postgres 用（T-0070）の `coder-restic-credentials` Secret（同じ Backblaze B2 バケット・同じ暗号化パスワード）をそのまま流用し、リポジトリパス末尾のみ `coder-workspace-homes` に変える設計
- 1リポジトリを workspace 間で共有し、`restic backup --host <workspace-id>` でホストタグを付ける。`coder-workspace-home-backup-retention`（毎週日曜 04:30 UTC）は `restic forget --group-by host` でホスト単位に世代管理する
- `ops/check_version_sync.py` の既存 GROUP「restic/restic backup CronJob image tag」に4ファイル目として登録し、`ops/inventory.json` にも `coder-workspace-home-restic-image` を追加した（今後のタグ更新で3ファイルとの割れを検出できるようにする）

## なぜこの起動では merge しない（cooldown）

CHARTER §4「縛る変更には実測か裏付けが要る」の対象と判断した:

- 新しい write 権限（Job の `create`）を持つ ServiceAccount を coder namespace に追加する
- オーケストレータ Pod の resources（cpu/memory の requests/limits）が実測の裏付けなし。既存の pvc-usage-reporter と同クラスの「緩い安全弁」として値を置いたが、類推であることに変わりはない
- restic-backup 子 Job の securityContext（`runAsUser: 0` + `DAC_READ_SEARCH`）は vaultwarden/coder-postgres の既存 backup CronJob と同じ値をそのまま流用（こちらは precedent あり）

このため `mcp__github__enable_pr_auto_merge` 相当の自動 merge は呼ばず、CI green を確認した上で PR を open のまま起動を終える。次の起動が issue #56 に新しい異議が来ていないことを確認した上で merge する。

## 検証したこと

- `python3 ops/check_version_sync.py` で全 GROUP green（新規追加した restic/restic image tag GROUP の4ファイル目を含む）
- `python3 ops/validate.py` で 0 error（10 warning、いずれも既存の別タスクに起因するもの）
- オーケストレータ script（ConfigMap 内の Python）を `py_compile` で構文検証、`build_job()` を実際に呼び出して生成される Job JSON の構造を確認した
- `kubectl get pvc -n coder -l app.kubernetes.io/name=coder-pvc` で実際に2件の workspace home PVC（`coder-0cd09458-...-home`, `coder-7fdb7787-...-home`）が対象ラベルを持つことを実機で確認した

## 残った不確実性

- デプロイ後の初回実行が実際に成功するか（オーケストレータの API 呼び出し・子 Job の生成・restic backup の完了）は未確認。復元試験（T-0071 と同型）も未実施。フォローアップとして backlog に起票する
- オーケストレータ Pod の実メモリ・CPU 使用量は未実測

## ロールバック手順

このリポジトリ内の変更のみ（`apps/coder/workspace-home-backup-cronjob.yaml` の新規追加・`kustomization.yaml`・`docs/backup.md`・`ops/check_version_sync.py`・`ops/inventory.json`）。revert すれば ArgoCD が新設した ServiceAccount/Role/RoleBinding/ConfigMap/CronJob 一式を prune する。実データ（workspace home PVC 本体）には一切書き込まないため、revert してもデータの不整合は残らない。すでに生成されていた子 Job があってもそれ自体は `ttlSecondsAfterFinished` で自然に GC される。

## backlog task id

T-0078
