### PR TITLE
docs: CronJob の schedule 記述を UTC → JST に訂正 (T-0125)

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -65,7 +65,9 @@ Box との比較検討は不要。宣言値（PVC の `requested`）と実測値
 
 `apps/vaultwarden/restic-backup-cronjob.yaml` に2つの CronJob を実装した。
 
-- **`vaultwarden-restic-backup`**（毎日 03:40 UTC）: `/data` を直接 restic に渡すと
+- **`vaultwarden-restic-backup`**（毎日 03:40 JST。node01 の `time.timeZone = "Asia/Tokyo"` により
+  k3s の CronJob スケジュールはホストのローカル時刻＝JST で評価される。UTC 換算では前日 18:40）:
+  `/data` を直接 restic に渡すと
   `db.sqlite3-wal`/`-shm` と本体の不整合を持ち込む（vaultwarden 公式 wiki の注意）ため、
   initContainer で SQLite の Online Backup API（Python 標準ライブラリの
   `sqlite3.Connection.backup()`。CLI の `.backup`/vaultwarden 内蔵の `VACUUM INTO` と同じ
@@ -79,7 +81,7 @@ Box との比較検討は不要。宣言値（PVC の `requested`）と実測値
   毎回依存してしまうため置き換えた。vaultwarden 内蔵の `/vaultwarden backup` コマンドは
   ソース確認の結果 `db.sqlite3` と同じディレクトリにしか出力できず読み取り専用マウントと
   両立しないため不採用）
-- **`vaultwarden-restic-retention`**（毎週日曜 04:00 UTC）: `restic forget --keep-daily 7
+- **`vaultwarden-restic-retention`**（毎週日曜 04:00 JST、UTC 換算では前日 19:00）: `restic forget --keep-daily 7
   --keep-weekly 4 --keep-monthly 6 --prune`
 - 保存先は Backblaze B2（`b2:<bucket>:vaultwarden`）。immich（T-0068）・coder-postgres
   （T-0070）も同じ bucket・同じ credential でパス末尾だけ変える設計にした
@@ -91,7 +93,11 @@ Box との比較検討は不要。宣言値（PVC の `requested`）と実測値
 `apps/immich/restic-backup-cronjob.yaml` に2つの CronJob を実装した。
 
 - immich server v2.7.5 には "Database Backup" 機能がデフォルトで有効（`server/src/config.ts`
-  の `backup.database`: `enabled: true`、毎日 02:00 UTC 実行、`keepLastAmount: 14`）で、
+  の `backup.database`: `enabled: true`、毎日 02:00 **UTC** 実行、`keepLastAmount: 14`）で、
+  これは k8s の CronJob ではなく immich-server コンテナ内で動くアプリケーション自身のタイマーの
+  ため、node01 の JST 設定の影響を受けない（`backup_listing` のファイル名・`mtime` が実際に
+  UTC 02:00 で揃っていることを 2026-08-06 実測で確認済み、T-0125）。この節の他の CronJob（下記）とは
+  時刻の基準が異なる点に注意
   pg_dump 相当のフルダンプ（pgvector/embeddings テーブル含め除外なし）を `.tmp` へ書いてから
   rename する形で `UPLOAD_LOCATION/backups/*.sql.gz` に確定させる（サブエージェントが v2.7.5
   タグの実ソース `database-backup.service.ts` を直接確認して裏取り済み）。`UPLOAD_LOCATION`
@@ -99,9 +105,10 @@ Box との比較検討は不要。宣言値（PVC の `requested`）と実測値
   のため、**`immich-library` PVC を restic で1本取るだけでライブラリ本体と DB ダンプ
   （immich-postgres-data 相当のデータを含む）が同時に取れる。** coder-postgres（T-0070）の
   ような専用 `pg_dump` initContainer は不要だった
-- **`immich-restic-backup`**（毎日 02:45 UTC、immich 自身のダンプ完了を待つため45分後に開始）:
+- **`immich-restic-backup`**（毎日 02:45 JST、immich 自身のダンプ完了を待つため45分後に開始。
+  UTC 換算では前日 17:45）:
   `immich-library` PVC をそのまま restic backup する
-- **`immich-restic-retention`**（毎週日曜 03:45 UTC）: `restic forget --keep-daily 7
+- **`immich-restic-retention`**（毎週日曜 03:45 JST、UTC 換算では前日 18:45）: `restic forget --keep-daily 7
   --keep-weekly 4 --keep-monthly 6 --prune`
 - 保存先は vaultwarden/coder-postgres と同じ Backblaze B2 バケット、パス末尾のみ `immich`
   （`b2:<bucket>:immich`）
@@ -127,7 +134,7 @@ Box との比較検討は不要。宣言値（PVC の `requested`）と実測値
 同じ設計思想（稼働中の DB を直接 restic に渡さず、一貫性のあるダンプを先に作る）を
 PostgreSQL 向けに適用したもの。
 
-- **`coder-restic-backup`**（毎日 03:10 UTC）: PostgreSQL は稼働中の PGDATA を restic で
+- **`coder-restic-backup`**（毎日 03:10 JST、UTC 換算では前日 18:10）: PostgreSQL は稼働中の PGDATA を restic で
   直接舐めてはいけない（サーバを止めない限り一貫したスナップショットにならないと
   PostgreSQL 公式ドキュメントが明記）ため、initContainer で `pg_dump -Fc`（カスタム形式、
   `pg_restore` で復元）を使いネットワーク経由で論理ダンプを取り、emptyDir 経由で本体の
@@ -137,7 +144,7 @@ PostgreSQL 向けに適用したもの。
   `ops/inventory.json` の `coder-postgres` エントリの `mirrors` としてバージョン同期を
   `check_version_sync.py` の CI で追う）。PVC には触れず DB へのネットワーク接続のみのため、
   vaultwarden の sqlite-snapshot initContainerと違い `DAC_READ_SEARCH` は不要
-- **`coder-restic-retention`**（毎週日曜 04:10 UTC）: `restic forget --keep-daily 7
+- **`coder-restic-retention`**（毎週日曜 04:10 JST、UTC 換算では前日 19:10）: `restic forget --keep-daily 7
   --keep-weekly 4 --keep-monthly 6 --prune`
 - 保存先は vaultwarden と同じ Backblaze B2 バケット、パス末尾のみ `coder-postgres`
   （`b2:<bucket>:coder-postgres`）
@@ -153,7 +160,8 @@ PostgreSQL 向けに適用したもの。
 vaultwarden/coder-postgres）と異なり、対象 PVC (`coder-<workspace-id>-home`) は workspace の
 作成・削除のたびに動的に増減するため、静的なマニフェストには書けない。
 
-- **オーケストレータ方式**: `coder-workspace-home-backup` CronJob（毎日 03:30 UTC）が
+- **オーケストレータ方式**: `coder-workspace-home-backup` CronJob（毎日 03:30 JST、UTC 換算では
+  前日 18:30）が
   python:3.12-alpine の Pod 1個を起動し、`app.kubernetes.io/name=coder-pvc` ラベル
   （`apps/coder/templates/personal/main.tf` が付与）で対象 PVC を毎回列挙、PVC ごとに
   使い捨ての Job（restic/restic イメージ、対象 PVC のみ readOnly マウント）を Kubernetes API
@@ -164,7 +172,8 @@ vaultwarden/coder-postgres）と異なり、対象 PVC (`coder-<workspace-id>-ho
   Secret（同じ Backblaze B2 バケット・同じ暗号化パスワード）をそのまま流用し、リポジトリパス
   末尾のみ `coder-workspace-homes` に変える設計
 - **1リポジトリを workspace 間で共有**: 各 Job は `restic backup --host <workspace-id>` で
-  ホストタグを付ける。**`coder-workspace-home-backup-retention`**（毎週日曜 04:30 UTC）は
+  ホストタグを付ける。**`coder-workspace-home-backup-retention`**（毎週日曜 04:30 JST、UTC 換算では
+  前日 19:30）は
   `restic forget --group-by host --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --prune`
   でホスト単位に世代管理する。workspace が削除されてもそのホストの世代は自然に切り捨てられる
   （明示的な削除はしない）

--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -79,9 +79,18 @@ T-0068 のバックアップは実質機能していないとみなして調査�
 
 **`pvc_usage` の `error`（404 相当）は「まだ」と「ずっと」を区別すること**（issue #56, 2026-08-05
 07:41:02 の指摘）。対象の `pvc-usage-reporter` CronJob（`immich`/`vaultwarden`/`coder`、schedule は
-それぞれ `5 */6 * * *` / `15 */6 * * *` / `25 */6 * * *`、つまり毎日 00:05・06:05・12:05・18:05 UTC
-+ namespace ごとに 0/10/20 分）がまだ一度もその時刻を迎えていなければ 404 は正常。`generated_at` を
+それぞれ `5 */6 * * *` / `15 */6 * * *` / `25 */6 * * *`、つまり毎日 00:05・06:05・12:05・18:05
+**JST**（namespace ごとに 0/10/20 分。UTC 換算では 03:05・09:05・15:05・21:05 が起点、以下 6 時間毎
++ 0/10/20 分）がまだ一度もその時刻を迎えていなければ 404 は正常。`generated_at` を
 これらの実行予定時刻と比較し、直近の予定時刻を過ぎてもなお 404 が続く場合にのみ CronJob の異常を疑う。
+**この節はかつて誤って「UTC」と書いていた**（T-0125, run #97 で訂正）。node01 の
+`time.timeZone = "Asia/Tokyo"`（`nix/images/proxmox-cloud/configuration.nix`）により、k3s の
+kube-controller-manager は `spec.timeZone` を明示していない CronJob の schedule 文字列を
+ホストのローカル時刻（JST）で評価する。これはこの CronJob に限らず、node01 上の全ての
+Kubernetes CronJob リソースに共通する（`spec.timeZone` を明示しているものは無い、2026-08-06 実測）。
+**アプリケーション内部のタイマー（例: immich サーバー自身の `backup.database` 機能、後述）はこの
+対象外で、コンテナ内プロセスの挙動に依存する** — immich の内蔵バックアップは `backup_listing` の
+ファイル名・`mtime` が実際に UTC 02:00 で揃っており、こちらは訂正不要（2026-08-06 実測）。
 
 **`coder`/`immich`/`vaultwarden` の ArgoCD Application health が `Degraded` でも、T-0106 が
 `needs-human` のままの間は新規異常ではない**（run #91 で発見）。T-0106（run #88, PR #263）が

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 125,
-  "updated": "2026-08-06T02:47:00Z",
+  "next_id": 126,
+  "updated": "2026-08-06T03:15:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2214,7 +2214,7 @@
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "run #83: T-0078 実装の副産物として分離起票。run #85: T-0078 は run #84 で done・PR #264 merge 済みのため blocked_by を解消。ただし CronJob の schedule（毎日 03:30 UTC）が未到来のため実行確認はまだできない"
+      "notes": "run #83: T-0078 実装の副産物として分離起票。run #85: T-0078 は run #84 で done・PR #264 merge 済みのため blocked_by を解消。ただし CronJob の schedule（毎日 03:30 UTC と当時記載）が未到来のため実行確認はまだできない。run #97 (T-0125) で訂正: この schedule は実際には JST（node01 の time.timeZone=Asia/Tokyo により k3s の CronJob は JST で評価される）。CronJob は 2026-08-06T00:40:29Z 作成で当日 03:30 JST の回には間に合っておらず、次回の実行予定は 2026-08-07 03:30 JST（= 2026-08-06T18:30Z）。run #94〜#97 が『毎時 UTC 基準でもうすぐ』と判断していたのは誤りで、実際はまだ半日以上先"
     },
     {
       "id": "T-0118",
@@ -2349,6 +2349,26 @@
       "created": "2026-08-06",
       "pr": 280,
       "notes": "run #95: 着手・完遂。コメントのみの変更で機能に影響なし"
+    },
+    {
+      "id": "T-0125",
+      "domain": "homelab",
+      "title": "CHARTER/docs/backup.md の CronJob schedule が「UTC」と誤記されていた（実際は JST）",
+      "kind": "chore",
+      "risk": "low",
+      "status": "done",
+      "priority": 12,
+      "why": "backlog の todo（T-0117）が CronJob schedule 未到来で着手不能だったため CHARTER §3 に従い調査。kubectl で pvc-usage-reporter (immich/vaultwarden/coder) と各 restic-backup/retention CronJob の実際の lastScheduleTime を、CHARTER/docs/backup.md が『UTC』と書く時刻と突き合わせたところ、4系統・8時刻すべてが UTC ではなく JST（UTC+9）で評価された結果と一致した。原因は node01 の `time.timeZone = \"Asia/Tokyo\"`（nix/images/proxmox-cloud/configuration.nix）で、この CronJob いずれも `spec.timeZone` を明示していないため k3s の kube-controller-manager がホストのローカル時刻（JST）で schedule 文字列を評価する。CHARTER §2 の pvc-usage-reporter 404 判定基準と docs/backup.md のバックアップ時刻表がいずれも UTC 前提で書かれており、T-0117 のように『あと何分で実行されるか』を UTC で見積もると最大 9 時間ずれる。immich サーバー内蔵の backup.database（アプリ内タイマー、コンテナ内で完結）は対象外で、backup_listing のファイル名/mtime が UTC 02:00 で揃っていることを実測し区別した",
+      "dod": "CHARTER §2 の pvc-usage-reporter schedule 記述と docs/backup.md の8箇所の CronJob 時刻表記を JST に訂正し、UTC 換算値も併記する。T-0117 の notes に、次回実行予定が実際には 2026-08-07 03:30 JST（=2026-08-06T18:30Z）である旨を追記する",
+      "blocked_by": null,
+      "refs": [
+        "ops/CHARTER.md",
+        "docs/backup.md",
+        "ops/backlog.json"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #97: kubectl での実測（pvc-usage-reporter 3件・immich/vaultwarden/coder-restic-backup/retention・coder-workspace-home-backup の lastScheduleTime）に基づき着手・完遂。コード変更は無くドキュメント訂正のみ、機能影響なし"
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2367,7 +2367,7 @@
         "ops/backlog.json"
       ],
       "created": "2026-08-06",
-      "pr": null,
+      "pr": 283,
       "notes": "run #97: kubectl での実測（pvc-usage-reporter 3件・immich/vaultwarden/coder-restic-backup/retention・coder-workspace-home-backup の lastScheduleTime）に基づき着手・完遂。コード変更は無くドキュメント訂正のみ、機能影響なし"
     }
   ]

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,5 +1,20 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 283,
+      "title": "docs: CronJob の schedule 記述を UTC → JST に訂正 (T-0125)",
+      "url": "https://github.com/hikuohiku/homelab/pull/283",
+      "isDraft": false,
+      "createdAt": null,
+      "statusCheckRollup": [
+        {
+          "conclusion": "PENDING"
+        }
+      ],
+      "headRefName": "autopilot/T-0125-cronjob-schedule-jst-not-utc",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
     {
       "number": 282,

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,20 @@
   "open": [],
   "merged": [
     {
+      "number": 282,
+      "title": "chore(ops): run #96 の実番号 (#281) を記録に反映",
+      "url": "https://github.com/hikuohiku/homelab/pull/282",
+      "mergedAt": "2026-08-06T03:01:14Z",
+      "headRefName": "autopilot/run96-pr-number"
+    },
+    {
+      "number": 281,
+      "title": "chore(ops): run #96 の記録更新（中断なし・進捗なし・健全性確認）",
+      "url": "https://github.com/hikuohiku/homelab/pull/281",
+      "mergedAt": "2026-08-06T02:59:40Z",
+      "headRefName": "autopilot/run96-wrapup"
+    },
+    {
       "number": 280,
       "title": "chore(autopilot): image ダイジェストコメントの実態乖離を修正 (T-0124)",
       "url": "https://github.com/hikuohiku/homelab/pull/280",
@@ -406,20 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/221",
       "mergedAt": "2026-08-05T18:18:27Z",
       "headRefName": "autopilot/T-0107-T-0108-substrate-charter-update"
-    },
-    {
-      "number": 220,
-      "title": "feat(autopilot): クラスタ内 autopilot を起動する",
-      "url": "https://github.com/hikuohiku/homelab/pull/220",
-      "mergedAt": "2026-08-05T18:05:14Z",
-      "headRefName": "autopilot/enable-in-cluster"
-    },
-    {
-      "number": 219,
-      "title": "feat(autopilot): クラスタ内常駐 autopilot のマニフェストを追加",
-      "url": "https://github.com/hikuohiku/homelab/pull/219",
-      "mergedAt": "2026-08-05T18:03:34Z",
-      "headRefName": "autopilot/in-cluster-substrate"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2843,3 +2843,29 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   #280 まで反映）、`python3 ops/validate.py` が 0 error, 0 warning、`ops/dashboard/build.py`
   正常終了を確認
   `ops/dashboard/build.py` を実行する
+
+## 2026-08-06 12:15 JST — run #97
+
+- 前回の中断確認: オープン PR 無し。`autopilot/*` 残存ブランチ無し
+- 読んだフィードバック: issue #56 のコメント計 102 件（`per_page=100` で2ページとも）を機械的に
+  確認。last_read（2026-08-06T01:26:31Z）以降の新規コメント無し
+- ops-health-report（generated_at 2026-08-06T03:00:06Z）を確認: ArgoCD 11 Application 中
+  coder/immich/vaultwarden の3件が引き続き Degraded（T-0106 由来の既知事象）で他は Healthy。
+  pod_issues は常連の restarts:19 のみで新規異常なし。autopilot 自身の heartbeat も正常
+  （iteration #41 last_end exit_code 0、deployment 1/1 ready）
+- backlog の唯一の todo（T-0117）は CronJob（coder-workspace-home-backup）が未実行のため
+  引き続き着手不能と確認する過程で、schedule の解釈が誤っていたことを発見（詳細は次項）
+- 見つけたこと・やったこと（T-0125）: kubectl で pvc-usage-reporter (immich/vaultwarden/coder) と
+  各 restic-backup/retention・coder-workspace-home-backup の実際の lastScheduleTime を確認し、
+  CHARTER §2・docs/backup.md が「UTC」と書く時刻とすべて9時間ずれている（実際は JST で評価されて
+  いる）と判明。原因は node01 の `time.timeZone = "Asia/Tokyo"`（configuration.nix）で、これらの
+  CronJob はいずれも `spec.timeZone` を明示していないため kube-controller-manager がホストの
+  ローカル時刻（JST）で schedule を評価する。immich サーバー内蔵の backup.database（アプリ内
+  タイマー、コンテナ内で完結）はこの影響を受けず UTC 02:00 のままであることも backup_listing の
+  ファイル名/mtime で確認し区別した。CHARTER §2・docs/backup.md（8箇所）を JST 表記＋UTC換算値の
+  併記に訂正し、T-0117 の notes に「次回実行予定は 2026-08-07 03:30 JST（=2026-08-06T18:30Z）で
+  従来の想定より半日以上先」と追記した（T-0125, コード変更なし・ドキュメント訂正のみ）
+- 次の起動へ: T-0117 は 2026-08-06T18:30Z（03:30 JST 翌日分）を過ぎるまで着手不能。この時刻を
+  UTC の現在時刻とそのまま比較しないこと（T-0125 参照）
+- ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
+  `ops/dashboard/build.py` を実行する

--- a/ops/state.json
+++ b/ops/state.json
@@ -1032,7 +1032,7 @@
       "kind": "scheduled",
       "by": "in-cluster autopilot",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。ops-health-report・autopilot heartbeat とも正常、既知の Degraded 3件のみ。backlog の唯一の todo（T-0117）の未着手理由を kubectl で裏取りする過程で、CHARTER §2・docs/backup.md が CronJob の schedule を「UTC」と誤記していたと発見（実際は node01 の time.timeZone=Asia/Tokyo により JST で評価される。9時間ずれ）。immich サーバー内蔵の backup.database は対象外で UTC のままと区別して確認。CHARTER・docs/backup.md（計9箇所）を訂正し、T-0117 の notes に正しい次回実行予定（2026-08-07 03:30 JST）を追記した（T-0125）",
-      "prs": []
+      "prs": [283]
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T02:56:00Z",
+  "updated": "2026-08-06T03:15:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -1025,6 +1025,14 @@
       "by": "in-cluster autopilot",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。ops-health-report・autopilot heartbeat とも正常、既知の Degraded 3件のみ。backlog の唯一の todo（T-0117）は CronJob schedule（03:30 UTC）未到来のため引き続き着手不能、needs-human 4件・blocked 5件も前提未変化で追加対応不可。新しい調査観点は見つからず、進捗なしのまま記録のみ更新",
       "prs": [281]
+    },
+    {
+      "n": 97,
+      "at": "2026-08-06T12:15:00+09:00",
+      "kind": "scheduled",
+      "by": "in-cluster autopilot",
+      "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。ops-health-report・autopilot heartbeat とも正常、既知の Degraded 3件のみ。backlog の唯一の todo（T-0117）の未着手理由を kubectl で裏取りする過程で、CHARTER §2・docs/backup.md が CronJob の schedule を「UTC」と誤記していたと発見（実際は node01 の time.timeZone=Asia/Tokyo により JST で評価される。9時間ずれ）。immich サーバー内蔵の backup.database は対象外で UTC のままと区別して確認。CHARTER・docs/backup.md（計9箇所）を訂正し、T-0117 の notes に正しい次回実行予定（2026-08-07 03:30 JST）を追記した（T-0125）",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`ops/CHARTER.md` と `docs/backup.md` に書かれていた CronJob（`pvc-usage-reporter` / 各コンポーネントの `*-restic-backup`・`*-restic-retention` / `coder-workspace-home-backup`・`*-retention`）の実行時刻が、実際には **JST** で評価されているにもかかわらず「UTC」と誤記されていました。

- 原因: node01 の `time.timeZone = "Asia/Tokyo"`（`nix/images/proxmox-cloud/configuration.nix`）により、`spec.timeZone` を明示していない k3s CronJob は kube-controller-manager が動くホストのローカル時刻（JST）で schedule を評価する
- 影響: `ops/backlog.json` の T-0117（coder workspace home backup 初回実行確認）が、「schedule 未到来」の判断を UTC 基準で行っており、実際の次回実行予定（2026-08-07 03:30 JST = 2026-08-06T18:30Z）より大幅に早いタイミングで「もうすぐ実行される」と誤認し続けていました
- immich サーバー内蔵の "Database Backup" 機能（`backup.database`、アプリ内タイマー）はコンテナ内で完結するためこの影響を受けず、UTC 02:00 のまま正しい記述でした（`backup_listing` のファイル名/mtime で実測確認）

CHARTER §2 と docs/backup.md の該当箇所（計9箇所）を JST 表記＋UTC換算値の併記に訂正し、T-0117 の notes に正しい次回実行予定を追記しました。コード・manifest の変更はなく、ドキュメント訂正のみです。

## 検証したこと

- `kubectl get cronjob -o custom-columns=...LAST:.status.lastScheduleTime` で pvc-usage-reporter (immich/vaultwarden/coder) と各 restic-backup/retention・coder-workspace-home-backup の直近実行時刻を取得し、CHARTER/docs 記載の「UTC」時刻ではなく JST 時刻と一致することを4系統・8時刻すべてで確認
- `nix/images/proxmox-cloud/configuration.nix` の `time.timeZone = "Asia/Tokyo"` を確認し、原因と整合することを確認
- immich の `ops-health-report` (`pvc_usage.immich.backup_listing`) のファイル名（`immich-db-backup-20260805T020000-*`）と `mtime`（`2026-08-05T02:00:03Z`）が一致しており、こちらは UTC のままであることを確認
- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 正常終了

## ロールバック手順

このコミットを revert すればドキュメントは訂正前の状態に戻ります。DB やクラスタの状態には一切触れていないため、revert によるデータ不整合は発生しません。

## backlog task id

T-0125（done）
