### PR TITLE
chore(ops): T-0078 を done に、run #84 の記録を反映

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 118,
-  "updated": "2026-08-06T00:05:00Z",
+  "updated": "2026-08-06T00:40:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -1437,7 +1437,7 @@
       "title": "Coder workspace ごとの home PVC (`coder-<workspace-id>-home`) 用の backup CronJob を追加する",
       "kind": "feature",
       "risk": "medium",
-      "status": "in_progress",
+      "status": "done",
       "priority": 40,
       "why": "T-0065（run #30）の調査で発見。`apps/coder/templates/personal/main.tf` が Coder の Terraform プロビジョナー経由で workspace 作成のたびに `coder-<workspace-id>-home` という PVC を動的作成しており（`/home/coder` にマウント、dotfiles・`ghq` clone・code-server 設定等のユーザーデータが載る）、これは `apps/coder/*.yaml` の静的マニフェストには現れないため T-0070（coder-postgres の backup）ではカバーされない。node01 揮発時に失われる実データの5つ目の対象",
       "dod": "workspace ごとに動的作成される `coder-<workspace-id>-home` PVC を列挙し（PVC 名は `coder-<workspace-id>-home` の命名規則で特定可能）、pg_dump 同様の考え方でファイルシステムスナップショット（tar もしくは直接 restic でファイルシステムを対象にする、DB とは異なりファイルなのでオンライン中でも整合性の問題は薄い）を restic で T-0067 の保存先へ push する CronJob を追加する。workspace は増減するため、対象 PVC の列挙は動的（`kubectl get pvc -l` 相当のラベルセレクタ、または命名パターンでのマッチ）にする",
@@ -1448,7 +1448,7 @@
       ],
       "created": "2026-08-05",
       "pr": 264,
-      "notes": "run #83: apps/coder/workspace-home-backup-cronjob.yaml を実装（オーケストレータ Pod が app.kubernetes.io/name=coder-pvc ラベルで対象 PVC を毎回列挙し、PVC ごとに使い捨ての restic backup Job を Kubernetes API 経由で生成する方式）。credential は coder-postgres 用 (T-0070) の coder-restic-credentials を流用し新規登録不要。新しい write RBAC （Job の create）と実測なしの resources/securityContext を持ち込むため CHARTER §4 の 『縛る変更には実測か裏付けが要る』cooldown 対象と判断し、PR #264 は CI green を確認した 上で merge せず open のまま起動を終える。次の起動で issue #56 に新しい異議が無いことを 確認して merge すること。デプロイ後の初回実行確認・復元試験は T-0117 として分離起票"
+      "notes": "run #83: apps/coder/workspace-home-backup-cronjob.yaml を実装（オーケストレータ Pod が app.kubernetes.io/name=coder-pvc ラベルで対象 PVC を毎回列挙し、PVC ごとに使い捨ての restic backup Job を Kubernetes API 経由で生成する方式）。credential は coder-postgres 用 (T-0070) の coder-restic-credentials を流用し新規登録不要。新しい write RBAC （Job の create）と実測なしの resources/securityContext を持ち込むため CHARTER §4 の 『縛る変更には実測か裏付けが要る』cooldown 対象と判断し、PR #264 は CI green を確認した 上で merge せず open のまま起動を終える。次の起動で issue #56 に新しい異議が無いことを 確認して merge すること。デプロイ後の初回実行確認・復元試験は T-0117 として分離起票。run #84: issue #56 に新しい異議が無いことを確認し PR #264 を merge（12e3d7f）。実行確認・復元試験は引き続き T-0117 で追う"
     },
     {
       "id": "T-0079",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,36 +1,20 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
+    {
+      "number": 265,
+      "title": "chore(ops): run #83 の記録更新",
+      "url": "https://github.com/hikuohiku/homelab/pull/265",
+      "mergedAt": "2026-08-06T00:36:29Z",
+      "headRefName": "autopilot/T-0078-run83-records"
+    },
     {
       "number": 264,
       "title": "feat(coder): workspace home PVC 用の restic backup CronJob を追加 (T-0078)",
       "url": "https://github.com/hikuohiku/homelab/pull/264",
-      "isDraft": false,
-      "createdAt": "2026-08-06T00:28:50Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        }
-      ],
-      "headRefName": "autopilot/T-0078-coder-workspace-home-backup",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-06T00:36:24Z",
+      "headRefName": "autopilot/T-0078-coder-workspace-home-backup"
+    },
     {
       "number": 263,
       "title": "docs(backup): PBS 退役判断を記録し、stale blocked を解消 (T-0072)",
@@ -436,20 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/202",
       "mergedAt": "2026-08-05T15:10:23Z",
       "headRefName": "autopilot/dashboard-redesign"
-    },
-    {
-      "number": 201,
-      "title": "ops: run #51 の記録更新（T-0102 完遂・journal・state・PRキャッシュ）",
-      "url": "https://github.com/hikuohiku/homelab/pull/201",
-      "mergedAt": "2026-08-05T14:42:43Z",
-      "headRefName": "autopilot/run51-record"
-    },
-    {
-      "number": 200,
-      "title": "ci: helm バイナリを v3.16.4 → v3.21.3 に更新 (T-0102)",
-      "url": "https://github.com/hikuohiku/homelab/pull/200",
-      "mergedAt": "2026-08-05T14:38:46Z",
-      "headRefName": "autopilot/T-0102-helm-binary-3.21.3"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,5 +1,20 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 266,
+      "title": "chore(ops): T-0078 を done に、run #84 の記録を反映",
+      "url": "https://github.com/hikuohiku/homelab/pull/266",
+      "isDraft": false,
+      "createdAt": "2026-08-06T00:42:35Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "PENDING"
+        }
+      ],
+      "headRefName": "autopilot/T-0078-mark-done",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
     {
       "number": 265,

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2487,3 +2487,26 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化（open 1件・merged 60件）、
   `ops/validate.py` 0 error（10 warning、既存のもの）、`ops/dashboard/build.py` 正常終了を確認。
   Artifact ツールがこの環境に無く re-publish はできなかった
+
+## 2026-08-06 09:40 JST — run #84
+
+- 前回の中断確認: オープン PR 2件（#264 T-0078 の CronJob 追加、cooldown 中に前回起動が open
+  のまま終えたもの／#265 run #83 の記録）を発見。`autopilot/*` 残存ブランチはこの2件のみ
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` で2ページとも）を
+  機械的に確認。last_read（2026-08-05T18:47:54Z）以降の新規コメント無し。#264 への異議も無し
+- やったこと: 異議が無いことを確認したので CHARTER §4 の cooldown 手順どおり #264・#265 を
+  順に merge（`d40c7f7`→`12e3d7f`）、GitHub が両ブランチを自動削除したことを `git fetch --prune`
+  で確認。ArgoCD の coder Application が新 revision へ自動 sync（Synced/Healthy）し、
+  `coder-workspace-home-backup`/`coder-workspace-home-backup-retention` CronJob が実際に
+  namespace `coder` に存在することを kubectl で確認。ただしどちらも schedule（毎日 03:30 UTC /
+  毎週日 04:30 UTC）がまだ来ておらず初回実行はこれから。T-0078 を `done` にした
+  （実行確認・復元試験は分離済みの T-0117 のまま）
+- ops-health-report（generated_at 2026-08-06T00:30:04Z）で Application 全件 Synced/Healthy、
+  pod_issues は常連の再起動カウントのみで新規異常なし、immich の backup_listing も最新
+  mtime が 2026-08-05T02:00:03Z（24時間以内）で正常、autopilot 自身の heartbeat（iteration
+  #28 exit_code 0）も正常と確認
+- 次の起動へ: T-0117（coder workspace home backup の初回実行確認・復元試験）は CronJob の
+  schedule（03:30 UTC）がまだ来ていないため未着手。次の起動時に schedule 時刻を過ぎていれば
+  `kubectl get jobs -n coder -l ...`（もしくは CronJob 名からの子 Job）で初回実行の成否を
+  確認できる。復元試験は autopilot の kubectl 権限が get/list のみで write が無いため自分では
+  完結できず、構築セッションへの依頼が必要になる見込み

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T00:11:00Z",
+  "updated": "2026-08-06T00:40:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -900,6 +900,14 @@
       "prs": [
         264
       ]
+    },
+    {
+      "n": 84,
+      "at": "2026-08-06T00:40:00Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "前回の中断: PR #264（T-0078, cooldown で open のまま終了）・#265（run #83 の記録）を発見。issue #56 に新しい異議が無いことを確認し両方を merge（#264: d40c7f7, #265: 12e3d7f）。ArgoCD が新 revision に自動 sync し、coder-workspace-home-backup/-retention CronJob の実在を kubectl で確認（schedule 未到来のため初回実行はこれから）。T-0078 を done にした",
+      "prs": []
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -907,7 +907,9 @@
       "kind": "scheduled",
       "by": "in-cluster autopilot",
       "summary": "前回の中断: PR #264（T-0078, cooldown で open のまま終了）・#265（run #83 の記録）を発見。issue #56 に新しい異議が無いことを確認し両方を merge（#264: d40c7f7, #265: 12e3d7f）。ArgoCD が新 revision に自動 sync し、coder-workspace-home-backup/-retention CronJob の実在を kubectl で確認（schedule 未到来のため初回実行はこれから）。T-0078 を done にした",
-      "prs": []
+      "prs": [
+        266
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

- PR #264（T-0078: coder workspace home PVC 用の restic backup CronJob）は前回起動が CHARTER §4 の cooldown 対象と判断して open のまま終えていた。この起動で issue #56 に新しい異議が来ていないことを確認した上で merge した（`d40c7f7`）
- PR #265（run #83 の記録更新）も CI green を確認して merge した（`12e3d7f`）
- ArgoCD の `coder` Application が新 revision へ自動 sync（Synced/Healthy）し、`coder-workspace-home-backup`/`coder-workspace-home-backup-retention` CronJob が namespace `coder` に実在することを kubectl で確認した（schedule は毎日 03:30 UTC / 毎週日 04:30 UTC でまだ未到来のため初回実行はこれから）
- `ops/backlog.json` の T-0078 を `done` にした（初回実行確認・復元試験は分離済みの T-0117 のまま todo）
- journal・state.json・`ops/dashboard/prs.json` キャッシュを更新

## 検証したこと

- `python3 ops/validate.py` で 0 error（10 warning、既存の別タスクに起因するもの）
- `python3 ops/dashboard/build.py` が例外なく完了することを確認
- kubectl で ArgoCD Application (`coder`) が `Synced`/`Healthy`、CronJob 2件の実在を確認

## ロールバック手順

この PR 自体は `ops/` 配下の運用記録のみ（コード変更なし）。revert しても実インフラには影響しない。
revert すると T-0078 のステータスが `in_progress` に戻るだけで、既に merge 済みの PR #264/#265 の内容（CronJob 本体）には影響しない。

## backlog task id

T-0078（記録更新のみ、実装は #264 で完了）