### PR TITLE
chore(ops): run #86 の記録更新（T-0118: helm v4 移行を blocked に）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2222,15 +2222,15 @@
       "title": "CI の helm バイナリ (azure/setup-helm の version input) を v3 系から v4 系への移行を検討する",
       "kind": "investigate",
       "risk": "low",
-      "status": "todo",
+      "status": "blocked",
       "priority": 55,
       "why": "run #85 の inventory 定期チェック（T-0117 が CronJob の schedule 未到来で着手不能だったため実施）で、CI が使う helm バイナリ（`gha-setup-helm-version`, 現行 v3.21.3, ops/inventory.json）の upstream (helm/helm) に v4 系（最新 v4.2.3）が存在し、v3 系の release notes に EOL 接近の告知があると判明した。v3.21.3 自体は v3 系列の最新なので inventory の『current が遅れている』判定（同一系列内の追従）には該当せず緊急性は無いが、系列そのものの移行は別論点として検討が要る",
       "dod": "helm v4 の breaking changes（release notes / migration guide）を原文で確認し、このリポジトリの CI（`kustomize build --enable-helm` を使う manifests job・manifest-diff job）が使う helm の呼び出し方（`--enable-helm` フラグの挙動、chart repo 設定等）に影響が無いか洗い出す。影響が無ければ `.github/workflows/ci.yml` の helm version input と `ops/inventory.json` の `gha-setup-helm-version` を v4 系に上げる PR を出す。影響があれば内容を記録し、blocked にする理由を明記する",
-      "blocked_by": null,
+      "blocked_by": "azure/setup-helm が v4 系の公式サポートを表明する（または実機検証で動作確認できる）まで",
       "refs": [".github/workflows/ci.yml", "ops/inventory.json"],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "run #85: 定期の inventory 調査（対象8件、他7件は current が最新のまま）で発見。緊急性は無い（v3.21.3 で CI は動いている）が EOL 接近の一次情報あり"
+      "notes": "run #85: 定期の inventory 調査（対象8件、他7件は current が最新のまま）で発見。緊急性は無い（v3.21.3 で CI は動いている）が EOL 接近の一次情報あり。run #86: 調査完遂。技術的な互換性のハードルは無い——kustomize v5.8.1（本リポジトリが既に使用中）は helm v4 対応の既知バグ修正（kubernetes-sigs/kustomize#6013, PR #6016）を取り込み済みで、本リポジトリが使う helmCharts の基本フィールド（repo/name/version/releaseName/namespace/valuesFile）は helm v4 の breaking changes に抵触しない（一次情報: https://helm.sh/blog/helm-4-released/ 、 https://helm.sh/docs/changelog/ ）。唯一の障害は CI が使う `azure/setup-helm` アクション自身が README で『v2+ of this action only support Helm3』と明言しており、v4 系のバージョン指定を公式サポートしていないこと（動く可能性はあるが未検証・未保証）。auto-merge のゲートである CI に根拠の薄い変更を入れないため blocked とした。再開条件: azure/setup-helm が v4 対応を明言するリリースを出す、または検証用ブランチで実機テストして動作を確認できたとき"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 267,
+      "title": "chore(ops): run #85 の記録更新（inventory 定点調査・T-0118 起票）",
+      "url": "https://github.com/hikuohiku/homelab/pull/267",
+      "mergedAt": "2026-08-06T00:53:42Z",
+      "headRefName": "autopilot/T-0118-inventory-sweep-records"
+    },
+    {
       "number": 266,
       "title": "chore(ops): T-0078 を done に、run #84 の記録を反映",
       "url": "https://github.com/hikuohiku/homelab/pull/266",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/205",
       "mergedAt": "2026-08-05T15:54:48Z",
       "headRefName": "autopilot/T-0103-restic-doppler-key-mismatch"
-    },
-    {
-      "number": 203,
-      "title": "ops: run #52 の記録更新（issue #56 フィードバック反映・PRキャッシュ・ダッシュボード再公開）",
-      "url": "https://github.com/hikuohiku/homelab/pull/203",
-      "mergedAt": "2026-08-05T15:33:35Z",
-      "headRefName": "autopilot/run52-record"
     }
   ]
 }

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -333,7 +333,7 @@
       "match": "version: v3.21.3",
       "upstream": "github:helm/helm",
       "policy": "auto",
-      "note": "azure/setup-helm@v5 の `with: version:` が指定する helm バイナリ本体のバージョン。gha-azure-setup-helm（Action 自体の pin, uses: azure/setup-helm@vX）とは別物。ci.yml の manifests job と manifest-diff job の2箇所に独立して書かれている（T-0090。ops/check_version_sync.py の GROUPS で内部一致を検証）",
+      "note": "azure/setup-helm@v5 の `with: version:` が指定する helm バイナリ本体のバージョン。gha-azure-setup-helm（Action 自体の pin, uses: azure/setup-helm@vX）とは別物。ci.yml の manifests job と manifest-diff job の2箇所に独立して書かれている（T-0090。ops/check_version_sync.py の GROUPS で内部一致を検証）。upstream に v4 系列があるが azure/setup-helm 自身が README で v3 のみ公式サポートと明言しており v4 系への更新は blocked（T-0118, run #86）。v3 系列内の更新（v3.21.3 → v3 系の新しい patch/minor）は引き続き通常の auto ポリシー対象",
       "observability_impact": "kustomize build job (--enable-helm) と manifest-diff job が使用。2箇所がずれると job ごとに異なる helm バージョンでレンダリングされ、T-0036 の削除検出（manifest-diff）がツールバージョン差分由来の偽陽性/偽陰性を出しうる"
     },
     {

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2535,3 +2535,30 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化（open 0件・merged 60件、
   #266 が最新）、`ops/validate.py` 0 error（10 warning、既存のもの）、`ops/dashboard/build.py`
   正常終了を確認。Artifact ツールがこの環境に無く re-publish はできなかった
+
+## 2026-08-06 09:58 JST — run #86
+
+- 前回の中断確認: オープン PR 無し。`autopilot/*` 残存ブランチ無し
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` で2ページとも）を
+  機械的に確認。last_read（2026-08-05T18:47:54Z）以降の新規コメント無し
+- ops-health-report（generated_at 2026-08-06T00:30:04Z）で Application 全11件 Synced/Healthy、
+  pod_issues は常連の再起動カウント（restarts=19、複数 namespace の Pod で同数のためノード
+  レベルの既知事象と判断）のみで新規異常なし、autopilot 自身の heartbeat（iteration #28
+  exit_code 0、#29 開始）も正常と確認
+- T-0117（coder workspace home backup の初回実行確認）は kubectl で
+  `coder-workspace-home-backup` CronJob の `LAST SCHEDULE: <none>` を確認（現在時刻 00:56 UTC、
+  schedule 03:30 UTC はまだ来ていない）。引き続き着手不能
+- やったこと: T-0118（CI の helm バイナリを v3→v4 系へ移行するか検討）に着手・完遂。subagent に
+  一次情報（helm.sh の v4 リリースノート・changelog、kubernetes-sigs/kustomize の issue/PR、
+  azure/setup-helm の README）を確認させた結果、技術的な互換性のハードルは無い
+  （kustomize v5.8.1 は helm v4 対応の既知バグ修正 (kustomize#6013, PR #6016) を取り込み済みで
+  本リポジトリが使う helmCharts の基本フィールドは v4 の breaking changes に抵触しない）が、
+  CI が使う `azure/setup-helm` アクション自身が README で『v2+ of this action only support
+  Helm3』と明言しており v4 系を公式サポートしていないと判明。auto-merge のゲートである CI に
+  根拠の薄い変更を入れないため、DoD の分岐（影響があれば blocked にする）に従い T-0118 を
+  blocked にし、根拠を backlog notes と ops/inventory.json の該当エントリに記録した（#未定）
+- 次の起動へ: backlog の todo は T-0117 のみ（schedule 03:30 UTC 待ち）。T-0118 は
+  azure/setup-helm の公式 v4 対応が出るまで再開しない
+- ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化、`ops/validate.py`
+  0 error（10 warning、既存のもの）、`ops/dashboard/build.py` 正常終了を確認。Artifact
+  ツールがこの環境に無く re-publish はできなかった

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T00:40:00Z",
+  "updated": "2026-08-06T00:56:52Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-05T18:47:54Z"
+    "last_read": "2026-08-06T00:56:52Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -910,6 +910,24 @@
       "prs": [
         266
       ]
+    },
+    {
+      "n": 85,
+      "at": "2026-08-06T00:51:00Z",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。backlog の唯一の todo（T-0117）は coder-workspace-home-backup CronJob の schedule（03:30 UTC）未到来のため着手不能と判断し、ops/inventory.json の未チェック分8件を subagent で調査。8件とも current が upstream 最新のままだったが、gha-setup-helm-version の upstream (helm/helm) に v4 系があり v3 系に EOL 接近の告知があると判明したため T-0118 として起票。T-0117 の blocked_by が T-0078 done 後も stale なままだったのを解消",
+      "prs": [
+        267
+      ]
+    },
+    {
+      "n": 86,
+      "at": "2026-08-06T09:58:00+09:00",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。ops-health-report で全11 Application Synced/Healthy、新規異常なし。T-0117 は CronJob schedule（03:30 UTC）未到来のため引き続き着手不能。T-0118（helm v3→v4系への移行検討）を完遂: kustomize v5.8.1 は helm v4 対応済みだが azure/setup-helm アクション自身が v3 のみ公式サポートと明言しているため blocked にし、一次情報を backlog/inventory に記録",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

- T-0118（CI の helm バイナリ [azure/setup-helm の version input] を v3 → v4 系へ移行するか検討）を調査・完遂。結論は **blocked**。
  - kustomize v5.8.1（本リポジトリが既に使用中）は helm v4 対応の既知バグ修正（kubernetes-sigs/kustomize#6013, PR #6016）を取り込み済みで、本リポジトリが使う `helmCharts` の基本フィールド（repo/name/version/releaseName/namespace/valuesFile）は helm v4 の breaking changes に抵触しないと確認
  - ただし CI が使う `azure/setup-helm` アクション自身が README で「v2+ of this action only support Helm3」と明言しており、v4 系のバージョン指定を公式サポートしていない。auto-merge のゲートである CI に根拠の薄い変更を入れないため、`ops/backlog.json` の T-0118 を `blocked` にし、根拠（一次情報 URL 含む）を notes と `ops/inventory.json` の該当エントリに記録した
- run #85 の `ops/state.json` 記録漏れ（journal にはあったが `runs` 配列に無かった）を埋め合わせ
- `ops/journal/2026-08.md` に run #86 の記録を追記、`ops/dashboard/prs.json` キャッシュを最新化

## 検証したこと

- `python3 ops/validate.py` → 0 error（既存の warning 10件のみ、本 PR とは無関係）
- `python3 ops/check_version_sync.py` / `check_pvc_usage_script_sync.py` / `check_doc_commands.py` → green
- `python3 ops/dashboard/build.py` → 例外なく終了

## ロールバック手順

`ops/` の記録・ドキュメントのみの変更で、クラスタに反映されるものは無い。revert すれば元に戻る（DB・スキーマは関与しない）。

## backlog task id

T-0118