### PR TITLE
fix(ops): dashboard の PR 一覧取得を gh CLI 依存から GitHub API 直叩きに (T-0126)

### DIFF
--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -617,9 +617,15 @@ PR に付いたレビューコメントも同じ扱い。**指摘を受けたら
 
 人間が朝に見る唯一の画面。`ops/` を更新したら**必ず**次を実行する。
 
-`ops/dashboard/build.py` の `fetch_prs()` は内部で `gh pr list` を呼ぶが、このクラウドサンドボックスに
-`gh` は無いので必ず失敗し、`ops/dashboard/prs.json` のキャッシュにフォールバックする（CHARTER §5.2）。
-**キャッシュは自動更新されない。** ビルド前に次の手順でキャッシュを最新化する（T-0016）。
+**T-0126（run #98）以降**、`ops/dashboard/build.py` の `fetch_prs()` は `gh` CLI に依存せず、
+`AUTOPILOT_GITHUB_TOKEN` で GitHub REST API を直接叩いて `ops/dashboard/prs.json` を自分で
+最新化してから読む。クラスタ内常駐（§5.5）ではこのトークンが使えるため、**手動でキャッシュを
+組み立てる手順は不要になった。** `python3 ops/dashboard/build.py` を実行するだけで PR 一覧も
+併せて最新化される。
+
+`AUTOPILOT_GITHUB_TOKEN` が無い実行環境（旧・クラウド定期実行サンドボックス等）では、
+`fetch_prs()` は例外を送出前提のまま `ops/dashboard/prs.json` のキャッシュにフォールバックする。
+その場合のみ、以下の手順でキャッシュを手で最新化してからビルドする。
 
 1. `mcp__github__list_pull_requests`（`state: open`）と（`state: closed`, `sort: updated`, `direction: desc`）
    で取得する。**`merged` フィールドは信用しない**（closed の全件で `false` を返すことがある実測済みの不具合。

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 126,
-  "updated": "2026-08-06T03:15:00Z",
+  "next_id": 129,
+  "updated": "2026-08-06T03:17:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2369,6 +2369,66 @@
       "created": "2026-08-06",
       "pr": 283,
       "notes": "run #97: kubectl での実測（pvc-usage-reporter 3件・immich/vaultwarden/coder-restic-backup/retention・coder-workspace-home-backup の lastScheduleTime）に基づき着手・完遂。コード変更は無くドキュメント訂正のみ、機能影響なし"
+    },
+    {
+      "id": "T-0126",
+      "domain": "homelab",
+      "title": "dashboard build.py の fetch_prs() を gh CLI 依存から GitHub REST API 直叩きに置き換え",
+      "kind": "chore",
+      "risk": "low",
+      "status": "done",
+      "priority": 10,
+      "why": "issue #56 (2026-08-06T03:07:26Z) の指摘。ops/dashboard/build.py の fetch_prs() は `gh pr list` を呼ぶが、この実行環境（クラウド定期実行サンドボックス・クラスタ内常駐いずれも）に `gh` は入っておらず必ず失敗し、ops/dashboard/prs.json の古いキャッシュにフォールバックしていた（CHARTER §5.2/§5.5）。ダッシュボードのPR一覧が『最新』の顔をして古いまま出るのが一番まずいとの指摘で、優先して直すよう明記されていた。クラスタ内常駐（§5.5）では AUTOPILOT_GITHUB_TOKEN で api.github.com に到達できることが実測済みなので、gh 依存を削って urllib（標準ライブラリのみという build.py の設計方針に合わせる）で置き換えた",
+      "dod": "fetch_prs() が gh CLI を使わず GitHub REST API（/pulls, /commits/{sha}/check-runs, /commits/{sha}/status）を AUTOPILOT_GITHUB_TOKEN で直接叩き、open/merged PR 一覧と CI 状態を組み立てて ops/dashboard/prs.json を自分で最新化する。トークンが無い環境では例外を投げて既存キャッシュへフォールバックする（後方互換）。CHARTER §7.1 の手順説明をこの変更に合わせて更新する",
+      "blocked_by": null,
+      "refs": [
+        "ops/dashboard/build.py",
+        "ops/CHARTER.md"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #98: 実装・ops/validate.py 0 error・ops/dashboard/build.py 実行で open 0件/merged 60件（PR #283 が最新として反映）を実機（この実行環境）で確認済み。PR番号は同じPRのマージ後に追記する。"
+    },
+    {
+      "id": "T-0127",
+      "domain": "homelab",
+      "title": "autopilot が生成した dashboard HTML を専用ブランチへ push する仕組みを追加",
+      "kind": "feature",
+      "risk": "medium",
+      "status": "todo",
+      "priority": 20,
+      "why": "issue #56 (2026-08-06T03:07:26Z) の指摘。クラスタ内常駐 (§5.5) の autopilot には Artifact ツールが無く、毎イテレーション ops/dashboard/build.py で HTML は作れているのに公開できず、journal に一行残して先へ進んでいた（CHARTER §7.1 どおりの正しい振る舞いだが、結果としてダッシュボードは常駐化直前（2026-08-05 17:32 UTC 版）で 9 時間半以上止まっていた）。ops-health-reporter が ops-health-reportブランチへ書き戻す（CHARTER §2）のと同型のパターンを、autopilot 自身の dashboard 生成にも適用する。T-0128（配信側）の前提",
+      "dod": "autopilot の loop（apps/autopilot/、または各イテレーションの Claude セッション）が ops/dashboard/build.py 実行後、生成された index.html を ops-dashboard のような専用ブランチへ commit・push する。push は既存の git credential（loop.sh の setup_git()）を使い、main への直 push にはならないことを確認する。100KB 近いファイルなので ConfigMap には埋めない（issue #56 の指摘どおり）",
+      "blocked_by": null,
+      "refs": [
+        "apps/autopilot/",
+        "ops/dashboard/build.py",
+        "ops/CHARTER.md"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #98 で起票。T-0128（配信側の Deployment/tailscale-operator 公開）とセットだが CHARTER §3 の起票の粒度（1 タスク = 1 PR = 1 論点）に従い分割した。この T-0127 が先。"
+    },
+    {
+      "id": "T-0128",
+      "domain": "homelab",
+      "title": "dashboard 配信用の静的ファイルサーバーを apps/ に追加し tailscale-operator で公開する",
+      "kind": "feature",
+      "risk": "medium",
+      "status": "todo",
+      "priority": 21,
+      "why": "issue #56 (2026-08-06T03:07:26Z) の指摘。claude.ai の Artifact は対話セッションの存在を前提にした置き場所で、常駐基盤（クラスタ内 autopilot）とは噛み合わない。coder が tailscale-operator 経由でcoder.tailae6c2.ts.net として公開されているのと同じパターンで、dashboard も自前でホストし、対話セッションの有無に依存せず autopilot 自身が更新できるようにする",
+      "dod": "T-0127 が push する専用ブランチ（例: ops-dashboard）の index.html を定期的に取得して配信するDeployment（nginx か python -m http.server）+ Service を apps/ 配下に追加し、tailscale-operator 経由で公開する。ops/state.json の dashboard.artifact_url もしくは新しいフィールドをこの URL に更新し、Artifact 版は当面残しつつ正とするのはこちらにする（issue #56 の指摘どおり）",
+      "blocked_by": "T-0127",
+      "refs": [
+        "apps/",
+        "apps/tailscale-operator/",
+        "apps/coder/",
+        "ops/state.json"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #98 で起票。T-0127（push 側）が先。"
     }
   ]
 }

--- a/ops/dashboard/build.py
+++ b/ops/dashboard/build.py
@@ -18,15 +18,20 @@ from __future__ import annotations
 
 import html
 import json
+import os
 import pathlib
 import re
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 
 OPS = pathlib.Path(__file__).resolve().parent.parent
 ROOT = OPS.parent
 OUT = OPS / "dashboard" / "index.html"
+REPO = "hikuohiku/homelab"
+API = "https://api.github.com"
 
 E = html.escape
 STALE: dict[str, str] = {}
@@ -83,21 +88,86 @@ def load_health() -> dict | None:
 MERGED_LIMIT = 60
 
 
-def _gh_prs(state: str, fields: str, limit: int) -> list[dict]:
-    out = subprocess.run(
-        ["gh", "pr", "list", "--state", state, "--limit", str(limit), "--json", fields],
-        cwd=ROOT, capture_output=True, text=True, timeout=60, check=True,
-    ).stdout
-    return json.loads(out)
+def _gh_api(path: str) -> list | dict:
+    """GitHub REST API を直叩きする。`gh` CLI はこの実行環境に無い（CHARTER §5.2/§5.5）。"""
+    token = os.environ.get("AUTOPILOT_GITHUB_TOKEN")
+    if not token:
+        raise RuntimeError("AUTOPILOT_GITHUB_TOKEN is not set")
+    req = urllib.request.Request(
+        f"{API}{path}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "homelab-autopilot-dashboard",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+        return json.loads(resp.read())
+
+
+def _status_rollup(sha: str) -> list[dict]:
+    """CI 状態は check-runs と status の両方を見る（外部 App は片方にしか出ないことがある、CHARTER §5.5）。"""
+    rollup = []
+    try:
+        runs = _gh_api(f"/repos/{REPO}/commits/{sha}/check-runs?per_page=100")
+        for r in runs.get("check_runs", []):
+            rollup.append({"conclusion": (r.get("conclusion") or r.get("status") or "").upper()})
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        status = _gh_api(f"/repos/{REPO}/commits/{sha}/status")
+        for s in status.get("statuses", []):
+            rollup.append({"conclusion": (s.get("state") or "").upper()})
+    except Exception:  # noqa: BLE001
+        pass
+    return rollup
+
+
+def _open_prs() -> list[dict]:
+    raw = _gh_api(f"/repos/{REPO}/pulls?state=open&per_page=100")
+    return [
+        {
+            "number": p["number"],
+            "title": p["title"],
+            "url": p["html_url"],
+            "isDraft": p.get("draft", False),
+            "createdAt": p.get("created_at"),
+            "statusCheckRollup": _status_rollup(p["head"]["sha"]),
+            "headRefName": p.get("head", {}).get("ref", ""),
+            "autoMergeRequest": p.get("auto_merge"),
+        }
+        for p in raw
+    ]
+
+
+def _merged_prs(limit: int) -> list[dict]:
+    # state=closed には未マージの close も混ざるので merged_at で絞る。sort=created&direction=desc
+    # で新しい方から辿れば、通常運用（作成後すぐマージ）では数ページで limit 件に届く。
+    merged = []
+    for page in range(1, 6):
+        batch = _gh_api(f"/repos/{REPO}/pulls?state=closed&sort=created&direction=desc&per_page=100&page={page}")
+        if not batch:
+            break
+        merged.extend(p for p in batch if p.get("merged_at"))
+        if len(batch) < 100 or len(merged) >= limit:
+            break
+    merged.sort(key=lambda p: p["merged_at"], reverse=True)
+    return [
+        {
+            "number": p["number"],
+            "title": p["title"],
+            "url": p["html_url"],
+            "mergedAt": p["merged_at"],
+            "headRefName": p.get("head", {}).get("ref", ""),
+        }
+        for p in merged[:limit]
+    ]
 
 
 def fetch_prs() -> tuple[list[dict], list[dict]]:
     cache = OPS / "dashboard" / "prs.json"
     try:
-        data = {
-            "open": _gh_prs("open", "number,title,url,isDraft,createdAt,statusCheckRollup,headRefName,autoMergeRequest", 30),
-            "merged": _gh_prs("merged", "number,title,url,mergedAt,headRefName", MERGED_LIMIT),
-        }
+        data = {"open": _open_prs(), "merged": _merged_prs(MERGED_LIMIT)}
         cache.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n")
         return data["open"], data["merged"]
     except Exception as e:  # noqa: BLE001

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,21 +1,13 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 283,
       "title": "docs: CronJob の schedule 記述を UTC → JST に訂正 (T-0125)",
       "url": "https://github.com/hikuohiku/homelab/pull/283",
-      "isDraft": false,
-      "createdAt": null,
-      "statusCheckRollup": [
-        {
-          "conclusion": "PENDING"
-        }
-      ],
-      "headRefName": "autopilot/T-0125-cronjob-schedule-jst-not-utc",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-06T03:11:38Z",
+      "headRefName": "autopilot/T-0125-cronjob-schedule-jst-not-utc"
+    },
     {
       "number": 282,
       "title": "chore(ops): run #96 の実番号 (#281) を記録に反映",
@@ -428,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/222",
       "mergedAt": "2026-08-05T18:18:37Z",
       "headRefName": "autopilot/loop-visibility"
-    },
-    {
-      "number": 221,
-      "title": "ops: クラスタ内 substrate の事実を CHARTER に記録し、T-0107/T-0108 起票漏れを埋める",
-      "url": "https://github.com/hikuohiku/homelab/pull/221",
-      "mergedAt": "2026-08-05T18:18:27Z",
-      "headRefName": "autopilot/T-0107-T-0108-substrate-charter-update"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2869,3 +2869,26 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   UTC の現在時刻とそのまま比較しないこと（T-0125 参照）
 - ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
   `ops/dashboard/build.py` を実行する
+
+## 2026-08-06 12:20 JST — run #98
+
+- 前回の中断確認: オープン PR 無し。`autopilot/*` 残存ブランチ無し
+- 読んだフィードバック: issue #56 のコメントを `per_page=100` で取得したところ1ページ目が
+  ちょうど100件返り、Link ヘッダで存在を確認した2ページ目に last_read（2026-08-06T01:26:31Z）
+  以降の新規コメント3件が隠れていた（CHARTER §6 が警告するページネーションの罠を実際に踏んだ）。
+  うち2件は run #58/#59（8/5）の反映済み内容、1件（2026-08-06T03:07:26Z）が新規指摘で今回反映した
+- 見つけたこと・やったこと（T-0126）: issue #56 の指摘どおり `ops/dashboard/build.py` の
+  `fetch_prs()` が `gh pr list` を呼んでいたが、この実行環境（旧クラウドサンドボックス・クラスタ内
+  常駐いずれも）に `gh` は無く必ず失敗し `ops/dashboard/prs.json` の古いキャッシュにフォール
+  バックしていた。`AUTOPILOT_GITHUB_TOKEN` による GitHub REST API 直叩き（`urllib`、標準ライブラリ
+  のみという設計方針に合わせた）に置き換え、CI 状態は check-runs と status の両方を見る
+  （CHARTER §5.5 の教訓どおり）。実行して open 0件・merged 60件（PR #283 が最新として反映）を
+  確認済み。CHARTER §7.1 の手順説明もこの変更に合わせて更新した
+- やったこと（起票のみ、T-0127/T-0128）: 同じ指摘の後半（dashboard の Artifact 公開がクラスタ内
+  常駐では機能せず 9 時間半止まっていた）を受け、自前ホストへの分割タスクを起票した。T-0127
+  （autopilot の loop が生成 HTML を専用ブランチへ push する仕組み）と T-0128（tailscale-operator
+  経由で配信する Deployment）に分け、CHARTER §3 の粒度規則（1 タスク = 1 PR = 1 論点）に従い
+  T-0127 を先とした。直列化ルールに従い、この起動では設計のみで実装には着手していない
+- 次の起動へ: T-0127 から着手可能。T-0117 は 2026-08-06T18:30Z まで引き続き着手不能
+- ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
+  `ops/dashboard/build.py` を実行する

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T03:15:00Z",
+  "updated": "2026-08-06T03:20:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T01:26:31Z"
+    "last_read": "2026-08-06T03:07:26Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -1024,7 +1024,9 @@
       "kind": "scheduled",
       "by": "in-cluster autopilot",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。ops-health-report・autopilot heartbeat とも正常、既知の Degraded 3件のみ。backlog の唯一の todo（T-0117）は CronJob schedule（03:30 UTC）未到来のため引き続き着手不能、needs-human 4件・blocked 5件も前提未変化で追加対応不可。新しい調査観点は見つからず、進捗なしのまま記録のみ更新",
-      "prs": [281]
+      "prs": [
+        281
+      ]
     },
     {
       "n": 97,
@@ -1032,7 +1034,17 @@
       "kind": "scheduled",
       "by": "in-cluster autopilot",
       "summary": "オープン PR・autopilot ブランチとも無く中断なし。issue #56 に未読フィードバックなし。ops-health-report・autopilot heartbeat とも正常、既知の Degraded 3件のみ。backlog の唯一の todo（T-0117）の未着手理由を kubectl で裏取りする過程で、CHARTER §2・docs/backup.md が CronJob の schedule を「UTC」と誤記していたと発見（実際は node01 の time.timeZone=Asia/Tokyo により JST で評価される。9時間ずれ）。immich サーバー内蔵の backup.database は対象外で UTC のままと区別して確認。CHARTER・docs/backup.md（計9箇所）を訂正し、T-0117 の notes に正しい次回実行予定（2026-08-07 03:30 JST）を追記した（T-0125）",
-      "prs": [283]
+      "prs": [
+        283
+      ]
+    },
+    {
+      "n": 98,
+      "at": "2026-08-06T03:20:00Z",
+      "kind": "scheduled",
+      "by": "cluster-resident (autopilot Pod)",
+      "summary": "前回の中断: オープン PR・autopilot ブランチとも無し。issue #56 の未読フィードバック1件（2026-08-06T03:07:26Z）を反映。get_comments 相当のページネーションの罠（per_page=100 で1ページ目が100件ちょうど返り、2ページ目に3件の未読が隠れていた）を実際に踏んで発見・回避した。内容は2点: (1) ops/dashboard/build.py の fetch_prs() が gh CLI 依存で常に失敗しキャッシュにフォールバックしていた点を、AUTOPILOT_GITHUB_TOKEN による GitHub REST API 直叩き（urllib、標準ライブラリのみ）に置き換え（T-0126, 完遂）。実行して open 0件・merged 60件（PR #283 が最新として反映）を確認した。(2) dashboard の Artifact 公開がクラスタ内常駐では機能しない（Artifact ツールが無い）ため 9 時間半止まっていたという指摘を受け、自前ホスト（HTML を専用ブランチへ push する仕組み T-0127 + tailscale-operator 経由で配信する Deployment T-0128）に分割して起票（直列化ルールに従い、この起動では設計のみで着手せず次回以降に回す）",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`ops/dashboard/build.py` の `fetch_prs()` が `gh pr list` を呼んでいたが、この実行環境（クラウド定期実行サンドボックス・クラスタ内常駐いずれも）に `gh` CLI は入っておらず、毎回必ず失敗して `ops/dashboard/prs.json` の古いキャッシュにフォールバックしていた。issue #56（2026-08-06T03:07:26Z）の指摘どおり、ダッシュボードの PR 一覧が「最新」の顔をして古いまま表示され続けていた。

`AUTOPILOT_GITHUB_TOKEN` を使って GitHub REST API を直接叩く実装（`urllib`、標準ライブラリのみという `build.py` の既存設計方針に合わせた）に置き換えた。

- open PR: `GET /pulls?state=open`
- CI 状態: `GET /commits/{sha}/check-runs` と `GET /commits/{sha}/status` の両方を見る（外部 App は片方にしか出ないことがあるという CHARTER §5.5 の教訓を踏襲）
- merged PR: `GET /pulls?state=closed&sort=created&direction=desc` を最大5ページ辿り `merged_at` で絞って `mergedAt` 降順で最大60件
- トークンが無い環境（旧クラウドサンドボックス等）では例外を投げて既存の `ops/dashboard/prs.json` キャッシュへフォールバックする（後方互換）

CHARTER §7.1 の手順説明もこの変更に合わせて更新した。

同じ PR に、issue #56 の未読フィードバック反映（journal・state.json の last_read 更新）と、指摘のもう一点（dashboard の自前ホスト）を分割起票した backlog の更新（T-0127/T-0128、実装はまだ・この PR には含まない）も相乗りさせている（CHARTER §4 の運用記録の相乗り例外）。

## 検証したこと

- この実行環境（`AUTOPILOT_GITHUB_TOKEN` が使える）で `fetch_prs()` を実行し、open 0件・merged 60件（直近マージの PR #283 が正しく先頭に来ることを確認）が取得できることを実機確認
- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 例外なく `index.html` を再生成

## ロールバック手順

このコミットを revert すれば `fetch_prs()` は `gh pr list` を呼ぶ実装に戻る（DB を持つコンポーネントではないためスキーマ等の残留懸念は無い）。`ops/dashboard/prs.json` のキャッシュは副作用として更新されるが、次回ビルド時にまた最新化されるため実害はない。

## backlog task id

T-0126（完遂）。派生: T-0127 / T-0128（dashboard 自前ホスト、todo・未着手）
