### PR TITLE
chore(ops): run #83 の記録更新

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 117,
+  "next_id": 118,
   "updated": "2026-08-06T00:05:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
@@ -1437,7 +1437,7 @@
       "title": "Coder workspace ごとの home PVC (`coder-<workspace-id>-home`) 用の backup CronJob を追加する",
       "kind": "feature",
       "risk": "medium",
-      "status": "todo",
+      "status": "in_progress",
       "priority": 40,
       "why": "T-0065（run #30）の調査で発見。`apps/coder/templates/personal/main.tf` が Coder の Terraform プロビジョナー経由で workspace 作成のたびに `coder-<workspace-id>-home` という PVC を動的作成しており（`/home/coder` にマウント、dotfiles・`ghq` clone・code-server 設定等のユーザーデータが載る）、これは `apps/coder/*.yaml` の静的マニフェストには現れないため T-0070（coder-postgres の backup）ではカバーされない。node01 揮発時に失われる実データの5つ目の対象",
       "dod": "workspace ごとに動的作成される `coder-<workspace-id>-home` PVC を列挙し（PVC 名は `coder-<workspace-id>-home` の命名規則で特定可能）、pg_dump 同様の考え方でファイルシステムスナップショット（tar もしくは直接 restic でファイルシステムを対象にする、DB とは異なりファイルなのでオンライン中でも整合性の問題は薄い）を restic で T-0067 の保存先へ push する CronJob を追加する。workspace は増減するため、対象 PVC の列挙は動的（`kubectl get pvc -l` 相当のラベルセレクタ、または命名パターンでのマッチ）にする",
@@ -1447,8 +1447,8 @@
         "docs/backup.md"
       ],
       "created": "2026-08-05",
-      "pr": null,
-      "notes": "run #82: blocked_by（T-0067）が run #53 時点で既に done になっていたにも関わらず放置されていたのに気づき todo に戻した（T-0072 の判断作業の副産物）"
+      "pr": 264,
+      "notes": "run #83: apps/coder/workspace-home-backup-cronjob.yaml を実装（オーケストレータ Pod が app.kubernetes.io/name=coder-pvc ラベルで対象 PVC を毎回列挙し、PVC ごとに使い捨ての restic backup Job を Kubernetes API 経由で生成する方式）。credential は coder-postgres 用 (T-0070) の coder-restic-credentials を流用し新規登録不要。新しい write RBAC （Job の create）と実測なしの resources/securityContext を持ち込むため CHARTER §4 の 『縛る変更には実測か裏付けが要る』cooldown 対象と判断し、PR #264 は CI green を確認した 上で merge せず open のまま起動を終える。次の起動で issue #56 に新しい異議が無いことを 確認して merge すること。デプロイ後の初回実行確認・復元試験は T-0117 として分離起票"
     },
     {
       "id": "T-0079",
@@ -2196,6 +2196,25 @@
       "created": "2026-08-06",
       "pr": null,
       "notes": "run #82: T-0072（PBS 退役判断）から実行タスクとして分離起票"
+    },
+    {
+      "id": "T-0117",
+      "domain": "homelab",
+      "title": "coder workspace home backup (T-0078) の初回実行確認・復元試験",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "todo",
+      "priority": 41,
+      "why": "T-0078（run #83, PR #264）はデプロイ後の初回実行が実際に成功するか未確認のまま cooldown で開いている。immich/vaultwarden/coder-postgres は T-0071 で復元試験まで完了しているが、workspace home はまだ同種の検証をしていない。T-0072（PBS 退役判断）はこの確認が完了することを PBS 退役（T-0116）の前提条件にしている",
+      "dod": "T-0078 (PR #264) が merge された後、(1) kubectl / ops-health-report で coder-workspace-home-backup CronJob の子 Job (chb-<workspace-id>) が成功していることを確認する、(2) T-0071 と同型の復元試験（使い捨て PVC への restic restore、CHOWN/FOWNER/DAC_OVERRIDE capability が要る可能性が高い点は docs/backup.md の教訓を踏まえる）を実施し docs/backup.md に記録する、(3) 可能であればオーケストレータ Pod の実メモリ/CPU 使用量を kubectl top で確認し、resources の値が妥当か見直す",
+      "blocked_by": "T-0078（PR #264 の merge 待ち）",
+      "refs": [
+        "apps/coder/workspace-home-backup-cronjob.yaml",
+        "docs/backup.md"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #83: T-0078 実装の副産物として分離起票"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,43 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 264,
+      "title": "feat(coder): workspace home PVC 用の restic backup CronJob を追加 (T-0078)",
+      "url": "https://github.com/hikuohiku/homelab/pull/264",
+      "isDraft": false,
+      "createdAt": "2026-08-06T00:28:50Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        }
+      ],
+      "headRefName": "autopilot/T-0078-coder-workspace-home-backup",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 263,
+      "title": "docs(backup): PBS 退役判断を記録し、stale blocked を解消 (T-0072)",
+      "url": "https://github.com/hikuohiku/homelab/pull/263",
+      "mergedAt": "2026-08-06T00:16:54Z",
+      "headRefName": "autopilot/T-0072-pbs-retire-decision"
+    },
     {
       "number": 262,
       "title": "docs(backup): immich restore-verify Job の削除記述を過去形に直す (T-0115)",
@@ -413,13 +450,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/200",
       "mergedAt": "2026-08-05T14:38:46Z",
       "headRefName": "autopilot/T-0102-helm-binary-3.21.3"
-    },
-    {
-      "number": 199,
-      "title": "ドキュメントが案内する just recipe の実在を CI で検証する (T-0096)",
-      "url": "https://github.com/hikuohiku/homelab/pull/199",
-      "mergedAt": "2026-08-05T13:41:09Z",
-      "headRefName": "autopilot/T-0096-doc-just-recipe-check"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2450,3 +2450,40 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   退役の実行タスクを T-0116（blocked_by: T-0078、実VM停止はneeds-human見込み）として分離起票
 - 次の起動へ: backlog の todo に T-0078（coder workspace home PVC backup）が乗った。
   次の起動はこれに着手してよい。T-0116 は T-0078 完了まで着手しない
+
+## 2026-08-06 09:29 JST — run #83
+
+- 前回の中断確認: オープン PR 1件（#263, T-0072, run #82 が open のまま終了）を発見。CI
+  （terraform validate / kustomize build / ops state validate / manifest deletion guard /
+  GitGuardian）全 green・`mergeable_state: clean` を確認して merge した（stale な blocked
+  backlog を解消する repo 内で閉じる低リスク変更のため即 merge）。ブランチは merge 時に
+  GitHub が自動削除済み
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` で2ページとも）を
+  機械的に確認。last_read（2026-08-05T18:47:54Z）以降の新規コメント無し
+- やったこと: backlog の唯一の todo だった T-0078（coder workspace home PVC の backup）に着手。
+  `apps/coder/workspace-home-backup-cronjob.yaml` を新設し、workspace の増減に対応するため
+  オーケストレータ Pod（python:3.12-alpine）が `app.kubernetes.io/name=coder-pvc` ラベルで
+  対象 PVC を毎回列挙し、PVC ごとに使い捨ての restic backup Job を Kubernetes API 経由で
+  生成する方式にした（生成した Job は `ttlSecondsAfterFinished` で自動 GC、オーケストレータ
+  自身は Job の削除権限を持たない）。credential は coder-postgres 用（T-0070）の
+  `coder-restic-credentials` を流用し新規の Doppler 登録は不要だった。`kubectl get pvc -n coder
+  -l app.kubernetes.io/name=coder-pvc` で実機に workspace home PVC が2件（ラベル込みで）存在する
+  ことを確認し、設計の前提を裏取りした。オーケストレータ script は `py_compile` で構文検証、
+  `build_job()` を直接呼んで生成 JSON の構造も確認した
+- `ops/check_version_sync.py` の既存 GROUP「restic/restic backup CronJob image tag」に
+  workspace-home-backup-cronjob.yaml を4ファイル目として登録。regex（`image: restic/restic:`
+  + 非空白）が Python script 内のコメント文言を誤検出しかけたため、リポジトリ名とタグを
+  分けて持つ形に直してから `python3 ops/check_version_sync.py` で green を確認した
+  （検出漏れではなく自分のミスとして先に気づいて直した）
+- この変更は新しい write RBAC（オーケストレータ ServiceAccount の Job `create` 権限）と
+  実測なしの resources/securityContext を持ち込むため CHARTER §4「縛る変更には実測か裏付けが
+  要る」の cooldown 対象と判断。CI green を確認した上で PR #264 は merge せず open のまま終える
+  （`ops/backlog.json` の T-0078 は `in_progress` にし、`pr: 264` のみ記録。§4 のとおり
+  cooldown 対象の記録更新はこの run 用の別 PR に分けた）。デプロイ後の初回実行確認・復元試験は
+  T-0117（todo, blocked_by: T-0078）として分離起票
+- 次の起動へ: PR #264（T-0078, cooldown）が open のまま残る。issue #56 に新しい異議が無いことを
+  確認した上で CI green なら merge すること。merge 後は T-0117（初回実行確認・復元試験）に
+  着手できる
+- ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化（open 1件・merged 60件）、
+  `ops/validate.py` 0 error（10 warning、既存のもの）、`ops/dashboard/build.py` 正常終了を確認。
+  Artifact ツールがこの環境に無く re-publish はできなかった

--- a/ops/state.json
+++ b/ops/state.json
@@ -890,6 +890,16 @@
       "by": "in-cluster autopilot",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。ops-health-report で新規異常なし、immich backup_listing も直近24時間以内で正常。backlog の blocked/needs-human をタスク単位ではなく部分単位で洗い直し、T-0072（PBS退役判断）・T-0078（coder workspace home backup）の blocked_by がそれぞれ run #68・#53 時点で解消済みなのに放置されていたと発見。T-0072 に着手し『今は PBS を維持、T-0078 完了後に退役』と判断（docs/backup.md に記録）、T-0078 を todo に戻し、退役実行タスク T-0116（blocked_by: T-0078）を分離起票",
       "prs": []
+    },
+    {
+      "n": 83,
+      "at": "2026-08-06T00:29:00Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "前回の中断: PR #263（T-0072, run #82 が open のまま終了）を CI green・mergeable_state clean を確認して merge。issue #56 に未読フィードバックなし。backlog の唯一の todo だった T-0078（coder workspace home PVC の backup）に着手し、オーケストレータ Pod が workspace ごとの PVC を動的に列挙して使い捨ての restic backup Job を Kubernetes API 経由で生成する方式で実装した（credential は coder-postgres 用を流用、新規登録不要）。新しい write RBAC・実測なしの resources/securityContext を持ち込むため CHARTER §4 の cooldown 対象と判断し、PR #264 は CI green 確認まで進めたが merge せず open のまま終える。T-0078 は in_progress、初回実行確認・復元試験は T-0117 として分離起票",
+      "prs": [
+        264
+      ]
     }
   ]
 }


### PR DESCRIPTION
T-0072 (PR #263) の merge 見届け・T-0078 (PR #264, cooldown) 着手・T-0117 起票を journal/backlog/state/dashboard キャッシュに反映。運用記録のみ、実インフラ・アプリには触れていない。CHARTER §4 の相乗り例外に該当する低リスク変更のため CI green で auto-merge 対象。

## backlog task id

T-0078 (in_progress), T-0117 (新規)