### PR TITLE
chore(autopilot): image ダイジェストコメントの実態乖離を修正 (T-0124)

### DIFF
--- a/apps/autopilot/deployment.yaml
+++ b/apps/autopilot/deployment.yaml
@@ -36,8 +36,11 @@ spec:
           type: RuntimeDefault
       containers:
         - name: autopilot
-          # タグはイメージのビルド経路が固まった時点で差し替えるプレースホルダ。
-          # ghcr の package が private の場合は imagePullSecrets が別途要る
+          # .github/workflows/build-autopilot-image.yml が images/autopilot/ の変更を
+          # main に取り込むたびに ghcr.io へ push する。このダイジェストは対応する
+          # images/autopilot/Dockerfile の内容を指す。中身を変えたら、ビルドが
+          # 終わったのを待ってこの行のダイジェストも合わせて更新する
+          # （ghcr の package が private の場合は imagePullSecrets が別途要る）
           image: ghcr.io/hikuohiku/homelab-autopilot@sha256:1ef41f711651af72fea996ba95c0e0a6e9171f4e6f5579325f54fed1605938a8
           command: ["bash", "/config/loop.sh"]
           securityContext:

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 124,
-  "updated": "2026-08-06T01:50:00Z",
+  "next_id": 125,
+  "updated": "2026-08-06T02:47:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2331,6 +2331,24 @@
       "created": "2026-08-06",
       "pr": 276,
       "notes": "run #92: 着手・完遂。python3 ops/validate.py で 0 error, 0 warning を確認済み"
+    },
+    {
+      "id": "T-0124",
+      "domain": "homelab",
+      "title": "apps/autopilot/deployment.yaml の image ダイジェストコメントが「プレースホルダ」のまま実態と乖離していた",
+      "kind": "chore",
+      "risk": "low",
+      "status": "done",
+      "priority": 60,
+      "why": "backlog の todo（T-0117）が CronJob schedule 未到来で着手不能だったため、CHARTER §3 に従い自分で調査。deployment.yaml のコメントが『タグはイメージのビルド経路が固まった時点で差し替えるプレースホルダ』のままだったが、run #57（2026-08-05 18:14）以降このダイジェストのまま autopilot 自身が継続的に正常稼働しており（現在 iteration #39、restartCount 0）、ビルド経路は既に固まっている。プレースホルダという表現は次の自分が『差し替えが必要』と誤読する原因になりうる",
+      "dod": "コメントを実態（build-autopilot-image.yml が images/autopilot/ の変更を main 取り込み時に push し、このダイジェストは対応する Dockerfile を指す。変更時はビルド完了を待ってダイジェストを更新する）に書き換える",
+      "blocked_by": null,
+      "refs": [
+        "apps/autopilot/deployment.yaml"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #95: 着手・完遂。コメントのみの変更で機能に影響なし"
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2347,7 +2347,7 @@
         "apps/autopilot/deployment.yaml"
       ],
       "created": "2026-08-06",
-      "pr": null,
+      "pr": 280,
       "notes": "run #95: 着手・完遂。コメントのみの変更で機能に影響なし"
     }
   ]

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,5 +1,16 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 280,
+      "title": "chore(autopilot): image ダイジェストコメントの実態乖離を修正 (T-0124)",
+      "url": "https://github.com/hikuohiku/homelab/pull/280",
+      "isDraft": false,
+      "createdAt": "2026-08-06T02:51:45Z",
+      "statusCheckRollup": [],
+      "headRefName": "autopilot/T-0124-autopilot-image-pin-comment",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
     {
       "number": 279,

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 279,
+      "title": "chore(ops): run #94 の記録更新（中断なし・T-0117 継続待ち・健全性確認）",
+      "url": "https://github.com/hikuohiku/homelab/pull/279",
+      "mergedAt": "2026-08-06T02:44:12Z",
+      "headRefName": "autopilot/run94-wrapup"
+    },
+    {
       "number": 278,
       "title": "chore(ops): run #93 の記録更新（PR #276 merge・健全性確認）",
       "url": "https://github.com/hikuohiku/homelab/pull/278",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/218",
       "mergedAt": "2026-08-05T17:53:39Z",
       "headRefName": "autopilot/incluster-image"
-    },
-    {
-      "number": 217,
-      "title": "ops: run #56 の記録更新（journal・state・PRキャッシュ、ダッシュボード再公開）",
-      "url": "https://github.com/hikuohiku/homelab/pull/217",
-      "mergedAt": "2026-08-05T17:32:06Z",
-      "headRefName": "autopilot/run56-wrapup"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2796,3 +2796,25 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - 次の起動へ: T-0117 は CronJob schedule（03:30 UTC）を過ぎていれば着手できる
 - ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化（open 0件・merged
   #278 まで反映）、`python3 ops/validate.py` / `ops/dashboard/build.py` の結果は次で確認する
+
+## 2026-08-06 11:47 JST — run #95
+
+- 前回の中断確認: オープン PR 無し。`autopilot/*` 残存ブランチ無し
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` で2ページとも）を機械的に
+  確認。last_read（2026-08-06T01:26:31Z）以降の新規コメント無し
+- ops-health-report（generated_at 2026-08-06T02:30:03Z）を確認: ArgoCD 11 Application 中
+  coder/immich/vaultwarden の3件が引き続き Degraded（T-0106 由来の既知事象）で他は Healthy。
+  pod_issues は常連の restarts:19 のみで新規異常なし。autopilot 自身の heartbeat も
+  last_end（iteration #38, exit_code 0, elapsed 350s）・deployment（1/1 ready）とも正常
+- backlog の唯一の todo（T-0117）は CronJob schedule（`30 3 * * *` = 03:30 UTC、現在時刻
+  02:47 UTC）がまだ先のため引き続き着手不能。needs-human 4件（T-0074/T-0106/T-0107/T-0112）も
+  外部コンソール操作か pods/log 権限待ちで追加対応不可と確認
+- 見つけたこと・やったこと: CHARTER §3 に従い新しい調査観点を探し、apps/autopilot/deployment.yaml
+  の image ダイジェストのコメントが「ビルド経路が固まった時点で差し替えるプレースホルダ」のまま
+  だった点を発見。run #57（2026-08-05 18:14）以降このダイジェストで継続稼働しており（現在
+  iteration #39、restartCount 0）ビルド経路は既に固まっているため、次の自分が誤読しない実態に
+  即したコメント（build-autopilot-image.yml が push する運用と更新手順）に書き換えた
+  （T-0124, コメントのみ・機能影響なし）
+- 次の起動へ: T-0117 は CronJob schedule（03:30 UTC）を過ぎていれば着手できる
+- ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
+  `ops/dashboard/build.py` を実行する

--- a/ops/state.json
+++ b/ops/state.json
@@ -1014,7 +1014,9 @@
       "kind": "scheduled",
       "by": "in-cluster autopilot",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。ops-health-report・autopilot heartbeat とも正常、既知の Degraded 3件のみ。backlog の唯一の todo（T-0117）は CronJob schedule（03:30 UTC）未到来のため引き続き着手不能、needs-human 4件も追加対応不可。CHARTER §3 に従い調査し、apps/autopilot/deployment.yaml の image ダイジェストコメントが「ビルド経路が固まった時点で差し替えるプレースホルダ」のまま実態（run #57 以降このダイジェストで継続稼働中）と乖離していたのを発見し実態に即した内容へ書き換えた（T-0124）",
-      "prs": []
+      "prs": [
+        280
+      ]
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T02:42:08Z",
+  "updated": "2026-08-06T02:47:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -1007,6 +1007,14 @@
       "prs": [
         279
       ]
+    },
+    {
+      "n": 95,
+      "at": "2026-08-06T11:47:00+09:00",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。ops-health-report・autopilot heartbeat とも正常、既知の Degraded 3件のみ。backlog の唯一の todo（T-0117）は CronJob schedule（03:30 UTC）未到来のため引き続き着手不能、needs-human 4件も追加対応不可。CHARTER §3 に従い調査し、apps/autopilot/deployment.yaml の image ダイジェストコメントが「ビルド経路が固まった時点で差し替えるプレースホルダ」のまま実態（run #57 以降このダイジェストで継続稼働中）と乖離していたのを発見し実態に即した内容へ書き換えた（T-0124）",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`apps/autopilot/deployment.yaml` の image ダイジェストに付いていたコメントが「タグはイメージのビルド経路が固まった時点で差し替えるプレースホルダ」のままだった。run #57（2026-08-05 18:14）以降、この同じダイジェストで autopilot 自身が継続稼働しており（現在 iteration #39、restartCount 0）、ビルド経路は既に固まっている。プレースホルダという表現は次の自分（または人間）が「差し替えが必要」と誤読する原因になりうるため、実際の運用（`.github/workflows/build-autopilot-image.yml` が `images/autopilot/` の変更を main 取り込み時に push し、このダイジェストは対応する Dockerfile の内容を指す。中身を変えたらビルド完了を待ってダイジェストも更新する）に即した内容へ書き換えた。コメントのみの変更で機能・挙動への影響は無い。

併せて run #95 の運用記録（journal / backlog.json / state.json / dashboard の PR キャッシュ）を同PRに相乗りさせた（低リスクな記録更新のため、CHARTER §4 の相乗り例外に該当）。

## 検証したこと

- `python3 ops/validate.py` で 0 error, 0 warning
- `python3 ops/dashboard/build.py` が例外なく終了し `ops/dashboard/index.html` を再生成
- コメント変更のみで `image:` の値（ダイジェスト）自体は変更していないことを diff で確認

## ロールバック手順

この PR を revert すればコメントのみ元に戻る。manifest の実質的な値（image ダイジェスト）は変更していないため、revert によるクラスタ側の影響は無い。

## backlog task id

T-0124
