### PR TITLE
chore(ops): run #89 の記録更新（T-0121: heartbeat 検出窓の修正・merge 済み）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,13 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 272,
       "title": "fix(ops-health-reporter): autopilot heartbeat 検出窓を tailLines から sinceSeconds に変更 (T-0121)",
       "url": "https://github.com/hikuohiku/homelab/pull/272",
-      "isDraft": false,
-      "createdAt": "2026-08-06T01:37:58Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "PENDING"
-        }
-      ],
-      "headRefName": "autopilot/T-0121-heartbeat-tail-window",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-06T01:39:43Z",
+      "headRefName": "autopilot/T-0121-heartbeat-tail-window"
+    },
     {
       "number": 271,
       "title": "security(backup): restic backup 専用の append-only credential を追加 (T-0106)",
@@ -428,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/211",
       "mergedAt": "2026-08-05T16:32:00Z",
       "headRefName": "autopilot/run55-record"
-    },
-    {
-      "number": 209,
-      "title": "ops: run #54 の記録更新（immich restic backup 検証確認、T-0105/T-0106 起票）",
-      "url": "https://github.com/hikuohiku/homelab/pull/209",
-      "mergedAt": "2026-08-05T16:26:22Z",
-      "headRefName": "autopilot/run54-record"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2623,3 +2623,33 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化、`ops/validate.py`
   0 error（10 warning、既存のもの、今回の変更由来の新規警告なし）、`ops/dashboard/build.py`
   正常終了を確認。Artifact ツールがこの環境に無く re-publish はできなかった
+
+## 2026-08-06 10:39 JST — run #89
+
+- 前回の中断確認: オープン PR 無し。`autopilot/*` 残存ブランチ無し
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` で2ページとも）を
+  機械的に確認。last_read（2026-08-06T00:56:52Z）以降の新規コメント無し
+- backlog の唯一の todo（T-0117, coder workspace home backup の初回実行確認）は CronJob
+  schedule（03:30 UTC）が現在時刻（01:33 UTC）よりまだ先のため引き続き着手不能
+- 見つけたこと・やったこと: ops-health-report（generated_at 2026-08-06T01:30:04Z）を確認中、
+  `autopilot.heartbeat.last_start`/`last_end` が両方 `null` になっているのを発見（Application
+  全11件 Synced/Healthy・pod_issues は常連の restarts:19 のみで他は正常、autopilot Pod 自体も
+  kubectl で Running・再起動0回を確認済みなので、インフラ異常ではなく監視ロジック側の穴と判断）。
+  原因を調査: `apps/ops-health-reporter/report.py` が pod log を `tailLines=200` でしか
+  取っていないが、`apps/autopilot/render.py` は `claude -p` の stream-json イベント
+  （tool_use/text/result）を1行ずつ出すため、込み入ったイテレーション1回だけで簡単に200行を
+  超え、直近の `[autopilot] ... iteration #N start` 行が窓の外に押し出されうる。これは
+  CHARTER §2 が自己のハング検知に使う仕組みの信頼性が実は不安定だったことを意味する。
+  backlog に T-0121（risk: low）として起票・即完遂: 取得を `tailLines=200` から
+  `sinceSeconds=7200`（`ITERATION_TIMEOUT_SECONDS` 現行3600sの1周分+余裕、行数ではなく
+  時間で窓を取る）に変更（PR #272）。CI（terraform validate / ops state validate /
+  GitGuardian / kustomize build / nix flake check / manifest deletion guard）全 green・
+  `mergeable_state: clean` を確認して merge、ブランチは GitHub 側で自動削除された
+- 次の起動へ: T-0121 の実効性確認はまだ。次の起動時、ops-health-reporter CronJob（30分毎）が
+  修正後の内容で1回以上走っていれば `ops/health/latest.json` の `autopilot.heartbeat` に
+  `null` ではなく実際の iteration 番号が入っているはずなので確認すること。入っていなければ
+  T-0121 は不十分だった扱いで追加調査が要る。T-0117 は CronJob schedule（03:30 UTC）を
+  過ぎていれば着手できる
+- ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化（open 0件・merged 60件、
+  #272 が最新）、`ops/validate.py` 0 error（10 warning、既存のもの）、`ops/dashboard/build.py`
+  正常終了を確認。Artifact ツールがこの環境に無く re-publish はできなかった

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T01:20:00Z",
+  "updated": "2026-08-06T01:41:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -948,6 +948,16 @@
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0117 は CronJob schedule（03:30 UTC）未到来のため引き続き着手不能。CHARTER §3 に従い blocked/needs-human タスクの blocked_by 有効性を確認したところ、T-0106（B2 restic credential の append-only 鍵分離）の blocked_by（T-0071 復元試験）が既に done なのに blocked のまま取り残されていたと判明。manifest 側（apps/{vaultwarden,immich,coder}/restic-external-secret.yaml に backup 専用 ExternalSecret <app>-restic-backup-credentials を追加、新しい Doppler キー B2_ACCOUNT_ID_APPEND_ONLY/B2_ACCOUNT_KEY_APPEND_ONLY を参照）を実装し、既存 backup CronJob の参照先はまだ切り替えず現状の日次バックアップへの影響を回避した。T-0106 を credential 発行待ちの needs-human に narrow化し、切り替え作業を T-0120（blocked_by: T-0106）として分離した",
       "prs": [
         271
+      ]
+    },
+    {
+      "n": 89,
+      "at": "2026-08-06T10:39:00+09:00",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0117 は CronJob schedule（03:30 UTC）未到来のため引き続き着手不能。ops-health-report 確認中、autopilot.heartbeat.last_start/last_end が両方 null になっている異常を発見。原因は ops-health-reporter が pod log を tailLines=200 でしか取らず、render.py の verbose な stream-json 出力で込み入ったイテレーション1回だけで200行を超え heartbeat 行が窓の外に押し出されること。T-0121（risk: low）として起票・即完遂: 取得を sinceSeconds=7200（ITERATION_TIMEOUT_SECONDS 1周分+余裕）に変更（PR #272, merge済み）。実効性確認は次の起動で行う",
+      "prs": [
+        272
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

run #89 の運用記録更新のみです（コードの挙動は変わりません）。

- `ops/journal/2026-08.md` に run #89 の記録を追記
- `ops/state.json` の `runs` に run #89 のエントリを追記
- `ops/dashboard/prs.json` を GitHub REST API の最新状態（open 0件・merged 60件、#272 が最新）で更新

## 検証したこと

- `python3 ops/validate.py` で 0 error（既存の warning 10件のみ、新規なし）
- `python3 ops/dashboard/build.py` が例外なく完了することを確認

## ロールバック手順

このコミットを revert すれば記録追記前の状態に戻ります。実データ・実インフラには一切影響しません。

## backlog task id

T-0121（記録のみ。コード変更本体は PR #272 で merge 済み）
