### PR TITLE
security(backup): restic backup 専用の append-only credential を追加 (T-0106)

### DIFF
--- a/apps/coder/restic-external-secret.yaml
+++ b/apps/coder/restic-external-secret.yaml
@@ -5,8 +5,14 @@
 # Requires: Doppler secrets（T-0067, ops/backlog.json 参照。バケット作成・キー発行は人間の作業）
 #   RESTIC_PASSWORD — restic リポジトリの暗号化パスワード（vaultwarden と共通）
 #   RESTIC_B2_BUCKET — Backblaze B2 のバケット名
-#   B2_ACCOUNT_ID    — B2 application key ID（append-only キー）
-#   B2_ACCOUNT_KEY   — B2 application key（同上）
+#   B2_ACCOUNT_ID    — B2 application key ID。retention CronJob（forget --prune、削除権限が要る）
+#                       と backup CronJob（coder-postgres 用・workspace home 用の両方、T-0078）が
+#                       この Secret を共用しているため、実際には削除権限を持つ鍵でなければならない
+#                       （append-only キーではない）。node01 が乗っ取られるとこのキーでバックアップ
+#                       自体を消せてしまう問題が T-0106 で指摘されており、backup 専用の append-only
+#                       キーは下の coder-restic-backup-credentials ExternalSecret に分離した
+#                       （登録が完了し次第 T-0120 で backup CronJob をそちらへ切り替える）
+#   B2_ACCOUNT_KEY   — 同上
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -34,3 +40,46 @@ spec:
     - secretKey: B2_ACCOUNT_KEY
       remoteRef:
         key: B2_ACCOUNT_KEY
+---
+# T-0106: backup 専用（削除権限を持たない append-only）credential。retention CronJob
+# （forget --prune、削除が必須）は引き続き上の coder-restic-credentials を使う。
+# coder-postgres 用backupとworkspace home 用backup（T-0078、動的Job生成）の両方がこの Secret を
+# 共用する想定（現行の coder-restic-credentials と同じ共有パターン）。RESTIC_PASSWORD/
+# RESTIC_B2_BUCKET はリポジトリの識別子であり秘匿すべき権限差が無いため上と同じ Doppler キーを
+# 共用する。B2_ACCOUNT_ID/B2_ACCOUNT_KEY だけ新しい Doppler キーを参照する。
+# Requires: Doppler secrets（未登録。登録手順は T-0106 の needs_human_reason 参照）
+#   B2_ACCOUNT_ID_APPEND_ONLY  — Backblaze で新規発行する B2 application key ID。
+#                                 capabilities は listBuckets/listFiles/readFiles/writeFiles のみ
+#                                 （deleteFiles を含めない）
+#   B2_ACCOUNT_KEY_APPEND_ONLY — 同上 application key
+# 登録されるまでこの ExternalSecret は SecretSyncedError のまま Ready にならないが、対応する
+# Secret（coder-restic-backup-credentials）を参照する CronJob/Job テンプレートはまだ無い（T-0120 で
+# 切り替えるまで backup 側は引き続き coder-restic-credentials を使う）ため、現状の日次バックアップ
+# には影響しない。
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: coder-restic-backup-credentials
+  namespace: coder
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler
+  target:
+    name: coder-restic-backup-credentials
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: RESTIC_PASSWORD
+      remoteRef:
+        key: RESTIC_PASSWORD
+    - secretKey: RESTIC_B2_BUCKET
+      remoteRef:
+        key: RESTIC_B2_BUCKET
+    - secretKey: B2_ACCOUNT_ID
+      remoteRef:
+        key: B2_ACCOUNT_ID_APPEND_ONLY
+    - secretKey: B2_ACCOUNT_KEY
+      remoteRef:
+        key: B2_ACCOUNT_KEY_APPEND_ONLY

--- a/apps/immich/restic-external-secret.yaml
+++ b/apps/immich/restic-external-secret.yaml
@@ -5,8 +5,14 @@
 # Requires: Doppler secrets（T-0067, ops/backlog.json 参照。バケット作成・キー発行は人間の作業）
 #   RESTIC_PASSWORD — restic リポジトリの暗号化パスワード（vaultwarden/coder-postgres と共通）
 #   RESTIC_B2_BUCKET — Backblaze B2 のバケット名
-#   B2_ACCOUNT_ID    — B2 application key ID（append-only キー）
-#   B2_ACCOUNT_KEY   — B2 application key（同上）
+#   B2_ACCOUNT_ID    — B2 application key ID。retention CronJob（forget --prune、削除権限が要る）
+#                       と backup CronJob の両方がこの Secret を共用しているため、実際には削除権限を
+#                       持つ鍵でなければならない（append-only キーではない）。node01 が乗っ取られると
+#                       このキーでバックアップ自体を消せてしまう問題が T-0106 で指摘されており、
+#                       backup 専用の append-only キーは下の immich-restic-backup-credentials
+#                       ExternalSecret に分離した（登録が完了し次第 T-0120 で backup CronJob を
+#                       そちらへ切り替える）
+#   B2_ACCOUNT_KEY   — 同上
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -34,3 +40,44 @@ spec:
     - secretKey: B2_ACCOUNT_KEY
       remoteRef:
         key: B2_ACCOUNT_KEY
+---
+# T-0106: backup 専用（削除権限を持たない append-only）credential。retention CronJob
+# （forget --prune、削除が必須）は引き続き上の immich-restic-credentials を使う。
+# RESTIC_PASSWORD/RESTIC_B2_BUCKET はリポジトリの識別子であり秘匿すべき権限差が無いため
+# 上と同じ Doppler キーを共用する。B2_ACCOUNT_ID/B2_ACCOUNT_KEY だけ新しい Doppler キーを参照する。
+# Requires: Doppler secrets（未登録。登録手順は T-0106 の needs_human_reason 参照）
+#   B2_ACCOUNT_ID_APPEND_ONLY  — Backblaze で新規発行する B2 application key ID。
+#                                 capabilities は listBuckets/listFiles/readFiles/writeFiles のみ
+#                                 （deleteFiles を含めない）
+#   B2_ACCOUNT_KEY_APPEND_ONLY — 同上 application key
+# 登録されるまでこの ExternalSecret は SecretSyncedError のまま Ready にならないが、対応する
+# Secret（immich-restic-backup-credentials）を参照する CronJob はまだ無い（T-0120 で切り替える
+# まで backup CronJob は引き続き immich-restic-credentials を使う）ため、現状の日次バックアップ
+# には影響しない。
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: immich-restic-backup-credentials
+  namespace: immich
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler
+  target:
+    name: immich-restic-backup-credentials
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: RESTIC_PASSWORD
+      remoteRef:
+        key: RESTIC_PASSWORD
+    - secretKey: RESTIC_B2_BUCKET
+      remoteRef:
+        key: RESTIC_B2_BUCKET
+    - secretKey: B2_ACCOUNT_ID
+      remoteRef:
+        key: B2_ACCOUNT_ID_APPEND_ONLY
+    - secretKey: B2_ACCOUNT_KEY
+      remoteRef:
+        key: B2_ACCOUNT_KEY_APPEND_ONLY

--- a/apps/vaultwarden/restic-external-secret.yaml
+++ b/apps/vaultwarden/restic-external-secret.yaml
@@ -5,8 +5,14 @@
 # Requires: Doppler secrets（T-0067, ops/backlog.json 参照。バケット作成・キー発行は人間の作業）
 #   RESTIC_PASSWORD — restic リポジトリの暗号化パスワード（新規に決めて登録する。復元時に必要）
 #   RESTIC_B2_BUCKET — Backblaze B2 のバケット名
-#   B2_ACCOUNT_ID    — B2 application key ID（append-only キー）
-#   B2_ACCOUNT_KEY   — B2 application key（同上）
+#   B2_ACCOUNT_ID    — B2 application key ID。retention CronJob（forget --prune、削除権限が要る）
+#                       と backup CronJob の両方がこの Secret を共用しているため、実際には削除権限を
+#                       持つ鍵でなければならない（append-only キーではない）。node01 が乗っ取られると
+#                       このキーでバックアップ自体を消せてしまう問題が T-0106 で指摘されており、
+#                       backup 専用の append-only キーは下の vaultwarden-restic-backup-credentials
+#                       ExternalSecret に分離した（登録が完了し次第 T-0120 で backup CronJob を
+#                       そちらへ切り替える）
+#   B2_ACCOUNT_KEY   — 同上
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -34,3 +40,44 @@ spec:
     - secretKey: B2_ACCOUNT_KEY
       remoteRef:
         key: B2_ACCOUNT_KEY
+---
+# T-0106: backup 専用（削除権限を持たない append-only）credential。retention CronJob
+# （forget --prune、削除が必須）は引き続き上の vaultwarden-restic-credentials を使う。
+# RESTIC_PASSWORD/RESTIC_B2_BUCKET はリポジトリの識別子であり秘匿すべき権限差が無いため
+# 上と同じ Doppler キーを共用する。B2_ACCOUNT_ID/B2_ACCOUNT_KEY だけ新しい Doppler キーを参照する。
+# Requires: Doppler secrets（未登録。登録手順は T-0106 の needs_human_reason 参照）
+#   B2_ACCOUNT_ID_APPEND_ONLY  — Backblaze で新規発行する B2 application key ID。
+#                                 capabilities は listBuckets/listFiles/readFiles/writeFiles のみ
+#                                 （deleteFiles を含めない）
+#   B2_ACCOUNT_KEY_APPEND_ONLY — 同上 application key
+# 登録されるまでこの ExternalSecret は SecretSyncedError のまま Ready にならないが、対応する
+# Secret（vaultwarden-restic-backup-credentials）を参照する CronJob はまだ無い（T-0120 で切り替える
+# まで backup CronJob は引き続き vaultwarden-restic-credentials を使う）ため、現状の日次バックアップ
+# には影響しない。
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: vaultwarden-restic-backup-credentials
+  namespace: vaultwarden
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler
+  target:
+    name: vaultwarden-restic-backup-credentials
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: RESTIC_PASSWORD
+      remoteRef:
+        key: RESTIC_PASSWORD
+    - secretKey: RESTIC_B2_BUCKET
+      remoteRef:
+        key: RESTIC_B2_BUCKET
+    - secretKey: B2_ACCOUNT_ID
+      remoteRef:
+        key: B2_ACCOUNT_ID_APPEND_ONLY
+    - secretKey: B2_ACCOUNT_KEY
+      remoteRef:
+        key: B2_ACCOUNT_KEY_APPEND_ONLY

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -282,11 +282,42 @@ DB 接続不要）の2段で行った。
 |---|---|
 | `RESTIC_PASSWORD` | restic リポジトリの暗号化パスワード（新規に決めて登録） |
 | `RESTIC_B2_BUCKET` | Backblaze B2 のバケット名 |
-| `B2_ACCOUNT_ID` | B2 application key ID（**append-only** キーを推奨。node01 が乗っ取られてもバックアップを消せないように） |
+| `B2_ACCOUNT_ID` | B2 application key ID（**実際には削除権限を持つ鍵**。retention CronJob の `forget --prune` と backup CronJob の両方がこのキーを共用しているため。append-only にはなっていない — 下記 T-0106 参照） |
 | `B2_ACCOUNT_KEY` | 同上 application key |
 
 登録後、`ops-health-report`（`pod_issues`）で `vaultwarden-restic-backup` CronJob の Job が
 Failed になっていないことを確認できれば実際に動作したとみなせる（T-0097）。
+
+## backup 専用 credential への分離 (T-0106, 2026-08-06)
+
+issue #56（2026-08-05 16:02:29）の指摘: 実際に `restic forget --prune` が B2 上のオブジェクトを
+削除できることを確認した際、上記 `B2_ACCOUNT_ID`/`B2_ACCOUNT_KEY` が backup と retention の両方の
+CronJob に共用されており、削除権限を持つ鍵であることが判明した（「append-only キーを推奨」という
+当初の登録依頼どおりには登録されていなかった、または退避目的で意図的に共用された）。node01 が
+侵害された場合、この単一の鍵でバックアップそのものを消せてしまう。「バックアップがある」ことと
+「バックアップが守られている」ことは別、という指摘どおり。
+
+**対処（manifest 側、この起動で完了）**: `apps/{vaultwarden,immich,coder}/restic-external-secret.yaml`
+に backup 専用の ExternalSecret（`<app>-restic-backup-credentials`）を追加した。新しい Doppler キー
+`B2_ACCOUNT_ID_APPEND_ONLY`/`B2_ACCOUNT_KEY_APPEND_ONLY` を参照する。retention CronJob
+（削除が必須）は引き続き既存の `<app>-restic-credentials` を使う。
+
+**現状は追加のみで、既存の backup CronJob の参照先はまだ切り替えていない。** 新しい Doppler キーが
+まだ存在しないため、新しい ExternalSecret は登録が済むまで `SecretSyncedError` のまま Ready に
+ならない想定だが、どの CronJob もまだこの新しい Secret を参照していないため、現行の日次バックアップ
+には影響しない。
+
+**人間への依頼（T-0106, needs-human）**: Backblaze の管理コンソールで、既存バケット向けの
+新しい Application Key を発行する。Capabilities は `listBuckets`/`listFiles`/`readFiles`/
+`writeFiles` のみ（`deleteFiles` を含めない = 真の append-only）にする。発行した keyID/
+applicationKey を Doppler（`homelab/prd`）に `B2_ACCOUNT_ID_APPEND_ONLY` /
+`B2_ACCOUNT_KEY_APPEND_ONLY` として登録する。
+
+**登録後の切り替え（T-0120, blocked）**: `kubectl get externalsecret <app>-restic-backup-credentials
+-n <app>` で Ready を確認した上で、4つの backup CronJob（`vaultwarden-restic-backup` /
+`immich-restic-backup` / `coder-restic-backup` / `coder-workspace-home-backup` の動的 Job
+テンプレート）の `B2_ACCOUNT_ID`/`B2_ACCOUNT_KEY` の `secretKeyRef.name` を新しい
+`<app>-restic-backup-credentials` に切り替える。retention CronJob 側は変更しない。
 
 ## わかっていること（repo から）
 

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1983,8 +1983,8 @@
         "docs/backup.md"
       ],
       "created": "2026-08-05",
-      "pr": null,
-      "notes": "run #29: T-0071（復元試験）完了を待つ方針で blocked に。run #88: T-0071 が既に done（2026-08-06 完了）と確認しblocked_by を解消。manifest（backup専用ExternalSecret 3ファイル分）を実装し、credential 発行のみを残す needs-human に変更。CronJob 側の参照切り替えは新しい鍵の存在確認が要るため T-0120 として分離"
+      "pr": 271,
+      "notes": "run #29: T-0071（復元試験）完了を待つ方針で blocked に。run #88: T-0071 が既に done（2026-08-06 完了）と確認しblocked_by を解消。manifest（backup専用ExternalSecret 3ファイル分）を実装し、credential 発行のみを残す needs-human に変更（#271）。CronJob 側の参照切り替えは新しい鍵の存在確認が要るため T-0120 として分離"
     },
     {
       "id": "T-0109",

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 120,
+  "next_id": 121,
   "updated": "2026-08-06T01:12:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
@@ -1970,20 +1970,21 @@
       "title": "B2 の restic 用 credential を append-only 鍵に分離する",
       "kind": "security",
       "risk": "medium",
-      "status": "blocked",
+      "status": "needs-human",
       "priority": 70,
       "why": "issue #56 (2026-08-05 16:02:29、構築セッション経由) の指摘。restic の動作確認で `restic forget --prune` が実際に B2 上のオブジェクトを削除できることが分かった。つまり現在発行されている B2 credential には削除権限がある。node01 が侵害された場合、攻撃者はバックアップ自体も消せてしまう（『バックアップがある』と『バックアップが守られている』は別）",
-      "dod": "restic backup（push のみ）用と retention/restore（削除・読み取りが要る）用で B2 アプリケーションキーを分離するか、backup 用キーを append-only（write専用、delete不可）にする。バックアップ用 CronJob には append-only 鍵、retention（forget --prune）用の CronJob には削除権限のある鍵を使い分ける",
-      "blocked_by": "T-0071（復元試験）が先。バックアップの仕組み自体がまだ復元まで検証できていないうちに credential 分離で複雑さを増やすと、切り分けが難しくなる（構築セッションの提案どおり優先度を後ろに置く）",
-      "needs_human_reason": "B2 の新しい append-only アプリケーションキーの発行は Backblaze 管理画面での操作が要る。manifest 側（ExternalSecret のキー参照を分ける等）の設計はこちらで先に進められる",
+      "dod": "manifest 側は完了（run #88）: apps/{vaultwarden,immich,coder}/restic-external-secret.yaml に backup 専用 ExternalSecret（<app>-restic-backup-credentials、新しい Doppler キー B2_ACCOUNT_ID_APPEND_ONLY/B2_ACCOUNT_KEY_APPEND_ONLY を参照）を追加した。残りは人間の credential 発行のみ。登録後の CronJob 切り替えは T-0120 に分離した",
+      "blocked_by": null,
+      "needs_human_reason": "Backblaze 管理コンソールで既存バケット向けの新しい Application Key を発行する。Capabilities は listBuckets/listFiles/readFiles/writeFiles のみ（deleteFiles を含めない = 真の append-only）にする。発行した keyID/applicationKey を Doppler (homelab/prd) に B2_ACCOUNT_ID_APPEND_ONLY / B2_ACCOUNT_KEY_APPEND_ONLY として登録する。登録後は ExternalSecret が自動同期し、T-0120 が拾える",
       "refs": [
-        "apps/vaultwarden/restic-backup-cronjob.yaml",
-        "apps/coder/restic-backup-cronjob.yaml",
-        "apps/immich/restic-backup-cronjob.yaml",
+        "apps/vaultwarden/restic-external-secret.yaml",
+        "apps/coder/restic-external-secret.yaml",
+        "apps/immich/restic-external-secret.yaml",
         "docs/backup.md"
       ],
       "created": "2026-08-05",
-      "pr": null
+      "pr": null,
+      "notes": "run #29: T-0071（復元試験）完了を待つ方針で blocked に。run #88: T-0071 が既に done（2026-08-06 完了）と確認しblocked_by を解消。manifest（backup専用ExternalSecret 3ファイル分）を実装し、credential 発行のみを残す needs-human に変更。CronJob 側の参照切り替えは新しい鍵の存在確認が要るため T-0120 として分離"
     },
     {
       "id": "T-0109",
@@ -2252,6 +2253,28 @@
       "created": "2026-08-06",
       "pr": 269,
       "notes": "run #87: backlog の todo（T-0117）が CronJob schedule 未到来で着手不能だったため CHARTER §3 の調査に切り替え、subagent が発見。同じクラスのドリフトが3回目のため、今後もアプリ追加のたびに再発する可能性が高い（自動検出の仕組みは無し、再発したら CI 化を検討）"
+    },
+    {
+      "id": "T-0120",
+      "domain": "homelab",
+      "title": "restic backup CronJob を append-only credential (T-0106) に切り替える",
+      "kind": "security",
+      "risk": "medium",
+      "status": "blocked",
+      "priority": 71,
+      "why": "T-0106 で backup 専用の append-only ExternalSecret（<app>-restic-backup-credentials）を3 namespace 分追加したが、新しい Doppler キー（B2_ACCOUNT_ID_APPEND_ONLY/B2_ACCOUNT_KEY_APPEND_ONLY）がまだ登録されておらず、4つの backup CronJob（vaultwarden-restic-backup/immich-restic-backup/coder-restic-backup/coder-workspace-home-backup）は引き続き削除権限を持つ既存credentialを参照したままになっている。credential 分離を実効化するにはこの切り替えが要る",
+      "dod": "各 namespace で `kubectl get externalsecret <app>-restic-backup-credentials -n <app>` を実行し、SecretSynced/Ready を確認する。確認できたら、4つの backup CronJob（coder-workspace-home-backup は動的 Job テンプレートのスクリプト側）の B2_ACCOUNT_ID/B2_ACCOUNT_KEY の secretKeyRef.name を <app>-restic-credentials から <app>-restic-backup-credentials に切り替える。retention CronJob（forget --prune、削除権限が要る）は変更しない。切り替え後、次回のスケジュール実行が成功することを ops-health-report の pod_issues で確認する",
+      "blocked_by": "T-0106（人間による Backblaze append-only キー発行 + Doppler 登録）",
+      "refs": [
+        "apps/vaultwarden/restic-backup-cronjob.yaml",
+        "apps/immich/restic-backup-cronjob.yaml",
+        "apps/coder/restic-backup-cronjob.yaml",
+        "apps/coder/workspace-home-backup-cronjob.yaml",
+        "docs/backup.md"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #88: T-0106 の manifest 実装（backup専用ExternalSecret 追加）の副産物として分離起票。credential 未登録の間に backup CronJob 側を切り替えると日次バックアップが失敗し続けるため、意図的に manifest 追加のみに留め、この切り替え作業を別タスクにした"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,20 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
+    {
+      "number": 270,
+      "title": "chore(ops): run #87 の記録更新",
+      "url": "https://github.com/hikuohiku/homelab/pull/270",
+      "mergedAt": "2026-08-06T01:16:58Z",
+      "headRefName": "autopilot/T-0119-run87-wrapup"
+    },
     {
       "number": 269,
       "title": "docs(apps): apps/README.md のアプリ一覧を kustomization.yaml と同期 (T-0119)",
       "url": "https://github.com/hikuohiku/homelab/pull/269",
-      "isDraft": false,
-      "createdAt": "2026-08-06T01:11:32Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "SUCCESS"
-        }
-      ],
-      "headRefName": "autopilot/T-0119-apps-readme-sync",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-06T01:14:31Z",
+      "headRefName": "autopilot/T-0119-apps-readme-sync"
+    },
     {
       "number": 268,
       "title": "chore(ops): run #86 の記録更新（T-0118: helm v4 移行を blocked に）",
@@ -421,20 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/208",
       "mergedAt": "2026-08-05T16:15:10Z",
       "headRefName": "autopilot/run53-record"
-    },
-    {
-      "number": 207,
-      "title": "feat: 一度きりの Job で restic backup を即時検証する (T-0104)",
-      "url": "https://github.com/hikuohiku/homelab/pull/207",
-      "mergedAt": "2026-08-05T16:09:10Z",
-      "headRefName": "autopilot/T-0104-restic-backup-verify-once"
-    },
-    {
-      "number": 206,
-      "title": "ops: issue #56 フィードバック反映 (T-0063 done, T-0079 dropped, T-0067 done)",
-      "url": "https://github.com/hikuohiku/homelab/pull/206",
-      "mergedAt": "2026-08-05T16:02:15Z",
-      "headRefName": "autopilot/run53-feedback-and-records"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,5 +1,20 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 271,
+      "title": "security(backup): restic backup 専用の append-only credential を追加 (T-0106)",
+      "url": "https://github.com/hikuohiku/homelab/pull/271",
+      "isDraft": false,
+      "createdAt": "2026-08-06T01:28:47Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "PENDING"
+        }
+      ],
+      "headRefName": "autopilot/T-0106-restic-backup-append-only-credential",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
     {
       "number": 270,

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2592,3 +2592,34 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化、`ops/validate.py`
   0 error（10 warning、既存のもの）、`ops/dashboard/build.py` 正常終了を確認。Artifact
   ツールがこの環境に無く re-publish はできなかった
+
+## 2026-08-06 10:26 JST — run #88
+
+- 前回の中断: オープン PR 無し。`autopilot/*` 残存ブランチ無し
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` で2ページとも）を
+  機械的に確認。last_read（2026-08-06T00:56:52Z）以降の新規コメント無し
+- ops-health-report（generated_at 2026-08-06T01:00:04Z）で Application 全11件 Synced/Healthy、
+  pod_issues は常連の再起動カウント（restarts:19、以前から変化なし）のみで新規異常なし、
+  immich の backup_listing も最新 mtime が 2026-08-05T02:00:03Z（24時間以内）で正常、
+  autopilot 自身の heartbeat（iteration #31 exit_code 0、#32 開始）も正常と確認
+- backlog の唯一の todo（T-0117, coder workspace home backup の初回実行確認）は CronJob
+  schedule（03:30 UTC）が現在時刻（01:20 UTC）よりまだ先のため引き続き着手不能
+- 見つけたこと・やったこと: CHARTER §3 に従い blocked/needs-human タスクの blocked_by が
+  今も有効か確認したところ、T-0106（B2 restic credential の append-only 鍵分離）の
+  blocked_by が指す T-0071（復元試験）が既に done（2026-08-06 完了）になっているのに
+  T-0106 側は blocked のまま取り残されていたと判明。CHARTER §3「blocked/needs-human は
+  タスク全体ではなくどの部分かで見る」に従い、manifest 側（backup 専用 ExternalSecret の
+  追加）を実装した。apps/{vaultwarden,immich,coder}/restic-external-secret.yaml に
+  `<app>-restic-backup-credentials`（新しい Doppler キー B2_ACCOUNT_ID_APPEND_ONLY/
+  B2_ACCOUNT_KEY_APPEND_ONLY を参照）を追加、既存の `<app>-restic-credentials`（backup と
+  retention の両方が共用しており実際には削除権限を持つ鍵）の説明コメントも実態に合わせて
+  訂正した。**既存の backup CronJob の参照先はまだ切り替えていない**（新しい Doppler キーが
+  無い状態で切り替えると日次バックアップが失敗し続けるため、意図的に追加のみに留めた）。
+  docs/backup.md に設計と手順を追記。T-0106 を「manifest 完了・credential 発行待ちの
+  needs-human」に narrow化し、切り替え作業は新規 T-0120（blocked_by: T-0106）として分離した
+- 次の起動へ: T-0117 は CronJob schedule（03:30 UTC）を過ぎていれば着手できる。T-0106 は
+  人間による Backblaze append-only キー発行 + Doppler 登録待ち。T-0120 はその登録が終わり
+  ExternalSecret が Ready になってから着手する
+- ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化、`ops/validate.py`
+  0 error（10 warning、既存のもの、今回の変更由来の新規警告なし）、`ops/dashboard/build.py`
+  正常終了を確認。Artifact ツールがこの環境に無く re-publish はできなかった

--- a/ops/state.json
+++ b/ops/state.json
@@ -946,7 +946,9 @@
       "kind": "scheduled",
       "by": "in-cluster autopilot",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0117 は CronJob schedule（03:30 UTC）未到来のため引き続き着手不能。CHARTER §3 に従い blocked/needs-human タスクの blocked_by 有効性を確認したところ、T-0106（B2 restic credential の append-only 鍵分離）の blocked_by（T-0071 復元試験）が既に done なのに blocked のまま取り残されていたと判明。manifest 側（apps/{vaultwarden,immich,coder}/restic-external-secret.yaml に backup 専用 ExternalSecret <app>-restic-backup-credentials を追加、新しい Doppler キー B2_ACCOUNT_ID_APPEND_ONLY/B2_ACCOUNT_KEY_APPEND_ONLY を参照）を実装し、既存 backup CronJob の参照先はまだ切り替えず現状の日次バックアップへの影響を回避した。T-0106 を credential 発行待ちの needs-human に narrow化し、切り替え作業を T-0120（blocked_by: T-0106）として分離した",
-      "prs": []
+      "prs": [
+        271
+      ]
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -6,7 +6,7 @@
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T00:56:52Z"
+    "last_read": "2026-08-06T01:26:31Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -939,6 +939,14 @@
         268,
         269
       ]
+    },
+    {
+      "n": 88,
+      "at": "2026-08-06T10:26:00+09:00",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0117 は CronJob schedule（03:30 UTC）未到来のため引き続き着手不能。CHARTER §3 に従い blocked/needs-human タスクの blocked_by 有効性を確認したところ、T-0106（B2 restic credential の append-only 鍵分離）の blocked_by（T-0071 復元試験）が既に done なのに blocked のまま取り残されていたと判明。manifest 側（apps/{vaultwarden,immich,coder}/restic-external-secret.yaml に backup 専用 ExternalSecret <app>-restic-backup-credentials を追加、新しい Doppler キー B2_ACCOUNT_ID_APPEND_ONLY/B2_ACCOUNT_KEY_APPEND_ONLY を参照）を実装し、既存 backup CronJob の参照先はまだ切り替えず現状の日次バックアップへの影響を回避した。T-0106 を credential 発行待ちの needs-human に narrow化し、切り替え作業を T-0120（blocked_by: T-0106）として分離した",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

restic backup（vaultwarden/immich/coder-postgres/coder workspace home の4系統）と
retention（`forget --prune`）が同じ B2 credential を共用しており、実際には削除権限を
持つ鍵だった。node01 が侵害されると、この単一の鍵でバックアップ自体を消せてしまう
（issue #56, 2026-08-05 16:02:29 の指摘、T-0106）。

- `apps/{vaultwarden,immich,coder}/restic-external-secret.yaml` に backup 専用の
  ExternalSecret（`<app>-restic-backup-credentials`）を追加。新しい Doppler キー
  `B2_ACCOUNT_ID_APPEND_ONLY`/`B2_ACCOUNT_KEY_APPEND_ONLY` を参照する
- 既存の `<app>-restic-credentials`（backup と retention 両方が共用）の説明コメントを
  実態（削除権限あり、append-only ではない）に訂正
- `docs/backup.md` に設計と手順を追記
- `ops/backlog.json`: T-0106 を「manifest 完了・credential 発行待ちの needs-human」に
  narrow化。切り替え作業を新規 T-0120（blocked_by: T-0106）として分離

**この PR では既存の backup CronJob の参照先はまだ切り替えていない。** 新しい Doppler
キーが登録されるまで新しい ExternalSecret は `SecretSyncedError` のままだが、どの
CronJob もまだこの Secret を参照していないため、現行の日次バックアップ（vaultwarden
03:40 UTC / immich 02:45 UTC / coder-postgres 03:10 UTC / coder workspace home 03:30 UTC）
には影響しない。retention（`forget --prune`）も変更していない。

## 人間への依頼（T-0106, needs-human）

Backblaze 管理コンソールで既存バケット向けの新しい Application Key を発行してください。
Capabilities は `listBuckets`/`listFiles`/`readFiles`/`writeFiles` のみ
（`deleteFiles` を含めない = 真の append-only）にしてください。発行した keyID/
applicationKey を Doppler（`homelab/prd`）に `B2_ACCOUNT_ID_APPEND_ONLY` /
`B2_ACCOUNT_KEY_APPEND_ONLY` として登録してください。登録後は ExternalSecret が自動で
同期し、次回以降の起動が T-0120（backup CronJob の参照切り替え）を拾います。

## 検証したこと

- `python3 ops/validate.py` → 0 error（既存の 10 warning のみ、今回の変更由来の新規警告なし）
- `python3 -c "import yaml; ...safe_load_all(...)"` で3ファイルとも2ドキュメントに
  正しくパースされることを確認
- `python3 ops/dashboard/build.py` 正常終了
- CI（`kustomize build` / `terraform validate` / `ops state validate` /
  manifest deletion guard 等）は green であることをこの後確認する

## ロールバック手順

このコミットを revert すれば追加した2つの ExternalSecret リソースが削除される
（`deletionPolicy: Retain` のため、生成された Kubernetes Secret 自体は残る想定だが
中身は空、どのワークロードからも参照されていないため実害なし）。既存の backup/retention
CronJob の動作には一切変更を加えていないため、revert 前後で挙動差は無い。**破壊的な
スキーマ変更やデータ変更は含まれない。**

## backlog task id

T-0106, T-0120
