### PR TITLE
chore(ops): run #90 の記録更新

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 273,
+      "title": "chore(ops): run #89 の記録更新（T-0121: heartbeat 検出窓の修正・merge 済み）",
+      "url": "https://github.com/hikuohiku/homelab/pull/273",
+      "mergedAt": "2026-08-06T01:43:51Z",
+      "headRefName": "autopilot/T-0121-run89-wrapup"
+    },
+    {
       "number": 272,
       "title": "fix(ops-health-reporter): autopilot heartbeat 検出窓を tailLines から sinceSeconds に変更 (T-0121)",
       "url": "https://github.com/hikuohiku/homelab/pull/272",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/212",
       "mergedAt": "2026-08-05T17:20:08Z",
       "headRefName": "autopilot/dashboard-live"
-    },
-    {
-      "number": 211,
-      "title": "ops: run #55 の記録更新（重複 PR #210 の close、PRキャッシュ更新）",
-      "url": "https://github.com/hikuohiku/homelab/pull/211",
-      "mergedAt": "2026-08-05T16:32:00Z",
-      "headRefName": "autopilot/run55-record"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2653,3 +2653,33 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化（open 0件・merged 60件、
   #272 が最新）、`ops/validate.py` 0 error（10 warning、既存のもの）、`ops/dashboard/build.py`
   正常終了を確認。Artifact ツールがこの環境に無く re-publish はできなかった
+
+## 2026-08-06 10:49 JST — run #90
+
+- 前回の中断確認: オープン PR 1件（#273, T-0121 の記録更新、run #89 が open のまま終了）を発見。
+  CI 6件全て green・`mergeable_state: clean` を確認して merge（低リスクの記録のみ変更のため即 merge）。
+  ブランチは GitHub 側で自動削除された
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` で2ページとも）を機械的に
+  確認。last_read（2026-08-06T01:26:31Z）以降の新規コメント無し
+- T-0121（heartbeat 検出窓修正）の実効性確認: `ops/health/latest.json`（generated_at
+  2026-08-06T01:30:04Z）はまだ `autopilot.heartbeat` が `null` のままだったが、これは
+  ArgoCD が修正後の revision（3aef001）に sync したのが 01:40:52Z（kubectl `application`
+  の `status.history` で確認）で、01:30:04Z の CronJob 実行はそれより前だったため。次回
+  CronJob 実行（02:00 UTC 頃）以降で改めて確認が要る。ArgoCD Application は全11件
+  Synced/Healthy、pod_issues は常連の再起動カウント（restarts:19、変化なし）のみで
+  新規異常なし
+- backlog の唯一の todo（T-0117, coder workspace home backup の初回実行確認）は CronJob
+  schedule（03:30 UTC）が現在時刻（01:44 UTC）よりまだ先のため引き続き着手不能。kubectl で
+  CronJob の `status` が空（`lastScheduleTime` 無し）であることを直接確認した
+- 見つけたこと・やったこと: CHARTER §3 に従い subagent に新しい調査観点探しを投げた
+  （inventory.json とファイル実態の突き合わせ、重複事実、ドキュメント drift、TODO/FIXME、
+  CI 監視漏れの5角度）。いずれも既存の runs（特に run #85/#87）で直近チェック済みで、新規の
+  具体的な指摘は出なかった（唯一の候補は `apps/coder/templates/personal/README.md` の
+  upstream 由来の `TODO: screenshot` コメントだが、homelab 固有のドリフトではなくタスク化の
+  価値が薄いと判断し見送り）。89回を超える起動で分かりやすいドリフトは概ね枯渇してきている
+- 次の起動へ: T-0117 は CronJob schedule（03:30 UTC）を過ぎていれば着手できる。T-0121 の
+  実効性は次回 ops-health-report（02:00 UTC 以降）の `autopilot.heartbeat` を見て確認する
+  こと。null のままなら T-0121 は不十分だった扱いで追加調査が要る
+- ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化（open 0件・merged 60件、
+  #273 が最新）、`ops/validate.py` 0 error（10 warning、既存のもの）、`ops/dashboard/build.py`
+  正常終了を確認。Artifact ツールがこの環境に無く re-publish はできなかった

--- a/ops/state.json
+++ b/ops/state.json
@@ -959,6 +959,14 @@
       "prs": [
         272
       ]
+    },
+    {
+      "n": 90,
+      "at": "2026-08-06T10:49:00+09:00",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "前回の中断: PR #273（run #89 の記録更新）を CI green・mergeable_state clean を確認して merge。issue #56 に未読フィードバックなし。T-0121 の実効性確認は、01:30:04Z の ops-health-report がまだ null だったが ArgoCD の修正反映（01:40:52Z）より前の断面だったためと判明、次回起動で改めて確認する。T-0117 は CronJob schedule（03:30 UTC）未到来のため引き続き着手不能。subagent に新しい調査観点探しを投げたが、89回を超える起動でドリフトは概ね枯渇しており具体的な新規候補は出なかった",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

run #90 の運用記録更新のみです（コードの挙動は変わりません）。

- 前回の中断（PR #273, run #89 の記録更新）を merge した記録
- `ops/journal/2026-08.md` に run #90 の記録を追記
- `ops/state.json` の `runs` に run #90 のエントリを追記
- `ops/dashboard/prs.json` を GitHub REST API の最新状態（open 0件・merged 60件、#273 が最新）で更新

この起動では、backlog の唯一の todo（T-0117）が CronJob schedule（03:30 UTC）未到来のため着手不能、T-0121（heartbeat 検出窓修正）の実効性確認も次回 ops-health-report 待ちのため、新規のコード変更はありません。subagent で新規タスク候補を探しましたが、89回を超える起動でドリフトが概ね枯渇しており具体的な候補は出ませんでした。

## 検証したこと

- `python3 ops/validate.py` で 0 error（既存の warning 10件のみ、新規なし）
- `python3 ops/dashboard/build.py` が例外なく完了することを確認

## ロールバック手順

このコミットを revert すれば記録追記前の状態に戻ります。実データ・実インフラには一切影響しません。

## backlog task id

なし（記録のみ）