### PR TITLE
chore(ops): run #93 の記録更新（PR #276 merge・健全性確認）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,13 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 276,
       "title": "chore(ops): T-0123 validate.py の PR-empty 警告ノイズを解消",
       "url": "https://github.com/hikuohiku/homelab/pull/276",
-      "isDraft": false,
-      "createdAt": "2026-08-06T02:14:02Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "PENDING"
-        }
-      ],
-      "headRefName": "autopilot/T-0123-validate-pr-notes-warning-noise",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-06T02:17:58Z",
+      "headRefName": "autopilot/T-0123-validate-pr-notes-warning-noise"
+    },
     {
       "number": 275,
       "title": "docs(ops): T-0106 由来の ArgoCD Degraded health を既知事象として記録 (T-0122)",
@@ -428,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/215",
       "mergedAt": "2026-08-05T17:28:31Z",
       "headRefName": "autopilot/T-0060-dex-argocd-oidc-secret"
-    },
-    {
-      "number": 214,
-      "title": "fix(vaultwarden): restic backup の activeDeadlineSeconds を 1800→3600 に緩和",
-      "url": "https://github.com/hikuohiku/homelab/pull/214",
-      "mergedAt": "2026-08-05T17:25:31Z",
-      "headRefName": "autopilot/T-0097-vaultwarden-backup-deadline"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2741,3 +2741,35 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   false positive ではなく genuine な指摘として扱うこと
 - ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
   `ops/dashboard/build.py` を実行する
+
+## 2026-08-06 11:33 JST — run #93
+
+- 前回の中断確認: オープン PR 1件（#276, T-0123。同じ「run #92」を名乗る別セッションが
+  `ops/validate.py` の PR-empty 警告ノイズを解消済み）を発見。CI 6件全て green・
+  `mergeable_state: clean` を確認して merge、ブランチは GitHub 側で自動削除された
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` で2ページとも）を機械的に
+  確認。last_read（2026-08-06T01:26:31Z）以降の新規コメント無し
+- 記録用 PR で自分のミスを1つ踏んだ: #276 を curl の REST API で merge した直後、ローカル
+  `main` を `git fetch`/`reset --hard` せずに次のブランチ（旧 autopilot/run92-wrapup）を
+  切ってしまい、stale な base のまま push して `mergeable_state: dirty` になった
+  （CHARTER §4 が run #72 の実例として既に警告していた失敗をそのまま踏んだ）。旧 PR #277 は
+  close・ブランチ削除し、`git reset --hard origin/main` で追従してから作り直した
+- 健全性確認: ops-health-report（generated_at 02:00:04Z 断面）で coder/immich/vaultwarden の
+  Application health が引き続き Degraded だが、`kubectl get externalsecret -n <ns>` で
+  3 namespace とも `<app>-restic-backup-credentials` だけが SecretSyncedError であることを
+  実測で再確認（T-0122 の既知事象どおり、新規異常ではない）。autopilot 自身の heartbeat も
+  iteration #36（exit_code 0）で正常
+- backlog の唯一の todo（T-0117, coder workspace home backup 初回実行確認）は CronJob
+  schedule（03:30 UTC）が現在時刻（02:33 UTC）よりまだ先のため引き続き着手不能。
+  `kubectl get cronjob` で `LAST SCHEDULE: <none>` を直接確認した
+- 見つけたこと: run #90/#91 で直近2回連続して広い調査（5角度 subagent・inventory 全32対象）を
+  行い新規ドリフトが枯渇していたため、今回は同種の調査を繰り返さず、CI の必須チェックと
+  main ruleset の整合という具体的な1点を確認した。`.github/workflows/ci.yml` の5 job
+  （kustomize build / manifest deletion guard / terraform validate / ops state validate /
+  nix flake check）と ruleset の `required_status_checks` が `GET /repos/.../rulesets/{id}`
+  で完全一致していることを実測し、§5.2 が懸念していた『CI に job を足しても必須チェック未登録』
+  のズレは現状発生していないと確認した（新規変更なし）
+- 次の起動へ: T-0117 は CronJob schedule（03:30 UTC）を過ぎていれば着手できる
+- ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化（open 0件・merged
+  #276 まで反映）、`python3 ops/validate.py` が 0 error, 0 warning（T-0123 の修正が効いている
+  ことも確認）、`ops/dashboard/build.py` 正常終了を確認

--- a/ops/state.json
+++ b/ops/state.json
@@ -987,6 +987,16 @@
       "prs": [
         276
       ]
+    },
+    {
+      "n": 93,
+      "at": "2026-08-06T11:33:00+09:00",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "前回の中断: PR #276（T-0123, 別セッションが同じ「run #92」で実装）を CI green・mergeable_state clean を確認して merge。issue #56 に未読フィードバックなし。自分のミス: #276 merge 直後にローカル main を追従させずに次のブランチを切り stale base で dirty になった（run #72 と同型）。旧 PR #277 を close・ブランチ削除し作り直した。健全性確認: coder/immich/vaultwarden の Degraded は T-0122 の既知事象どおり restic-backup-credentials ExternalSecret のみが原因と実測で再確認、autopilot 自身の heartbeat も正常。backlog の唯一の todo（T-0117）は CronJob schedule（03:30 UTC）未到来のため引き続き着手不能。run #90/#91 で広い調査が直近2回連続していたため今回は繰り返さず、CI 5 job と main ruleset の required_status_checks が完全一致していることを実測確認（変更なし）",
+      "prs": [
+        278
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

run #93 の運用記録更新（journal / state.json / dashboard の PR キャッシュ）。
コード・manifest の変更は無い。#277 の作り直し（stale base で dirty になったため close・再作成）。

- 前回の中断だった PR #276（T-0123, `ops/validate.py` の PR-empty 警告ノイズ解消。別セッションが
  同じ「run #92」で実装済み）を CI green・`mergeable_state: clean` を確認して merge した
- coder/immich/vaultwarden の ArgoCD Application health が引き続き Degraded だが、`kubectl get
  externalsecret` で3 namespace とも `<app>-restic-backup-credentials` だけが SecretSyncedError で
  あることを実測し、T-0122 の既知事象（T-0106 の Doppler 登録待ち）どおりで新規異常でないことを確認した
- `.github/workflows/ci.yml` の5 job と main ruleset の `required_status_checks` が完全一致している
  ことを実測確認した（CHARTER §5.2 が懸念する『CI に job を足しても必須チェック未登録』のズレは
  現状発生していない。変更なし）
- backlog の唯一の todo（T-0117, coder workspace home backup 初回実行確認）は CronJob schedule
  （03:30 UTC）が未到来のため引き続き着手不能

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning（T-0123 の修正が効いていることも確認）
- `python3 ops/dashboard/build.py` → 例外なく完走（`gh` 非搭載のため `prs.json` キャッシュへ
  フォールバック、既知の挙動）
- `python3 -c "import json; json.load(open('ops/backlog.json')); json.load(open('ops/state.json'))"` で
  JSON として壊れていないことを確認

## ロールバック手順

この PR を revert すれば運用記録は前回の状態に戻る。DB・クラスタ状態には触れていないため
データ・スキーマの不整合は残らない。

## backlog task id

なし（運用記録のみ、CHARTER §4 の相乗り例外）
