### PR TITLE
chore(ops): run #92 の記録更新（PR #276 merge・健全性確認）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 123,
-  "updated": "2026-08-06T01:50:00Z",
+  "next_id": 124,
+  "updated": "2026-08-06T02:20:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,36 +1,20 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
+    {
+      "number": 276,
+      "title": "chore(ops): T-0123 validate.py の PR-empty 警告ノイズを解消",
+      "url": "https://github.com/hikuohiku/homelab/pull/276",
+      "mergedAt": "2026-08-06T02:17:58Z",
+      "headRefName": "autopilot/T-0123-validate-pr-notes-warning-noise"
+    },
     {
       "number": 275,
       "title": "docs(ops): T-0106 由来の ArgoCD Degraded health を既知事象として記録 (T-0122)",
       "url": "https://github.com/hikuohiku/homelab/pull/275",
-      "isDraft": false,
-      "createdAt": "2026-08-06T02:04:28Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        }
-      ],
-      "headRefName": "autopilot/T-0122-degraded-health-from-t0106",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-06T02:06:56Z",
+      "headRefName": "autopilot/T-0122-degraded-health-from-t0106"
+    },
     {
       "number": 274,
       "title": "chore(ops): run #90 の記録更新",
@@ -436,20 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/215",
       "mergedAt": "2026-08-05T17:28:31Z",
       "headRefName": "autopilot/T-0060-dex-argocd-oidc-secret"
-    },
-    {
-      "number": 214,
-      "title": "fix(vaultwarden): restic backup の activeDeadlineSeconds を 1800→3600 に緩和",
-      "url": "https://github.com/hikuohiku/homelab/pull/214",
-      "mergedAt": "2026-08-05T17:25:31Z",
-      "headRefName": "autopilot/T-0097-vaultwarden-backup-deadline"
-    },
-    {
-      "number": 213,
-      "title": "ops: issue #56 のフィードバック5件を backlog/CHARTER に反映",
-      "url": "https://github.com/hikuohiku/homelab/pull/213",
-      "mergedAt": "2026-08-05T17:24:01Z",
-      "headRefName": "autopilot/T-0107-run56-feedback-records"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2714,3 +2714,30 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   チェックは今回全件確認済みなので、しばらくは新規ドリフトが出にくい見込み
 - ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
   `ops/dashboard/build.py` を実行する
+
+## 2026-08-06 11:20 JST — run #92
+
+- 前回の中断確認: オープン PR 1件（#276, T-0123 `validate.py` の PR-empty 警告ノイズ解消。
+  backlog には正式起票されておらず PR ラベルとしてのみ使われていた、run #48 と同型の運用）を
+  発見。CI 6件全て green・`mergeable_state: clean` を確認して merge、ブランチは GitHub 側で
+  自動削除された（404 で確認）
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` で2ページとも）を機械的に
+  確認。last_read（2026-08-06T01:26:31Z）以降の新規コメント無し
+- 健全性確認: ops-health-report（generated_at 02:00:04Z）で coder/immich/vaultwarden の
+  Application health が引き続き Degraded だが、`kubectl get externalsecret -n <ns>` で
+  3 namespace とも `<app>-restic-backup-credentials` だけが SecretSyncedError であることを
+  実測で確認（T-0122 の既知事象どおり、新規異常ではない）。autopilot 自身の heartbeat は
+  last_end（iteration #36, exit_code 0）が正常。pod_issues は常連の再起動カウントのみ
+- backlog の唯一の todo（T-0117, coder workspace home backup 初回実行確認）は CronJob
+  schedule（03:30 UTC）が現在時刻（02:20 UTC）よりまだ先のため引き続き着手不能。
+  `kubectl get cronjob` で `LAST SCHEDULE: <none>` を直接確認した
+- 副次確認: run #90/#91 で直近2回連続して広い調査（5角度 subagent・inventory 全32対象）を
+  行い新規ドリフトが枯渇していたため、今回は同種の重い調査を繰り返さず、CI の必須チェックと
+  main ruleset の整合という具体的な1点を確認した。`.github/workflows/ci.yml` の5 job
+  （kustomize build / manifest deletion guard / terraform validate / ops state validate /
+  nix flake check）と ruleset の `required_status_checks` が完全一致していることを
+  `GET /repos/.../rulesets/{id}` で実測、§5.2 が懸念していた『CI に job を足しても必須
+  チェックに入っていない』状態は現状発生していないと確認した（新規変更なし）
+- 次の起動へ: T-0117 は CronJob schedule（03:30 UTC）を過ぎていれば着手できる
+- ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化（open 0件・merged 60件、
+  #276 が最新）、`ops/validate.py`/`ops/dashboard/build.py` を実行して確認する

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T02:04:00Z",
+  "updated": "2026-08-06T02:20:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -976,6 +976,16 @@
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。T-0121 の実効性確認完了（02:00:04Z の ops-health-report で heartbeat が iteration #36/#37 の実値を返した）。同じ断面で coder/immich/vaultwarden の Application health が揃って Degraded になっているのを発見、kubectl 調査で Pod 自体は無事、T-0106 が追加した backup credential ExternalSecret の SecretSyncedError が原因と判明。T-0122（risk: low）として起票・即完遂、CHARTER に既知事象として記録（#275）。並行して inventory 全32対象を subagent が一次ソースで確認、追従が必要な対象は無し。T-0117 は CronJob schedule（03:30 UTC）未到来のため引き続き着手不能",
       "prs": [
         275
+      ]
+    },
+    {
+      "n": 92,
+      "at": "2026-08-06T11:20:00+09:00",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "前回の中断: PR #276（T-0123, validate.py の PR-empty 警告ノイズ解消。backlog には正式起票されておらず PR ラベルとしてのみ使われていた）を CI green・mergeable_state clean を確認して merge。issue #56 に未読フィードバックなし。健全性確認: coder/immich/vaultwarden の Degraded は T-0122 の既知事象どおり restic-backup-credentials ExternalSecret のみが原因と実測で再確認、autopilot 自身の heartbeat も正常。backlog の唯一の todo（T-0117）は CronJob schedule（03:30 UTC）未到来のため引き続き着手不能。run #90/#91 で広い調査が直近2回連続していたため今回は繰り返さず、CI 5 job と main ruleset の required_status_checks が完全一致していることを実測確認（§5.2 の懸念どおりのズレは現状無し、変更なし）",
+      "prs": [
+        276
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

run #92 の運用記録更新（journal / state.json / backlog.json の next_id / dashboard の PR キャッシュ）。
コード・manifest の変更は無い。

- 前回の中断だった PR #276（T-0123, `ops/validate.py` の PR-empty 警告ノイズ解消）を CI green・
  `mergeable_state: clean` を確認して merge した。T-0123 は backlog に正式起票されず PR ラベルとしてのみ
  使われていたため、`next_id` を 124 に補正し以後の重複採番を防いだ
- coder/immich/vaultwarden の ArgoCD Application health が引き続き Degraded だが、`kubectl get
  externalsecret` で3 namespace とも `<app>-restic-backup-credentials` だけが SecretSyncedError で
  あることを実測し、T-0122 の既知事象（T-0106 の Doppler 登録待ち）どおりで新規異常でないことを確認した
- `.github/workflows/ci.yml` の5 job と main ruleset の `required_status_checks` が完全一致している
  ことを実測確認した（CHARTER §5.2 が懸念する『CI に job を足しても必須チェック未登録』のズレは
  現状発生していない。変更なし）
- backlog の唯一の todo（T-0117, coder workspace home backup 初回実行確認）は CronJob schedule
  （03:30 UTC）が未到来のため引き続き着手不能

## 検証したこと

- `python3 ops/validate.py` → 0 error, 10 warning（既存のもの、変化なし）
- `python3 ops/dashboard/build.py` → 例外なく完走（`gh` 非搭載のため `prs.json` キャッシュへ
  フォールバック、既知の挙動）
- `python3 -c "import json; json.load(open('ops/backlog.json')); json.load(open('ops/state.json'))"` で
  JSON として壊れていないことを確認

## ロールバック手順

この PR を revert すれば運用記録は前回の状態に戻る。DB・クラスタ状態には触れていないため
データ・スキーマの不整合は残らない。

## backlog task id

なし（運用記録のみ、CHARTER §4 の相乗り例外）
