### PR TITLE
chore(ops): run #85 の記録更新（inventory 定点調査・T-0118 起票）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 118,
+  "next_id": 119,
   "updated": "2026-08-06T00:40:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
@@ -2207,14 +2207,30 @@
       "priority": 41,
       "why": "T-0078（run #83, PR #264）はデプロイ後の初回実行が実際に成功するか未確認のまま cooldown で開いている。immich/vaultwarden/coder-postgres は T-0071 で復元試験まで完了しているが、workspace home はまだ同種の検証をしていない。T-0072（PBS 退役判断）はこの確認が完了することを PBS 退役（T-0116）の前提条件にしている",
       "dod": "T-0078 (PR #264) が merge された後、(1) kubectl / ops-health-report で coder-workspace-home-backup CronJob の子 Job (chb-<workspace-id>) が成功していることを確認する、(2) T-0071 と同型の復元試験（使い捨て PVC への restic restore、CHOWN/FOWNER/DAC_OVERRIDE capability が要る可能性が高い点は docs/backup.md の教訓を踏まえる）を実施し docs/backup.md に記録する、(3) 可能であればオーケストレータ Pod の実メモリ/CPU 使用量を kubectl top で確認し、resources の値が妥当か見直す",
-      "blocked_by": "T-0078（PR #264 の merge 待ち）",
+      "blocked_by": null,
       "refs": [
         "apps/coder/workspace-home-backup-cronjob.yaml",
         "docs/backup.md"
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "run #83: T-0078 実装の副産物として分離起票"
+      "notes": "run #83: T-0078 実装の副産物として分離起票。run #85: T-0078 は run #84 で done・PR #264 merge 済みのため blocked_by を解消。ただし CronJob の schedule（毎日 03:30 UTC）が未到来のため実行確認はまだできない"
+    },
+    {
+      "id": "T-0118",
+      "domain": "homelab",
+      "title": "CI の helm バイナリ (azure/setup-helm の version input) を v3 系から v4 系への移行を検討する",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "todo",
+      "priority": 55,
+      "why": "run #85 の inventory 定期チェック（T-0117 が CronJob の schedule 未到来で着手不能だったため実施）で、CI が使う helm バイナリ（`gha-setup-helm-version`, 現行 v3.21.3, ops/inventory.json）の upstream (helm/helm) に v4 系（最新 v4.2.3）が存在し、v3 系の release notes に EOL 接近の告知があると判明した。v3.21.3 自体は v3 系列の最新なので inventory の『current が遅れている』判定（同一系列内の追従）には該当せず緊急性は無いが、系列そのものの移行は別論点として検討が要る",
+      "dod": "helm v4 の breaking changes（release notes / migration guide）を原文で確認し、このリポジトリの CI（`kustomize build --enable-helm` を使う manifests job・manifest-diff job）が使う helm の呼び出し方（`--enable-helm` フラグの挙動、chart repo 設定等）に影響が無いか洗い出す。影響が無ければ `.github/workflows/ci.yml` の helm version input と `ops/inventory.json` の `gha-setup-helm-version` を v4 系に上げる PR を出す。影響があれば内容を記録し、blocked にする理由を明記する",
+      "blocked_by": null,
+      "refs": [".github/workflows/ci.yml", "ops/inventory.json"],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #85: 定期の inventory 調査（対象8件、他7件は current が最新のまま）で発見。緊急性は無い（v3.21.3 で CI は動いている）が EOL 接近の一次情報あり"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,13 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 266,
       "title": "chore(ops): T-0078 を done に、run #84 の記録を反映",
       "url": "https://github.com/hikuohiku/homelab/pull/266",
-      "isDraft": false,
-      "createdAt": "2026-08-06T00:42:35Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "PENDING"
-        }
-      ],
-      "headRefName": "autopilot/T-0078-mark-done",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-06T00:44:57Z",
+      "headRefName": "autopilot/T-0078-mark-done"
+    },
     {
       "number": 265,
       "title": "chore(ops): run #83 の記録更新",
@@ -428,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/203",
       "mergedAt": "2026-08-05T15:33:35Z",
       "headRefName": "autopilot/run52-record"
-    },
-    {
-      "number": 202,
-      "title": "feat(ops): ダッシュボードを作り直す — 主役を「何をすればいいか」にする",
-      "url": "https://github.com/hikuohiku/homelab/pull/202",
-      "mergedAt": "2026-08-05T15:10:23Z",
-      "headRefName": "autopilot/dashboard-redesign"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2510,3 +2510,28 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   `kubectl get jobs -n coder -l ...`（もしくは CronJob 名からの子 Job）で初回実行の成否を
   確認できる。復元試験は autopilot の kubectl 権限が get/list のみで write が無いため自分では
   完結できず、構築セッションへの依頼が必要になる見込み
+
+## 2026-08-06 09:51 JST — run #85
+
+- 前回の中断確認: オープン PR 無し。`autopilot/*` 残存ブランチ無し
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` で2ページとも）を
+  機械的に確認。last_read（2026-08-05T18:47:54Z）以降の新規コメント無し
+- ops-health-report（generated_at 2026-08-06T00:30:04Z）で Application 全件 Synced/Healthy、
+  pod_issues は常連の再起動カウントのみで新規異常なし、immich の backup_listing も正常、
+  autopilot 自身の heartbeat（iteration #28 exit_code 0、#29 開始）も正常と確認
+- backlog の唯一の todo（T-0117）は `coder-workspace-home-backup` CronJob（schedule 03:30 UTC）の
+  初回実行を前提にしているが、kubectl で `LAST SCHEDULE: <none>` を確認（現在時刻 00:48 UTC、
+  schedule 未到来）。着手不能と判断し、CHARTER §3 の「backlog が実質進められないときは調査
+  タスクを自分で起票する」に従い `ops/inventory.json` の未チェック分（dex-chart/immich-chart/
+  busybox/restic 4ファイル/terraform-binary/kustomize-binary/helm/install-nix-action の計8件）を
+  subagent で調査
+- 見つけたこと: 8件とも current が upstream 最新のまま（更新不要）。ただし `gha-setup-helm-version`
+  の upstream (helm/helm) に v4 系（最新 v4.2.3）があり、v3 系の release notes に EOL 接近の告知が
+  あると判明。v3.21.3 自体は v3 系列内では最新なので緊急性は無いが、系列移行の検討として
+  T-0118（priority 55, todo）を起票。あわせて T-0117 の `blocked_by` が run #84 で T-0078 が
+  done になった後も stale なままだったのを解消（null に修正）
+- 次の起動へ: T-0117 は CronJob の schedule（03:30 UTC）を過ぎていれば着手できる。T-0118 は
+  緊急ではないので priority 順で後回しでよい
+- ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化（open 0件・merged 60件、
+  #266 が最新）、`ops/validate.py` 0 error（10 warning、既存のもの）、`ops/dashboard/build.py`
+  正常終了を確認。Artifact ツールがこの環境に無く re-publish はできなかった


### PR DESCRIPTION
## 変更点

- `ops/backlog.json`: T-0118（CI の helm を v3 系→v4 系へ移行するか検討する調査タスク、priority 55、todo）を新規起票。あわせて T-0117 の `blocked_by` を修正（既に merge 済みの T-0078 を指したまま stale になっていたのを `null` に）
- `ops/journal/2026-08.md`: run #85 の記録を追記
- `ops/dashboard/prs.json`: GitHub REST API から open/merged PR 一覧を取り直してキャッシュを最新化（open 0件・merged 60件）

利用者から見た変化は無し（backlog・journal・ダッシュボードキャッシュの更新のみ）。

## 検証したこと

- `python3 ops/validate.py` → 0 error, 10 warning（既存の warning のみ、新規発生なし）
- `python3 ops/dashboard/build.py` → 例外なく `index.html` を再生成（このファイル自体は Git 管理対象外）
- inventory.json の未チェック8対象（dex-chart, immich-chart, busybox, restic×4ファイル, terraform-binary, kustomize-binary, gha-setup-helm-version, gha-cachix-install-nix-action）を upstream と突き合わせ、全て current が最新のままであることを確認

## ロールバック手順

このコミットを revert すれば元に戻る。DB・実データは含まれない記録変更のみ。

## backlog task id

T-0118（新規起票）、T-0117（blocked_by の修正のみ）
