### PR TITLE
docs(ops): T-0106 由来の ArgoCD Degraded health を既知事象として記録 (T-0122)

### DIFF
--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -83,6 +83,18 @@ T-0068 のバックアップは実質機能していないとみなして調査�
 + namespace ごとに 0/10/20 分）がまだ一度もその時刻を迎えていなければ 404 は正常。`generated_at` を
 これらの実行予定時刻と比較し、直近の予定時刻を過ぎてもなお 404 が続く場合にのみ CronJob の異常を疑う。
 
+**`coder`/`immich`/`vaultwarden` の ArgoCD Application health が `Degraded` でも、T-0106 が
+`needs-human` のままの間は新規異常ではない**（run #91 で発見）。T-0106（run #88, PR #263）が
+追加した `<app>-restic-backup-credentials` ExternalSecret は、参照する Doppler キー
+（`B2_ACCOUNT_ID_APPEND_ONLY`/`B2_ACCOUNT_KEY_APPEND_ONLY`）が未登録のため `SecretSyncedError`
+のまま存在し、この 1 リソースの不健全がそのまま親 Application の集約health を `Degraded` に
+引き上げる。Pod は 3 namespace とも全て `Running`/`Ready` で実際のサービスに影響はない。
+`applications` の `health` だけで異常を判断せず、`kubectl get externalsecret -n <ns>` で
+`SecretSyncedError` が `<app>-restic-backup-credentials` だけであること（他の ExternalSecret や
+Pod に波及していないこと）を確認する。T-0106 の Doppler 登録が完了し ExternalSecret が
+`SecretSynced` になれば、この 3 Application の health は自然に `Healthy` へ戻るはずで、
+戻らなければそちらを調査する。
+
 **時間が尽きたら途中で止めてよい。** ただし止まる前に、その時点までの内容で PR を作るか、
 作りかけのブランチを push しておく。ブランチ名は必ず `autopilot/` で始める。
 **次の起動は「オープン PR と `autopilot/*` ブランチ」から中断を拾う。** これが唯一の引き継ぎ経路なので、

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 122,
+  "next_id": 123,
   "updated": "2026-08-06T01:50:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
@@ -1984,7 +1984,7 @@
       ],
       "created": "2026-08-05",
       "pr": 271,
-      "notes": "run #29: T-0071（復元試験）完了を待つ方針で blocked に。run #88: T-0071 が既に done（2026-08-06 完了）と確認しblocked_by を解消。manifest（backup専用ExternalSecret 3ファイル分）を実装し、credential 発行のみを残す needs-human に変更（#271）。CronJob 側の参照切り替えは新しい鍵の存在確認が要るため T-0120 として分離"
+      "notes": "run #29: T-0071（復元試験）完了を待つ方針で blocked に。run #88: T-0071 が既に done（2026-08-06 完了）と確認しblocked_by を解消。manifest（backup専用ExternalSecret 3ファイル分）を実装し、credential 発行のみを残す needs-human に変更（#271）。CronJob 側の参照切り替えは新しい鍵の存在確認が要るため T-0120 として分離。run #91: 追加した ExternalSecret が SecretSyncedError のまま存在すること自体が coder/immich/vaultwarden の ArgoCD Application health を Degraded に引き上げる副作用を発見（Pod 自体は無事）。CHARTER §2 に既知事象として記録（T-0122）。Doppler 登録が済み次第、この Degraded も自然解消するはず"
     },
     {
       "id": "T-0109",
@@ -2294,7 +2294,26 @@
       ],
       "created": "2026-08-06",
       "pr": 272,
-      "notes": "run #89 で発見・即完遂。修正後の実効性確認（次回 CronJob 実行後の latest.json）は次の起動で見る"
+      "notes": "run #89 で発見・即完遂。run #91: 実効性確認完了。02:00:04Z の ops-health-report で autopilot.heartbeat.last_start/last_end とも null ではなく iteration #36/#37 の実値を返すことを確認した"
+    },
+    {
+      "id": "T-0122",
+      "domain": "homelab",
+      "title": "T-0106 が追加した backup credential ExternalSecret の SecretSyncedError が coder/immich/vaultwarden の ArgoCD health を Degraded にする副作用を CHARTER に記録する",
+      "kind": "docs",
+      "risk": "low",
+      "status": "done",
+      "priority": 42,
+      "why": "run #91 で ops-health-report（02:00:04Z 断面）を確認中、coder/immich/vaultwarden の Application health が揃って Degraded になっているのを発見した。kubectl で調査したところ 3 namespace とも Pod は全て Running/Ready で異常無く、原因は T-0106（run #88, PR #271）が追加した `<app>-restic-backup-credentials` ExternalSecret が、まだ登録されていない Doppler キー（B2_ACCOUNT_ID_APPEND_ONLY/B2_ACCOUNT_KEY_APPEND_ONLY）を参照しているため SecretSyncedError のままで、この 1 リソースの不健全が ArgoCD の health 集約ロジックで親 Application 全体に波及していたと判明した。CHARTER §2 の健全性確認手順（`applications` が全て Synced/Healthy か確認する）はこの状態を『壊れている』と誤検知し続けてしまうため、既知事象として記録しないと毎回同じ調査をやり直すことになる",
+      "dod": "CHARTER §2 に、T-0106 が needs-human のままの間は coder/immich/vaultwarden の Degraded がこの ExternalSecret 由来である可能性を先に疑い、`kubectl get externalsecret -n <ns>` で `<app>-restic-backup-credentials` だけが SecretSyncedError であることを確認する手順を追記する。T-0106 の notes にもこの副作用を追記する",
+      "blocked_by": null,
+      "refs": [
+        "ops/CHARTER.md",
+        "ops/backlog.json"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #91 で発見・即完遂。実際の Degraded 状態を解消するには T-0106 の Doppler 登録（人間専有）が要る。この task 自体は既知事象化のドキュメント更新のみ"
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2312,7 +2312,7 @@
         "ops/backlog.json"
       ],
       "created": "2026-08-06",
-      "pr": null,
+      "pr": 275,
       "notes": "run #91 で発見・即完遂。実際の Degraded 状態を解消するには T-0106 の Doppler 登録（人間専有）が要る。この task 自体は既知事象化のドキュメント更新のみ"
     }
   ]

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,43 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 275,
+      "title": "docs(ops): T-0106 由来の ArgoCD Degraded health を既知事象として記録 (T-0122)",
+      "url": "https://github.com/hikuohiku/homelab/pull/275",
+      "isDraft": false,
+      "createdAt": "2026-08-06T02:04:28Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        }
+      ],
+      "headRefName": "autopilot/T-0122-degraded-health-from-t0106",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 274,
+      "title": "chore(ops): run #90 の記録更新",
+      "url": "https://github.com/hikuohiku/homelab/pull/274",
+      "mergedAt": "2026-08-06T01:52:17Z",
+      "headRefName": "autopilot/run90-wrapup"
+    },
     {
       "number": 273,
       "title": "chore(ops): run #89 の記録更新（T-0121: heartbeat 検出窓の修正・merge 済み）",
@@ -413,13 +450,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/213",
       "mergedAt": "2026-08-05T17:24:01Z",
       "headRefName": "autopilot/T-0107-run56-feedback-records"
-    },
-    {
-      "number": 212,
-      "title": "feat(ops): ダッシュボードに「いま動いているもの」を追加し鮮度を可視化する",
-      "url": "https://github.com/hikuohiku/homelab/pull/212",
-      "mergedAt": "2026-08-05T17:20:08Z",
-      "headRefName": "autopilot/dashboard-live"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2683,3 +2683,34 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化（open 0件・merged 60件、
   #273 が最新）、`ops/validate.py` 0 error（10 warning、既存のもの）、`ops/dashboard/build.py`
   正常終了を確認。Artifact ツールがこの環境に無く re-publish はできなかった
+
+## 2026-08-06 11:04 JST — run #91
+
+- 前回の中断確認: オープン PR 無し。`autopilot/*` 残存ブランチ無し
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` で2ページとも）を機械的に
+  確認。last_read（2026-08-06T01:26:31Z）以降の新規コメント無し
+- T-0121（heartbeat 検出窓修正）の実効性確認: 02:00:04Z の ops-health-report で
+  `autopilot.heartbeat.last_start`/`last_end` が null ではなく iteration #36（exit_code 0）/
+  #37 の実値を返すことを確認した。修正が効いている
+- 見つけたこと・やったこと: 同じ 02:00:04Z の断面で `coder`/`immich`/`vaultwarden` の
+  Application health が揃って `Degraded` になっているのを発見（01:30:04Z 時点では全11件
+  Synced/Healthy だった）。kubectl で調査した結果、3 namespace とも Pod は全て
+  Running/Ready で異常なし。原因は T-0106（run #88, #271）が追加した
+  `<app>-restic-backup-credentials` ExternalSecret が未登録の Doppler キー
+  （B2_ACCOUNT_ID_APPEND_ONLY/B2_ACCOUNT_KEY_APPEND_ONLY）を参照していて
+  `SecretSyncedError` のままなこと。この 1 リソースの不健全が親 Application の health 集約に
+  波及していた。CHARTER §2 の健全性確認手順はこれを『壊れている』と誤検知し続けるため、
+  T-0122（risk: low）として起票・即完遂: CHARTER に既知事象と見分け方
+  （`kubectl get externalsecret` で `<app>-restic-backup-credentials` だけが
+  SecretSyncedError であることを確認する）を追記、T-0106 の notes にも副作用を追記（#275）
+- 並行して subagent に ops/inventory.json の全32対象（helm chart・container image・
+  GitHub Actions・CLI バイナリ）の upstream 最新版を一次ソース（GitHub Releases API /
+  Docker Hub API / ghcr.io registry API）で確認させた。全対象が現行 pin のまま最新か、
+  既知の理由（k8s-nameserver の image 未公開、postgres 18 は対象外、vaultwarden 1.37.0 の
+  alpine ビルド破損を正しく回避済み）で追従不要と判明。新規のアクション対象は無し
+- 次の起動へ: backlog の todo は T-0117 のみ（schedule 03:30 UTC、現在時刻 02:04 UTC でまだ
+  先）。T-0122 の PR (#275) が merge されたら、coder/immich/vaultwarden の Degraded は
+  T-0106 の Doppler 登録（人間専有）が終わるまで既知事象として扱ってよい。定期 inventory
+  チェックは今回全件確認済みなので、しばらくは新規ドリフトが出にくい見込み
+- ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
+  `ops/dashboard/build.py` を実行する

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T01:41:00Z",
+  "updated": "2026-08-06T02:04:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -967,6 +967,16 @@
       "by": "in-cluster autopilot",
       "summary": "前回の中断: PR #273（run #89 の記録更新）を CI green・mergeable_state clean を確認して merge。issue #56 に未読フィードバックなし。T-0121 の実効性確認は、01:30:04Z の ops-health-report がまだ null だったが ArgoCD の修正反映（01:40:52Z）より前の断面だったためと判明、次回起動で改めて確認する。T-0117 は CronJob schedule（03:30 UTC）未到来のため引き続き着手不能。subagent に新しい調査観点探しを投げたが、89回を超える起動でドリフトは概ね枯渇しており具体的な新規候補は出なかった",
       "prs": []
+    },
+    {
+      "n": 91,
+      "at": "2026-08-06T11:04:00+09:00",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0121 の実効性確認完了（02:00:04Z の ops-health-report で heartbeat が iteration #36/#37 の実値を返した）。同じ断面で coder/immich/vaultwarden の Application health が揃って Degraded になっているのを発見、kubectl 調査で Pod 自体は無事、T-0106 が追加した backup credential ExternalSecret の SecretSyncedError が原因と判明。T-0122（risk: low）として起票・即完遂、CHARTER に既知事象として記録（#275）。並行して inventory 全32対象を subagent が一次ソースで確認、追従が必要な対象は無し。T-0117 は CronJob schedule（03:30 UTC）未到来のため引き続き着手不能",
+      "prs": [
+        275
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`ops-health-report` の 02:00:04Z 断面で `coder`/`immich`/`vaultwarden` の ArgoCD Application health が揃って `Degraded` になっているのを発見した。調査の結果、実際の Pod（Deployment/StatefulSet 等）は 3 namespace とも全て `Running`/`Ready` で正常だが、T-0106（#271, run #88）が追加した `<app>-restic-backup-credentials` ExternalSecret が、まだ Doppler に登録されていないキー（`B2_ACCOUNT_ID_APPEND_ONLY`/`B2_ACCOUNT_KEY_APPEND_ONLY`）を参照しているため `SecretSyncedError` のまま存在し、この 1 リソースの不健全が ArgoCD の health 集約ロジックで親 Application 全体に波及していた。

`ops/CHARTER.md` §2（健全性確認の手順）に、この状態は T-0106 が `needs-human` のままの間は新規異常ではないことと、確認手順（`kubectl get externalsecret -n <ns>` で対象が `<app>-restic-backup-credentials` のみであることを見る）を追記した。あわせて `ops/backlog.json` に T-0122 として起票・即完遂で記録し、T-0106 の notes にもこの副作用を追記した。ついでに T-0121（heartbeat 検出窓修正）の実効性確認が取れた（02:00:04Z の断面で iteration #36/#37 の実値を確認）ので、そちらの notes も更新している。

## 検証したこと

- `kubectl get pods -n coder/immich/vaultwarden`: 全 Pod `Running`/`Ready`、異常なし
- `kubectl get externalsecret -n coder/immich/vaultwarden`: `<app>-restic-backup-credentials` のみ `SecretSyncedError`、他は `SecretSynced`
- `kubectl get application <app> -n argocd`: `status.conditions` の `lastTransitionTime`（01:31〜01:34 UTC）が T-0106 の merge タイミングと一致
- `python3 ops/validate.py`: 0 error（既存 warning のみ、新規に増えたのは「T-0122 が done なのに pr が空」という一時的なもので、この PR の merge 後に pr フィールドを埋める予定の想定内の警告）

## ロールバック手順

ドキュメント（CHARTER.md）と backlog.json のみの変更で、実インフラには一切触れていない。revert すれば元の記述に戻るだけで、データやスキーマへの影響はない。

## backlog task id

T-0122（done）。T-0106（needs-human, 変更なし）、T-0121（done, 実効性確認を追記）