### PR TITLE
chore(ops): run #96 の実番号 (#281) を記録に反映

### DIFF
--- a/ops/state.json
+++ b/ops/state.json
@@ -1024,7 +1024,7 @@
       "kind": "scheduled",
       "by": "in-cluster autopilot",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。ops-health-report・autopilot heartbeat とも正常、既知の Degraded 3件のみ。backlog の唯一の todo（T-0117）は CronJob schedule（03:30 UTC）未到来のため引き続き着手不能、needs-human 4件・blocked 5件も前提未変化で追加対応不可。新しい調査観点は見つからず、進捗なしのまま記録のみ更新",
-      "prs": []
+      "prs": [281]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

#281（run #96 の記録更新 PR）を作成した時点では PR 番号が分からず `ops/state.json` の該当 run の `prs` を空配列のまま記録していた。マージ後に判明した実番号 (#281) を反映する（コード変更なし）。

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning

## ロールバック手順

記録の1フィールドの訂正のみ。revert しても実インフラへの影響は無い。

## backlog task id

なし（定例の記録更新）