### PR TITLE
feat(autopilot): loop.sh が自分の更新を拾って exec し直す (T-0129)

### DIFF
--- a/apps/autopilot/deployment.yaml
+++ b/apps/autopilot/deployment.yaml
@@ -19,6 +19,12 @@ spec:
     metadata:
       labels:
         app: autopilot
+      annotations:
+        # ConfigMap の中身が変わっても Deployment の spec は変わらないため、Pod は
+        # 作り直されない。loop.sh は自分の更新を検知して exec し直すようになったので、
+        # 以降この値を触る必要はない。この 1 回だけ、その仕組みを載せた loop.sh を
+        # 動かすために Pod を作り直す。
+        autopilot/loop-revision: "2"
     spec:
       serviceAccountName: autopilot
       # 走行中のイテレーションが SIGTERM を受けてから降りるまでの猶予。

--- a/apps/autopilot/loop.sh
+++ b/apps/autopilot/loop.sh
@@ -131,6 +131,21 @@ EOF
   return "${rc}"
 }
 
+# ConfigMap は disableNameSuffixHash: true なので、loop.sh を書き換えても Deployment の
+# spec は変わらず Pod は作り直されない。kubelet が /config を更新したあと、自分で
+# 拾い直せるようにする。prompt-*.md が再起動なしで効くのと同じ性質を loop.sh 自身にも持たせる。
+SELF="${SELF:-/config/loop.sh}"
+self_digest() { md5sum "${SELF}" 2>/dev/null | cut -d" " -f1; }
+SELF_DIGEST="$(self_digest)"
+
+reexec_if_updated() {
+  now="$(self_digest)"
+  if [ -n "${now}" ] && [ "${now}" != "${SELF_DIGEST}" ]; then
+    log "loop.sh が更新された（${SELF_DIGEST} -> ${now}）。exec し直す"
+    exec bash "${SELF}"
+  fi
+}
+
 main() {
   # HOME は emptyDir 配下を指す（deployment.yaml 参照）。git/npm/claude が
   # ホームに書けるよう、先に実体を作っておく
@@ -142,6 +157,8 @@ main() {
 
   i=0
   while true; do
+    # イテレーションの途中では入れ替えない
+    reexec_if_updated
     i=$((i + 1))
     started_at="$(date -u '+%s')"
     log "iteration #${i} start"

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 129,
-  "updated": "2026-08-06T03:17:00Z",
+  "next_id": 130,
+  "updated": "2026-08-06T03:30:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2429,6 +2429,25 @@
       "created": "2026-08-06",
       "pr": null,
       "notes": "run #98 で起票。T-0127（push 側）が先。"
+    },
+    {
+      "id": "T-0129",
+      "domain": "homelab",
+      "title": "autopilot の loop.sh が自分の更新を拾って exec し直す仕組みを追加（ConfigMap のみで反映）",
+      "kind": "chore",
+      "risk": "high",
+      "status": "in_progress",
+      "priority": 5,
+      "why": "run #99 で発見。loop.sh はコンテナ起動時に一度だけ読み込まれ、ConfigMap（disableNameSuffixHash: true）を書き換えても Deployment の spec は変わらないため Pod は作り直されず、実行中の loop.sh は古いまま変わらない（loop.sh 冒頭のコメントに明記済みの既知の制約）。この run 自身がその実例で、T-0126 相当の役割分担（計画役/実行役プロンプト分割, PR #286, a5e3cc9 で merge 済み）が導入された後もこの Pod は旧 loop.sh のまま単一プロンプト（旧 prompt.md 相当）で動いていた。原因は、PR #286 merge 直後（2026-08-06T03:22:08Z、merge は 03:21:33Z）に origin/autopilot/plan-execute-split ブランチへ直接 1 コミット（2f92db4, author: hikuohiku, Co-Authored-By: Claude Opus 5 経由の構築セッション）が追加され、loop.sh 自身に自己更新検知（起動中の /config/loop.sh の md5 を毎イテレーション先頭で比較し、変化していれば exec で入れ替える）を持たせる修正が作られていたが、対応する PR が一度も開かれず main に取り込まれていなかった。この T-0129 はその孤立コミットを cherry-pick して正式に PR 化するもの",
+      "dod": "apps/autopilot/loop.sh に reexec_if_updated()（/config/loop.sh の md5sum を起動時点と比較し、変化していればイテレーション境界で exec bash \"${SELF}\" して入れ替える）を追加し、apps/autopilot/deployment.yaml の pod template に一度きりの annotation（autopilot/loop-revision: \"2\"）を追加してこの Pod 自身を作り直す。CI green を確認して merge し、ArgoCD sync 後に新しい Pod が起動し旧 Pod が Recreate 戦略で置き換わることを次回起動（新 Pod での iteration）の heartbeat で確認する。以降 loop.sh を書き換えても Pod 再作成なしで次のイテレーション境界から反映されることが期待値",
+      "blocked_by": null,
+      "refs": [
+        "apps/autopilot/loop.sh",
+        "apps/autopilot/deployment.yaml"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #99: この Pod（autopilot-7786d96c58-nj7sn, 起動 2026-08-05T18:23:23Z）はロールを指定しないプロンプトを受け取っており、CHARTER §3 の計画役/実行役の判別ができない状態で稼働していたことから発覚した。merge 後、この Pod は SIGTERM を受けて終了する見込み（strategy: Recreate, terminationGracePeriodSeconds: 60s）。ops/ 記録の更新は途中で打ち切られる可能性があるため、この run はコード変更のコミットを最優先で push し、journal/state 更新も同じブランチに追加コミットしてから merge する順序で進める。"
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2446,7 +2446,7 @@
         "apps/autopilot/deployment.yaml"
       ],
       "created": "2026-08-06",
-      "pr": null,
+      "pr": 287,
       "notes": "run #99: この Pod（autopilot-7786d96c58-nj7sn, 起動 2026-08-05T18:23:23Z）はロールを指定しないプロンプトを受け取っており、CHARTER §3 の計画役/実行役の判別ができない状態で稼働していたことから発覚した。merge 後、この Pod は SIGTERM を受けて終了する見込み（strategy: Recreate, terminationGracePeriodSeconds: 60s）。ops/ 記録の更新は途中で打ち切られる可能性があるため、この run はコード変更のコミットを最優先で push し、journal/state 更新も同じブランチに追加コミットしてから merge する順序で進める。"
     }
   ]

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,50 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 287,
+      "title": "feat(autopilot): loop.sh が自分の更新を拾って exec し直す (T-0129)",
+      "url": "https://github.com/hikuohiku/homelab/pull/287",
+      "isDraft": false,
+      "createdAt": "2026-08-06T03:32:34Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "IN_PROGRESS"
+        },
+        {
+          "conclusion": "IN_PROGRESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "IN_PROGRESS"
+        }
+      ],
+      "headRefName": "autopilot/T-0129-loop-self-reexec",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 285,
+      "title": "chore(ops): T-0126 の PR 番号 (#284) を記録に反映",
+      "url": "https://github.com/hikuohiku/homelab/pull/285",
+      "mergedAt": "2026-08-06T03:21:38Z",
+      "headRefName": "autopilot/T-0126-record-pr-number"
+    },
+    {
+      "number": 286,
+      "title": "feat(autopilot): 計画役と実行役を分ける",
+      "url": "https://github.com/hikuohiku/homelab/pull/286",
+      "mergedAt": "2026-08-06T03:21:34Z",
+      "headRefName": "autopilot/plan-execute-split"
+    },
     {
       "number": 284,
       "title": "fix(ops): dashboard の PR 一覧取得を gh CLI 依存から GitHub API 直叩きに (T-0126)",
@@ -406,20 +450,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/225",
       "mergedAt": "2026-08-05T18:49:17Z",
       "headRefName": "autopilot/T-0108-argocd-force-replace"
-    },
-    {
-      "number": 224,
-      "title": "ops: run #58 の記録更新（T-0028/T-0071 前提訂正）",
-      "url": "https://github.com/hikuohiku/homelab/pull/224",
-      "mergedAt": "2026-08-05T18:41:20Z",
-      "headRefName": "autopilot/run58-wrapup"
-    },
-    {
-      "number": 223,
-      "title": "fix(vaultwarden): restic backup verify Job のハング切り分け診断を追加 (T-0108)",
-      "url": "https://github.com/hikuohiku/homelab/pull/223",
-      "mergedAt": "2026-08-05T18:36:27Z",
-      "headRefName": "autopilot/T-0108-vaultwarden-restic-diagnostics"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2892,3 +2892,51 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - 次の起動へ: T-0127 から着手可能。T-0117 は 2026-08-06T18:30Z まで引き続き着手不能
 - ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
   `ops/dashboard/build.py` を実行する
+
+## 2026-08-06 12:31 JST — run #99
+
+- **この run はロールを指定しないプロンプトで起動した。** 渡された入口テキストが
+  計画役/実行役分割（PR #286, a5e3cc9）より前の単一プロンプト（旧 `prompt.md`）と
+  一字一句一致しており、CHARTER §3 の「自分がどちらかは渡されたプロンプトを見れば
+  分かる」が成立しなかった。原因を調べ、旧来の統合ロール（読む・選ぶ・実装するを
+  1 起動でやる）として振る舞うことにした（判断根拠は本項）
+- 読んだフィードバック: issue #56 は last_read（2026-08-06T03:07:26Z）以降 1 件
+  （自分自身の返信、run #98 の T-0126 反映報告）のみで新規の人間フィードバックなし
+- 前回の中断確認: オープン PR は無かったが、**`origin/autopilot/plan-execute-split`
+  ブランチに未マージのコミットが残っていた**（本項の本題）
+- 見つけたこと・原因: `kubectl get pods -n autopilot` でこの Pod
+  （`autopilot-7786d96c58-nj7sn`）の起動時刻が `2026-08-05T18:23:23Z` と判明。
+  一方 PR #286（計画役/実行役分割）の merge は `2026-08-06T03:21:33Z` で、Pod 起動
+  より後。loop.sh は「コンテナ起動時に一度だけ読み込まれ、ConfigMap を書き換えても
+  Deployment の spec が変わらない限り Pod は作り直されない」という loop.sh 自身の
+  コメントどおりの状態になっており、この Pod は今も 計画役/実行役分割**前**の
+  loop.sh（単一プロンプト）を実行し続けていた。さらに調べると、PR #286 merge の
+  約1分後（`2026-08-06T03:22:08Z`）に同じブランチへ直接 1 コミット（`2f92db4`,
+  author: hikuohiku、`Co-Authored-By: Claude Opus 5` — 構築セッション経由と見られる）
+  が追加され、まさにこの問題（loop.sh 自身の自己更新検知 + 1 回限りの Pod 再作成
+  annotation）を解決する実装が既に書かれていたが、対応する PR が一度も開かれず
+  孤立していた
+- やったこと（T-0129, 起票・実装）: この孤立コミットを検証（`bash -n` で構文確認、
+  ロジックを読み下し、md5sum 比較 → `exec bash "${SELF}"` によるイテレーション境界
+  での安全な自己入れ替えと判断）した上で、現在の main に cherry-pick して
+  `autopilot/T-0129-loop-self-reexec` ブランチを作成した。PR 本文には、この変更が
+  自分自身（autopilot の実行基盤）を対象とする「到達性を失いうる変更」に該当する旨と、
+  仮に新しい loop.sh が壊れていても復旧は git ベース（human/構築セッションによる
+  revert や修正 push、次回コンテナ再起動時に /config/loop.sh を再読込）で完結し
+  autopilot 自身の健全性に依存しないことを明記する
+- **次に何が起きるか**: この PR が merge されると ArgoCD の自動 sync（`autopilot`
+  Application, selfHeal: true）が pod template の annotation 変更を検知し、
+  `strategy: Recreate`（同時に2つ動かないための設計）によりこの Pod（このセッション
+  自身）を終了させ、新しい loop.sh を積んだ Pod を起動する。
+  `terminationGracePeriodSeconds: 60s` のため、このセッションが merge 後すぐに
+  作業を終えられない場合は打ち切られる可能性がある。そのため、この journal・
+  backlog（T-0129）・state.json の更新はコード変更と同じブランチに乗せ、merge 前に
+  すべて push 済みにしてある
+- 次の起動へ: T-0129 の merge 後、新しい Pod が起動したら heartbeat
+  （`ops-health-report` の `autopilot.heartbeat`）で iteration が正常に進んでいる
+  ことと、今後は `prompt-plan.md`/`prompt-execute.md` のいずれかを渡されて
+  計画役/実行役が判別できることを確認する。もし異常（CrashLoopBackOff 等）が
+  見えたら新規タスクより先に原因を調べる（CHARTER §2）。T-0127（dashboard 専用
+  ブランチ push）は次点で着手可能。T-0117 は 2026-08-06T18:30Z まで着手不能
+- ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
+  `ops/dashboard/build.py` を実行する

--- a/ops/state.json
+++ b/ops/state.json
@@ -6,7 +6,7 @@
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T03:07:26Z"
+    "last_read": "2026-08-06T03:19:42Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -1046,6 +1046,16 @@
       "summary": "前回の中断: オープン PR・autopilot ブランチとも無し。issue #56 の未読フィードバック1件（2026-08-06T03:07:26Z）を反映。get_comments 相当のページネーションの罠（per_page=100 で1ページ目が100件ちょうど返り、2ページ目に3件の未読が隠れていた）を実際に踏んで発見・回避した。内容は2点: (1) ops/dashboard/build.py の fetch_prs() が gh CLI 依存で常に失敗しキャッシュにフォールバックしていた点を、AUTOPILOT_GITHUB_TOKEN による GitHub REST API 直叩き（urllib、標準ライブラリのみ）に置き換え（T-0126, 完遂）。実行して open 0件・merged 60件（PR #283 が最新として反映）を確認した。(2) dashboard の Artifact 公開がクラスタ内常駐では機能しない（Artifact ツールが無い）ため 9 時間半止まっていたという指摘を受け、自前ホスト（HTML を専用ブランチへ push する仕組み T-0127 + tailscale-operator 経由で配信する Deployment T-0128）に分割して起票（直列化ルールに従い、この起動では設計のみで着手せず次回以降に回す）",
       "prs": [
         284
+      ]
+    },
+    {
+      "n": 99,
+      "at": "2026-08-06T12:31:00+09:00",
+      "kind": "scheduled",
+      "by": "cluster-resident (autopilot Pod)",
+      "summary": "この Pod は計画役/実行役分割（PR #286）後もロールを指定しない旧プロンプトのまま起動していた（Pod 起動 2026-08-05T18:23:23Z が PR #286 merge 2026-08-06T03:21:33Z より前だったため）。issue #56 に未読フィードバックなし。原因調査の過程で origin/autopilot/plan-execute-split ブランチに、まさにこの問題（loop.sh は ConfigMap 更新だけでは再読込されない）を解決する未マージコミットが孤立しているのを発見し、cherry-pick して PR 化した（T-0129, #287）。merge 後は ArgoCD の Recreate 戦略でこの Pod 自身が置き換わる見込み",
+      "prs": [
+        287
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

`apps/autopilot/loop.sh` に、`/config/loop.sh`（ConfigMap マウント）の内容が起動時から
変化していたらイテレーション境界で `exec` し直す `reexec_if_updated()` を追加した。
これまで loop.sh はコンテナ起動時に一度だけ読み込まれ、ConfigMap を書き換えても
Deployment の spec が変わらない限り Pod は作り直されなかった（loop.sh 自身のコメントに
既知の制約として明記済み）。`apps/autopilot/deployment.yaml` の pod template に
一度だけの annotation（`autopilot/loop-revision: "2"`）を追加し、この 1 回限り Pod を
作り直してこの自己更新の仕組み自体を載せる。以降は不要（loop.sh がイテレーション毎に
自分の digest を確認し、変化していれば `exec bash "${SELF}"` で入れ替わる）。

## 背景（T-0129）

この変更は元々、PR #286（計画役/実行役分割, `a5e3cc9`）merge 直後（2026-08-06T03:22:08Z）に
`autopilot/plan-execute-split` ブランチへ直接 1 コミット（`2f92db4`, おそらく構築セッション
経由）として書かれていたが、対応する PR が一度も開かれず main に取り込まれていなかった。
実際にこの問題が発生していたことを、今回の起動自身が実例として確認した:
このセッションが動いている Pod（`autopilot-7786d96c58-nj7sn`）は 2026-08-05T18:23:23Z に
起動しており、PR #286 の merge（2026-08-06T03:21:33Z）より前のため、計画役/実行役分割
より前の単一プロンプトのまま動いていた。孤立コミットの内容を検証（`bash -n` で構文確認、
ロジックを読み下し）した上で、現在の main に cherry-pick した。

## 検証したこと

- `bash -n apps/autopilot/loop.sh` で構文エラー無し
- ロジックを読み下し: `reexec_if_updated()` はイテレーションの先頭（`iterate()` 呼び出し
  より前）でのみ digest を比較するため、実行中の `claude -p` を巻き込んだ入れ替えは起きない
- `exec bash "${SELF}"` は PID を維持したままプロセスイメージを入れ替えるため、
  `trust_workspace`/`setup_git` を含む `main()` が新しいスクリプト内容で再実行される
  （どちらも冪等な処理で、二重実行しても安全）
- CI（`kustomize build` / `terraform validate` / `ops state validate`）の green を確認する

## 影響範囲についての注意（経路自身への変更）

**この変更は autopilot 自身の実行基盤（自分がこの homelab を操作する経路自身）を対象とする。**
merge 後、ArgoCD の自動 sync（`autopilot` Application, `selfHeal: true`）が pod template の
annotation 変更を検知し、`strategy: Recreate`（同時に2重稼働しないための既存の設計）により
**この PR を作っているこの Pod 自身が終了し、新しい loop.sh を積んだ Pod に置き換わる。**
`terminationGracePeriodSeconds: 60s` のため、このセッションが merge 直後に打ち切られる
可能性がある。

**復旧経路（到達性を失った場合）**: 新しい loop.sh に問題があり Pod が
CrashLoopBackOff に陥っても、復旧は autopilot 自身の健全性に依存しない。
(1) `ops-health-reporter`（別 Deployment、この変更の影響を受けない）が
`autopilot.deployment.readyReplicas` の異常を `ops-health-report` ブランチへ書き続ける、
(2) human または構築セッションが git 経由で revert コミットを push すれば、
Kubernetes の再起動ループのたびに `/config/loop.sh` を再読込するため、次回のコンテナ
再起動時点で修正が反映される（autopilot プロセスが動いている必要はない）。

## ロールバック手順

`git revert` で本 PR のコミットを打ち消し、通常の PR フローで merge する。
DB マイグレーションや破壊的スキーマ変更は含まないため、revert すれば挙動は完全に戻る。
唯一の注意点は revert 自体の反映にも同じ ArgoCD sync + Pod 再作成（Recreate）を要すること。

## backlog task id

T-0129