### PR TITLE
docs(apps): apps/README.md のアプリ一覧を kustomization.yaml と同期 (T-0119)

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -70,6 +70,7 @@ NAME                 SYNC STATUS   HEALTH STATUS
 apps                 Synced        Healthy
 agent-rbac           Synced        Healthy
 argocd               Synced        Healthy
+autopilot            Synced        Healthy
 coder                Synced        Healthy
 dex                  Synced        Healthy
 external-secrets     Synced        Healthy
@@ -125,7 +126,8 @@ apps/
 ├── immich/
 ├── vaultwarden/
 ├── coder/
-└── ops-health-reporter/
+├── ops-health-reporter/
+└── autopilot/
 ```
 
 各アプリは以下の構造:

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 120,
-  "updated": "2026-08-06T01:15:00Z",
+  "updated": "2026-08-06T01:12:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2250,7 +2250,7 @@
         "apps/kustomization.yaml"
       ],
       "created": "2026-08-06",
-      "pr": null,
+      "pr": 269,
       "notes": "run #87: backlog の todo（T-0117）が CronJob schedule 未到来で着手不能だったため CHARTER §3 の調査に切り替え、subagent が発見。同じクラスのドリフトが3回目のため、今後もアプリ追加のたびに再発する可能性が高い（自動検出の仕組みは無し、再発したら CI 化を検討）"
     }
   ]

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 119,
-  "updated": "2026-08-06T00:40:00Z",
+  "next_id": 120,
+  "updated": "2026-08-06T01:15:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2227,10 +2227,31 @@
       "why": "run #85 の inventory 定期チェック（T-0117 が CronJob の schedule 未到来で着手不能だったため実施）で、CI が使う helm バイナリ（`gha-setup-helm-version`, 現行 v3.21.3, ops/inventory.json）の upstream (helm/helm) に v4 系（最新 v4.2.3）が存在し、v3 系の release notes に EOL 接近の告知があると判明した。v3.21.3 自体は v3 系列の最新なので inventory の『current が遅れている』判定（同一系列内の追従）には該当せず緊急性は無いが、系列そのものの移行は別論点として検討が要る",
       "dod": "helm v4 の breaking changes（release notes / migration guide）を原文で確認し、このリポジトリの CI（`kustomize build --enable-helm` を使う manifests job・manifest-diff job）が使う helm の呼び出し方（`--enable-helm` フラグの挙動、chart repo 設定等）に影響が無いか洗い出す。影響が無ければ `.github/workflows/ci.yml` の helm version input と `ops/inventory.json` の `gha-setup-helm-version` を v4 系に上げる PR を出す。影響があれば内容を記録し、blocked にする理由を明記する",
       "blocked_by": "azure/setup-helm が v4 系の公式サポートを表明する（または実機検証で動作確認できる）まで",
-      "refs": [".github/workflows/ci.yml", "ops/inventory.json"],
+      "refs": [
+        ".github/workflows/ci.yml",
+        "ops/inventory.json"
+      ],
       "created": "2026-08-06",
       "pr": null,
       "notes": "run #85: 定期の inventory 調査（対象8件、他7件は current が最新のまま）で発見。緊急性は無い（v3.21.3 で CI は動いている）が EOL 接近の一次情報あり。run #86: 調査完遂。技術的な互換性のハードルは無い——kustomize v5.8.1（本リポジトリが既に使用中）は helm v4 対応の既知バグ修正（kubernetes-sigs/kustomize#6013, PR #6016）を取り込み済みで、本リポジトリが使う helmCharts の基本フィールド（repo/name/version/releaseName/namespace/valuesFile）は helm v4 の breaking changes に抵触しない（一次情報: https://helm.sh/blog/helm-4-released/ 、 https://helm.sh/docs/changelog/ ）。唯一の障害は CI が使う `azure/setup-helm` アクション自身が README で『v2+ of this action only support Helm3』と明言しており、v4 系のバージョン指定を公式サポートしていないこと（動く可能性はあるが未検証・未保証）。auto-merge のゲートである CI に根拠の薄い変更を入れないため blocked とした。再開条件: azure/setup-helm が v4 対応を明言するリリースを出す、または検証用ブランチで実機テストして動作を確認できたとき"
+    },
+    {
+      "id": "T-0119",
+      "domain": "homelab",
+      "title": "apps/README.md のアプリ一覧を apps/kustomization.yaml と同期する（autopilot 追記漏れ）",
+      "kind": "docs",
+      "risk": "low",
+      "status": "done",
+      "priority": 56,
+      "why": "apps/kustomization.yaml は10個の子 Application（argocd, agent-rbac, dex, external-secrets, tailscale-operator, immich, vaultwarden, coder, ops-health-reporter, autopilot）を持つが、apps/README.md の『期待される出力』kubectl ブロックと『ディレクトリ構造』図はどちらも autopilot 追加前のまま9個/8個止まりだった。同型のドリフトは T-0057/T-0058/T-0102 でも過去に発生しており、新しいアプリを追加するたびに再発している",
+      "dod": "apps/README.md の2箇所（kubectl 期待出力の一覧、ディレクトリ構造図）に autopilot を追加し、apps/kustomization.yaml の resources と一致させる",
+      "refs": [
+        "apps/README.md",
+        "apps/kustomization.yaml"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #87: backlog の todo（T-0117）が CronJob schedule 未到来で着手不能だったため CHARTER §3 の調査に切り替え、subagent が発見。同じクラスのドリフトが3回目のため、今後もアプリ追加のたびに再発する可能性が高い（自動検出の仕組みは無し、再発したら CI 化を検討）"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,28 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 269,
+      "title": "docs(apps): apps/README.md のアプリ一覧を kustomization.yaml と同期 (T-0119)",
+      "url": "https://github.com/hikuohiku/homelab/pull/269",
+      "isDraft": false,
+      "createdAt": "2026-08-06T01:11:32Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "SUCCESS"
+        }
+      ],
+      "headRefName": "autopilot/T-0119-apps-readme-sync",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 268,
+      "title": "chore(ops): run #86 の記録更新（T-0118: helm v4 移行を blocked に）",
+      "url": "https://github.com/hikuohiku/homelab/pull/268",
+      "mergedAt": "2026-08-06T01:05:55Z",
+      "headRefName": "autopilot/T-0118-helm-v4-investigate"
+    },
     {
       "number": 267,
       "title": "chore(ops): run #85 の記録更新（inventory 定点調査・T-0118 起票）",
@@ -413,13 +435,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/206",
       "mergedAt": "2026-08-05T16:02:15Z",
       "headRefName": "autopilot/run53-feedback-and-records"
-    },
-    {
-      "number": 205,
-      "title": "fix: restic ExternalSecret の remoteRef を実際の Doppler キー名に合わせる (T-0103)",
-      "url": "https://github.com/hikuohiku/homelab/pull/205",
-      "mergedAt": "2026-08-05T15:54:48Z",
-      "headRefName": "autopilot/T-0103-restic-doppler-key-mismatch"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2562,3 +2562,33 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化、`ops/validate.py`
   0 error（10 warning、既存のもの）、`ops/dashboard/build.py` 正常終了を確認。Artifact
   ツールがこの環境に無く re-publish はできなかった
+
+## 2026-08-06 10:10 JST — run #87
+
+- 前回の中断確認: オープン PR 1件（#268, T-0118 の記録更新、run #86 が open のまま終了）を発見。
+  CI（terraform validate / ops state validate / nix flake check / manifest deletion guard /
+  kustomize build / GitGuardian）全 green・`mergeable_state: clean` を確認して merge した
+  （ops/ 記録のみの低リスク変更のため即 merge）。ブランチは merge 時に GitHub が自動削除
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` で2ページとも）を
+  機械的に確認。last_read（2026-08-05T18:47:54Z）以降の新規コメント無し
+- ops-health-report（generated_at 2026-08-06T01:00:04Z）で Application 全件 Synced/Healthy、
+  pod_issues は常連の再起動カウントのみ（argocd 系4 Pod・coredns・local-path-provisioner・
+  metrics-server がいずれも restarts:19 だが waiting_reasons 無し、以前から変化なし）、
+  immich の backup_listing 最新ファイルは 2026-08-05T02:00:03Z（24時間以内）で正常、
+  autopilot 自身の heartbeat（iteration #31 exit_code 0、#32 開始）も正常と確認
+- backlog の唯一の todo（T-0117, coder workspace home backup の初回実行確認）は CronJob
+  schedule（03:30 UTC）が現在時刻（01:06 UTC）よりまだ先のため着手不能と判断。kubectl で
+  `LAST SCHEDULE: <none>` を確認。CHARTER §3 に従い調査タスクを自分で起票することにした
+- 見つけたこと・やったこと: subagent に新しい調査観点探しを投げ、apps/README.md の2箇所
+  （kubectl 期待出力一覧、ディレクトリ構造図）が apps/kustomization.yaml の10個の子
+  Application のうち autopilot を欠いたままだったと判明（README 最終更新 08-05 11:25 UTC、
+  autopilot Application 追加は同日 18:02 UTC で README がその後に追随していなかった）。
+  同型のドリフトは T-0057/T-0058/T-0102 で3回既出のため、今後もアプリ追加のたびに再発しうる。
+  T-0119 として起票・即完遂（2箇所とも autopilot 行を追加し kustomization.yaml と一致させた）
+- 次の起動へ: backlog の todo は T-0117 のみ（schedule 03:30 UTC 待ち。次の起動時に
+  現在時刻がこれを過ぎていれば着手できる）。同型ドリフトが3回目になったので、次に気づいたら
+  CI 検出（apps/kustomization.yaml の resources と apps/README.md の一覧を突き合わせる）の
+  追加を検討してもよい
+- ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化、`ops/validate.py`
+  0 error（10 warning、既存のもの）、`ops/dashboard/build.py` 正常終了を確認。Artifact
+  ツールがこの環境に無く re-publish はできなかった


### PR DESCRIPTION
## 変更点

- `apps/README.md` の2箇所（kubectl 期待出力一覧、ディレクトリ構造図）が `apps/kustomization.yaml`
  の10個の子 Application のうち `autopilot` を欠いたまま残っていた（README 最終更新は
  autopilot Application 追加より前）。両方に `autopilot` を追記し kustomization.yaml と一致させた
- 同型のドリフト（README のアプリ一覧が実態と食い違う）は T-0057/T-0058/T-0102 でも過去に発生しており、
  今後もアプリ追加のたびに再発しうる。CI 検出の追加は今回のスコープ外とし、次回気づいたら検討する
- `ops/journal/2026-08.md` に run #87 の記録を追記、`ops/backlog.json` に T-0119 を起票・完遂として記録

## 検証したこと

- `python3 ops/validate.py` → 0 error（既存の warning 10件のみ、本 PR とは無関係）
- `python3 ops/check_doc_commands.py` → ok
- `python3 ops/check_version_sync.py` → ok
- `python3 ops/dashboard/build.py` → 例外なく終了

## ロールバック手順

ドキュメントのみの変更で、クラスタに反映されるものは無い。revert すれば元に戻る（DB・スキーマは関与しない）。

## backlog task id

T-0119
