### PR TITLE
chore(ops): T-0123 validate.py の PR-empty 警告ノイズを解消

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 123,
+  "next_id": 124,
   "updated": "2026-08-06T01:50:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
@@ -1619,12 +1619,11 @@
       "dod": "T-0086 の PR が merge・ArgoCD に反映されてから1起動以上後、ops-health-report ブランチの pod_issues に immich-machine-learning の CrashLoopBackOff/Error が無いことを確認する。問題が無ければ done、あれば v2.6.3 への revert PR を出す",
       "blocked_by": "T-0086 の反映待ち（ArgoCD sync + 次回 health report、CronJob は30分毎）",
       "refs": [
-        "apps/immich/values.yaml",
-        "ops/health/latest.json"
+        "apps/immich/values.yaml"
       ],
       "created": "2026-08-05",
       "pr": null,
-      "notes": "run #42: #171 merge (08:16:43Z) 後の ops-health-report (generated_at 08:30:04Z) を確認。immich アプリは Synced/Healthy、pod_issues に immich-server/immich-machine-learning のいずれも出現せず（restarts の載っている pod は argocd/coredns/local-path-provisioner/metrics-server の常駐系のみで、いずれもノード再起動由来の既知の値。immich 側に新規のクラッシュ兆候なし）。v2.7.0/v2.7.1 の numpy クラッシュは node01 で再発していないと確認できたため done"
+      "notes": "run #42: #171 merge (08:16:43Z) 後の ops-health-report (generated_at 08:30:04Z) を確認。immich アプリは Synced/Healthy、pod_issues に immich-server/immich-machine-learning のいずれも出現せず（restarts の載っている pod は argocd/coredns/local-path-provisioner/metrics-server の常駐系のみで、いずれもノード再起動由来の既知の値。immich 側に新規のクラッシュ兆候なし）。v2.7.0/v2.7.1 の numpy クラッシュは node01 で再発していないと確認できたため done | run #92: refs の ops/health/latest.json は main とは別ブランチ（ops-health-report）にしか存在しないファイルで、validate.py のチェックは main の working tree しか見ないため常に警告になっていた。参照先を documentation として残す価値が薄いため refs から削除した"
     },
     {
       "id": "T-0088",
@@ -2314,6 +2313,24 @@
       "created": "2026-08-06",
       "pr": 275,
       "notes": "run #91 で発見・即完遂。実際の Degraded 状態を解消するには T-0106 の Doppler 登録（人間専有）が要る。この task 自体は既知事象化のドキュメント更新のみ"
+    },
+    {
+      "id": "T-0123",
+      "domain": "homelab",
+      "title": "ops/validate.py の『done なのに pr が空』警告が notes 記載済みでも常に出るノイズを解消する",
+      "kind": "chore",
+      "risk": "low",
+      "status": "done",
+      "priority": 60,
+      "why": "同じ 10 件の warning が run #14 以降 40 回以上の起動で journal に『既存のもの、今回の変更由来の新規警告なし』と書かれ続けており、warning が実質的に意味を失っていた（新しい genuine な警告が出ても埋もれる）。全 9 件の該当タスクは既に notes に PR が無い理由が書かれており、チェック自体が notes の有無を見ていなかったのが原因",
+      "dod": "ops/validate.py の該当チェックを notes が空の場合のみ warn するよう修正し、python3 ops/validate.py が 0 warning になることを確認する。あわせて T-0087 の refs にあった ops/health/latest.json（main とは別の ops-health-report ブランチにしか存在せず常に警告の原因だった）を削除する",
+      "blocked_by": null,
+      "refs": [
+        "ops/validate.py"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #92: 着手・完遂。python3 ops/validate.py で 0 error, 0 warning を確認済み。この PR に相乗りさせる形で実施したため pr は同じ PR 番号を後で反映する"
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2329,8 +2329,8 @@
         "ops/validate.py"
       ],
       "created": "2026-08-06",
-      "pr": null,
-      "notes": "run #92: 着手・完遂。python3 ops/validate.py で 0 error, 0 warning を確認済み。この PR に相乗りさせる形で実施したため pr は同じ PR 番号を後で反映する"
+      "pr": 276,
+      "notes": "run #92: 着手・完遂。python3 ops/validate.py で 0 error, 0 warning を確認済み"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,36 +1,13 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 275,
       "title": "docs(ops): T-0106 由来の ArgoCD Degraded health を既知事象として記録 (T-0122)",
       "url": "https://github.com/hikuohiku/homelab/pull/275",
-      "isDraft": false,
-      "createdAt": "2026-08-06T02:04:28Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        }
-      ],
-      "headRefName": "autopilot/T-0122-degraded-health-from-t0106",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-06T02:06:56Z",
+      "headRefName": "autopilot/T-0122-degraded-health-from-t0106"
+    },
     {
       "number": 274,
       "title": "chore(ops): run #90 の記録更新",
@@ -443,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/214",
       "mergedAt": "2026-08-05T17:25:31Z",
       "headRefName": "autopilot/T-0097-vaultwarden-backup-deadline"
-    },
-    {
-      "number": 213,
-      "title": "ops: issue #56 のフィードバック5件を backlog/CHARTER に反映",
-      "url": "https://github.com/hikuohiku/homelab/pull/213",
-      "mergedAt": "2026-08-05T17:24:01Z",
-      "headRefName": "autopilot/T-0107-run56-feedback-records"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,5 +1,20 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 276,
+      "title": "chore(ops): T-0123 validate.py の PR-empty 警告ノイズを解消",
+      "url": "https://github.com/hikuohiku/homelab/pull/276",
+      "isDraft": false,
+      "createdAt": "2026-08-06T02:14:02Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "PENDING"
+        }
+      ],
+      "headRefName": "autopilot/T-0123-validate-pr-notes-warning-noise",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
     {
       "number": 275,

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2714,3 +2714,30 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   チェックは今回全件確認済みなので、しばらくは新規ドリフトが出にくい見込み
 - ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
   `ops/dashboard/build.py` を実行する
+
+## 2026-08-06 11:12 JST — run #92
+
+- 前回の中断確認: オープン PR 無し。`autopilot/*` 残存ブランチ無し（run #91 の PR #275 は前回起動中に merge 済みと git log で確認）
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` で2ページとも）を機械的に確認。
+  last_read（2026-08-06T01:26:31Z）以降の新規コメント無し
+- ops-health-report（generated_at 2026-08-06T02:00:04Z）を確認: ArgoCD 11 Application 中
+  coder/immich/vaultwarden の3件が引き続き Degraded（T-0106 由来の既知事象、CHARTER §2 参照）で
+  他は Healthy。pod_issues は常連の restarts:19 のみで新規異常なし。autopilot 自身の heartbeat
+  も iteration #36 exit_code 0 で正常
+- backlog の唯一の todo（T-0117, coder workspace home backup 初回実行確認）は CronJob schedule
+  （03:30 UTC）が現在時刻（02:12 UTC）よりまだ先のため引き続き着手不能
+- 見つけたこと・やったこと: `python3 ops/validate.py` の「done なのに pr が空」warning が
+  run #14 以降 40 回以上の起動で同じ 10 件のまま出続け、journal に毎回「既存のもの、新規警告
+  なし」と書かれるだけの実質ノイズになっていたと気づいた。該当 9 タスク全件を確認したところ
+  いずれも notes に PR が無い理由が既に書かれており、チェック側が notes の有無を見ずに
+  無条件で warn していたのが原因。T-0123（risk: low）として起票・即完遂: `ops/validate.py`
+  の該当チェックに `not t.get("notes")` 条件を追加。あわせて同じ warning リストに混ざっていた
+  T-0087 の `refs: ["ops/health/latest.json"]` も削除した（このファイルは main ではなく
+  `ops-health-report` ブランチにしか存在せず、main の working tree しか見ない validate.py の
+  refs チェックが常に誤検知していた）。`python3 ops/validate.py` が 0 error, 0 warning になる
+  ことを確認済み
+- 次の起動へ: T-0117 は CronJob schedule（03:30 UTC）を過ぎていれば着手できる。validate.py の
+  warning が今後 0 件になったはずなので、もし新しい warning が出たら今回のような既知の
+  false positive ではなく genuine な指摘として扱うこと
+- ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
+  `ops/dashboard/build.py` を実行する

--- a/ops/state.json
+++ b/ops/state.json
@@ -984,7 +984,9 @@
       "kind": "scheduled",
       "by": "in-cluster autopilot",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。ops-health-report は coder/immich/vaultwarden の既知の Degraded 以外は正常、autopilot 自身の heartbeat も正常。backlog の todo（T-0117）は CronJob schedule（03:30 UTC）未到来で引き続き着手不能。ops/validate.py の『done なのに pr が空』warning が run #14 以降 40 回以上同じ 10 件のまま出続け、journal で毎回『既存のもの』と流されるだけのノイズになっていたと気づいた。該当 9 件は全て notes に理由が既に書かれていたため、T-0123（risk: low）としてチェック側を notes 有無で判定するよう修正・即完遂。あわせて T-0087 の refs にあった ops-health-report ブランチ専用ファイルへの誤参照も削除し、python3 ops/validate.py が 0 error, 0 warning になることを確認した",
-      "prs": []
+      "prs": [
+        276
+      ]
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T02:04:00Z",
+  "updated": "2026-08-06T02:12:43Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -977,6 +977,14 @@
       "prs": [
         275
       ]
+    },
+    {
+      "n": 92,
+      "at": "2026-08-06T11:12:00+09:00",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。ops-health-report は coder/immich/vaultwarden の既知の Degraded 以外は正常、autopilot 自身の heartbeat も正常。backlog の todo（T-0117）は CronJob schedule（03:30 UTC）未到来で引き続き着手不能。ops/validate.py の『done なのに pr が空』warning が run #14 以降 40 回以上同じ 10 件のまま出続け、journal で毎回『既存のもの』と流されるだけのノイズになっていたと気づいた。該当 9 件は全て notes に理由が既に書かれていたため、T-0123（risk: low）としてチェック側を notes 有無で判定するよう修正・即完遂。あわせて T-0087 の refs にあった ops-health-report ブランチ専用ファイルへの誤参照も削除し、python3 ops/validate.py が 0 error, 0 warning になることを確認した",
+      "prs": []
     }
   ]
 }

--- a/ops/validate.py
+++ b/ops/validate.py
@@ -91,7 +91,7 @@ def check_backlog(b) -> None:
                 )
         if t.get("status") == "blocked" and not t.get("blocked_by"):
             err(f"{where}: blocked には blocked_by が必要")
-        if t.get("status") == "done" and not t.get("pr"):
+        if t.get("status") == "done" and not t.get("pr") and not t.get("notes"):
             warn(f"{where}: done なのに pr が空（PR を伴わない完了なら理由を notes に）")
 
         for ref in t.get("refs", []):


### PR DESCRIPTION
## 変更点

`ops/validate.py` の「done なのに pr が空」警告が、run #14 以降 40 回以上の起動で
同じ 10 件のまま出続けていました。該当タスクは全て `notes` に PR が無い理由が
既に書かれているのに、チェック側が notes の有無を見ずに無条件で warn していたのが
原因です。notes が空でない場合は warn しないよう修正しました。

あわせて T-0087 の `refs` にあった `ops/health/latest.json` への参照も削除しました。
このファイルは `main` ではなく `ops-health-report` という別ブランチにしか存在せず、
`main` の working tree しか見ない `validate.py` の refs チェックが常に誤検知して
いました。

この PR には run #92 の journal / state.json / dashboard PR キャッシュ更新も
相乗りしています（repo 内で閉じる低リスク変更のため）。

## 検証したこと

- `python3 ops/validate.py` が `0 error, 0 warning` になることを確認
- `python3 ops/dashboard/build.py` が例外なく完走することを確認（`gh` 非搭載のため
  `ops/dashboard/prs.json` キャッシュへフォールバック、これは既知の挙動）
- `python3 -c "import json; json.load(open('ops/backlog.json'))"` / 同 state.json で
  JSON として壊れていないことを確認

## ロールバック手順

この PR を revert すれば `ops/validate.py` のチェックは元の無条件 warn に戻る。
DB やクラスタ状態には触れていないため、revert してもデータやスキーマの不整合は
一切残らない。

## backlog task id

T-0123 (risk: low)
