### PR TITLE
fix(ops-health-reporter): autopilot heartbeat 検出窓を tailLines から sinceSeconds に変更 (T-0121)

### DIFF
--- a/apps/ops-health-reporter/report.py
+++ b/apps/ops-health-reporter/report.py
@@ -268,8 +268,16 @@ def collect_autopilot_health():
 
     if pod_name:
         try:
+            # tailLines=200 は不十分だった（2026-08-06 run #89 で last_start/last_end が
+            # 両方 null になる事象を観測）。render.py (apps/autopilot/render.py) は
+            # claude -p の stream-json イベント（tool_use/text/result）を 1 行ずつ出すため、
+            # 込み入ったイテレーション 1 回だけで 200 行を超え、直近の
+            # "iteration #N start" 行が窓の外に押し出されうる。行数ではなく時間で窓を取り、
+            # ITERATION_TIMEOUT_SECONDS（apps/autopilot/deployment.yaml, 現行 3600s）
+            # 1 周分 + 余裕を確実にカバーする。deployment.yaml 側の値を大きく変えたら
+            # ここも合わせて見直すこと
             raw = k8s_get_text(
-                "/api/v1/namespaces/{}/pods/{}/log?tailLines=200".format(
+                "/api/v1/namespaces/{}/pods/{}/log?sinceSeconds=7200".format(
                     AUTOPILOT_NAMESPACE, pod_name
                 )
             )

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 121,
-  "updated": "2026-08-06T01:12:00Z",
+  "next_id": 122,
+  "updated": "2026-08-06T01:45:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2275,6 +2275,26 @@
       "created": "2026-08-06",
       "pr": null,
       "notes": "run #88: T-0106 の manifest 実装（backup専用ExternalSecret 追加）の副産物として分離起票。credential 未登録の間に backup CronJob 側を切り替えると日次バックアップが失敗し続けるため、意図的に manifest 追加のみに留め、この切り替え作業を別タスクにした"
+    },
+    {
+      "id": "T-0121",
+      "domain": "homelab",
+      "title": "ops-health-reporter の autopilot heartbeat 検出窓を tailLines から sinceSeconds に変更",
+      "kind": "fix",
+      "risk": "low",
+      "status": "done",
+      "priority": 42,
+      "why": "run #89 で ops-health-report の autopilot.heartbeat.last_start/last_end が両方 null になっているのを発見。原因は apps/ops-health-reporter/report.py が pod log を tailLines=200 でしか取っていないこと。render.py は claude -p の stream-json イベントを 1 行ずつ出すため、込み入ったイテレーション 1 回で 200 行を超え、直近の \"iteration #N start\" 行が窓の外に押し出されうる。CHARTER §2 が autopilot 自身のハング検知に使う仕組みが、実際には頻繁に効いていない状態だった",
+      "dod": "apps/ops-health-reporter/report.py の pod log 取得を tailLines=200 から sinceSeconds ベース（ITERATION_TIMEOUT_SECONDS 現行3600s の1周分+余裕を確実にカバーする7200s）に変更する。CI（kustomize build 等）green を確認する。次回の ops-health-reporter CronJob 実行（30分毎）後、latest.json の autopilot.heartbeat が null でなく実際の iteration 番号を返すことを確認する",
+      "blocked_by": null,
+      "refs": [
+        "apps/ops-health-reporter/report.py",
+        "apps/autopilot/render.py",
+        "apps/autopilot/deployment.yaml"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #89 で発見・即完遂。修正後の実効性確認（次回 CronJob 実行後の latest.json）は次の起動で見る"
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 122,
-  "updated": "2026-08-06T01:45:00Z",
+  "updated": "2026-08-06T01:50:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2293,7 +2293,7 @@
         "apps/autopilot/deployment.yaml"
       ],
       "created": "2026-08-06",
-      "pr": null,
+      "pr": 272,
       "notes": "run #89 で発見・即完遂。修正後の実効性確認（次回 CronJob 実行後の latest.json）は次の起動で見る"
     }
   ]

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,28 @@
 {
   "open": [
     {
-      "number": 271,
-      "title": "security(backup): restic backup 専用の append-only credential を追加 (T-0106)",
-      "url": "https://github.com/hikuohiku/homelab/pull/271",
+      "number": 272,
+      "title": "fix(ops-health-reporter): autopilot heartbeat 検出窓を tailLines から sinceSeconds に変更 (T-0121)",
+      "url": "https://github.com/hikuohiku/homelab/pull/272",
       "isDraft": false,
-      "createdAt": "2026-08-06T01:28:47Z",
+      "createdAt": "2026-08-06T01:37:58Z",
       "statusCheckRollup": [
         {
           "conclusion": "PENDING"
         }
       ],
-      "headRefName": "autopilot/T-0106-restic-backup-append-only-credential",
+      "headRefName": "autopilot/T-0121-heartbeat-tail-window",
       "autoMergeRequest": null
     }
   ],
   "merged": [
+    {
+      "number": 271,
+      "title": "security(backup): restic backup 専用の append-only credential を追加 (T-0106)",
+      "url": "https://github.com/hikuohiku/homelab/pull/271",
+      "mergedAt": "2026-08-06T01:30:35Z",
+      "headRefName": "autopilot/T-0106-restic-backup-append-only-credential"
+    },
     {
       "number": 270,
       "title": "chore(ops): run #87 の記録更新",
@@ -428,13 +435,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/209",
       "mergedAt": "2026-08-05T16:26:22Z",
       "headRefName": "autopilot/run54-record"
-    },
-    {
-      "number": 208,
-      "title": "ops: run #53 の記録更新（T-0103 修正確認、journal・state・PRキャッシュ、ダッシュボード再公開）",
-      "url": "https://github.com/hikuohiku/homelab/pull/208",
-      "mergedAt": "2026-08-05T16:15:10Z",
-      "headRefName": "autopilot/run53-record"
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`ops-health-reporter`（30分毎に ArgoCD/k8s の健全性を集める CronJob）が autopilot 自身の
ハング検知（CHARTER §2）に使っている heartbeat 検出の取得窓を、ログの `tailLines=200` から
`sinceSeconds=7200`（2時間）に変更しました。

## 見つけたこと・背景

今回の起動（run #89）で `ops/health/latest.json` の `autopilot.heartbeat.last_start`/`last_end`
が両方 `null` になっているのを発見しました。原因は `apps/autopilot/render.py` が
`claude -p --output-format stream-json` のイベント（tool_use / text / result）を1行ずつ
`[claude] ...` として出力するため、込み入ったイテレーション1回だけで簡単に200行を
超えてしまい、直近の `[autopilot] ... iteration #N start` 行が `tailLines=200` の
窓の外に押し出されてしまうことでした。autopilot Pod 自体は `Running`・再起動0回で
正常に動いており、インフラ側の異常ではなく監視ロジック側の穴でした。

行数ではなく時間で窓を取るよう変更し、`ITERATION_TIMEOUT_SECONDS`（現行 3600s、
`apps/autopilot/deployment.yaml`）1周分 + 余裕を確実にカバーするようにしています。

## 検証したこと

- `python3 -m py_compile apps/ops-health-reporter/report.py` で構文確認
- `python3 ops/validate.py` で 0 error（既存 warning のみ、今回の変更由来の新規 warning は
  「done なのに pr が空」の1件のみで想定どおり）
- CI（`kustomize build` / `terraform validate` / `ops state validate` / manifest deletion guard /
  `nix flake check`）の green を確認予定
- 実効性の確認は次回の CronJob 実行（30分毎）後、`ops/health/latest.json` の
  `autopilot.heartbeat` に実際の iteration 番号が入ることで行う（次の起動で確認）

## ロールバック手順

このコミットを revert すれば `tailLines=200` に戻ります。DB・実データは一切扱わないため、
revert 後に残る不整合はありません（監視スクリプトのみの変更）。

## backlog task id

T-0121
