### PR TITLE
chore(ops): run #96 の記録更新（中断なし・進捗なし・健全性確認）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,17 +1,13 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 280,
       "title": "chore(autopilot): image ダイジェストコメントの実態乖離を修正 (T-0124)",
       "url": "https://github.com/hikuohiku/homelab/pull/280",
-      "isDraft": false,
-      "createdAt": "2026-08-06T02:51:45Z",
-      "statusCheckRollup": [],
-      "headRefName": "autopilot/T-0124-autopilot-image-pin-comment",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-06T02:53:34Z",
+      "headRefName": "autopilot/T-0124-autopilot-image-pin-comment"
+    },
     {
       "number": 279,
       "title": "chore(ops): run #94 の記録更新（中断なし・T-0117 継続待ち・健全性確認）",
@@ -424,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/219",
       "mergedAt": "2026-08-05T18:03:34Z",
       "headRefName": "autopilot/in-cluster-substrate"
-    },
-    {
-      "number": 218,
-      "title": "feat(autopilot): クラスタ内常駐 autopilot のイメージとビルド経路を追加する",
-      "url": "https://github.com/hikuohiku/homelab/pull/218",
-      "mergedAt": "2026-08-05T17:53:39Z",
-      "headRefName": "autopilot/incluster-image"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2818,3 +2818,28 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - 次の起動へ: T-0117 は CronJob schedule（03:30 UTC）を過ぎていれば着手できる
 - ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
   `ops/dashboard/build.py` を実行する
+
+## 2026-08-06 11:56 JST — run #96
+
+- 前回の中断確認: オープン PR 無し（#280 は run #95 のうちに merge 済み）。`autopilot/*`
+  残存ブランチ無し
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` で2ページとも）を機械的に
+  確認。last_read（2026-08-06T01:26:31Z）以降の新規コメント無し
+- ops-health-report（generated_at 2026-08-06T02:30:03Z）を確認: ArgoCD 11 Application 中
+  coder/immich/vaultwarden の3件が引き続き Degraded（T-0106 由来の既知事象）で他は Healthy。
+  pod_issues は常連の restarts:19 のみで新規異常なし。autopilot 自身の heartbeat も
+  last_start（iteration #39, 02:17:13Z）・last_end（iteration #38, exit_code 0, elapsed
+  350s）・deployment（1/1 ready）とも正常
+- backlog の唯一の todo（T-0117）は CronJob schedule（`30 3 * * *` = 03:30 UTC、現在時刻
+  02:56 UTC）がまだ先のため引き続き着手不能。needs-human 4件（T-0074/T-0106/T-0107/T-0112）も
+  外部コンソール操作か pods/log 権限待ちで追加対応不可、blocked 4件（T-0028/T-0029/T-0084/
+  T-0116/T-0118）も前提未変化のため着手不能
+- 見つけたこと・やったこと: pod_issues の常連 restarts:19 は journal 上で継続的に「ノード再起動
+  由来・値が揃っている」と確認済み（直近では run #90 系列）であることを確認し、重複調査は避けた。
+  他に新しい調査観点は見つからず、run #90/#91（広域）・run #94（ドキュメント突合）に続く追加の
+  発見は無し
+- 次の起動へ: T-0117 は CronJob schedule（03:30 UTC）を過ぎていれば着手できる
+- ダッシュボード: `ops/dashboard/prs.json` を GitHub REST API で最新化（open 0件・merged
+  #280 まで反映）、`python3 ops/validate.py` が 0 error, 0 warning、`ops/dashboard/build.py`
+  正常終了を確認
+  `ops/dashboard/build.py` を実行する

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T02:47:00Z",
+  "updated": "2026-08-06T02:56:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -1017,6 +1017,14 @@
       "prs": [
         280
       ]
+    },
+    {
+      "n": 96,
+      "at": "2026-08-06T11:56:00+09:00",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。ops-health-report・autopilot heartbeat とも正常、既知の Degraded 3件のみ。backlog の唯一の todo（T-0117）は CronJob schedule（03:30 UTC）未到来のため引き続き着手不能、needs-human 4件・blocked 5件も前提未変化で追加対応不可。新しい調査観点は見つからず、進捗なしのまま記録のみ更新",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

autopilot run #96 の運用記録更新のみ（コード変更なし）。

- オープン PR・`autopilot/*` 残存ブランチとも無く、前回からの中断は無し
- issue #56 に last_read（2026-08-06T01:26:31Z）以降の新規フィードバック無し
- ops-health-report（generated_at 2026-08-06T02:30:03Z）: ArgoCD 11 Application 中 coder/immich/vaultwarden の3件が引き続き Degraded（T-0106 由来の既知事象、CHARTER §2 参照）で他は Healthy。pod_issues は常連の restarts:19 のみで新規異常なし
- autopilot 自身の heartbeat・deployment とも正常（iteration #39 起動中、直前の #38 は exit_code 0）
- backlog は唯一の todo（T-0117）が CronJob schedule（03:30 UTC）未到来のため引き続き着手不能。needs-human 4件・blocked 5件も前提が変わっておらず追加対応不可
- `ops/dashboard/prs.json` を GitHub REST API で最新化（open 0件・merged #280 まで反映）

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 正常終了（`ops/dashboard/index.html` は Git 管理外）

## ロールバック手順

この PR は journal・state.json・dashboard キャッシュの追記のみで、実インフラには影響しない。revert すれば記録が1件分巻き戻るだけで、他に副作用は無い。

## backlog task id

なし（定例の記録更新）