### PR TITLE
feat(autopilot): loop.sh が自分の更新を拾って exec し直す

### DIFF
--- a/apps/autopilot/deployment.yaml
+++ b/apps/autopilot/deployment.yaml
@@ -19,6 +19,12 @@ spec:
     metadata:
       labels:
         app: autopilot
+      annotations:
+        # ConfigMap の中身が変わっても Deployment の spec は変わらないため、Pod は
+        # 作り直されない。loop.sh は自分の更新を検知して exec し直すようになったので、
+        # 以降この値を触る必要はない。この 1 回だけ、その仕組みを載せた loop.sh を
+        # 動かすために Pod を作り直す。
+        autopilot/loop-revision: "2"
     spec:
       serviceAccountName: autopilot
       # 走行中のイテレーションが SIGTERM を受けてから降りるまでの猶予。

--- a/apps/autopilot/loop.sh
+++ b/apps/autopilot/loop.sh
@@ -131,6 +131,21 @@ EOF
   return "${rc}"
 }
 
+# ConfigMap は disableNameSuffixHash: true なので、loop.sh を書き換えても Deployment の
+# spec は変わらず Pod は作り直されない。kubelet が /config を更新したあと、自分で
+# 拾い直せるようにする。prompt-*.md が再起動なしで効くのと同じ性質を loop.sh 自身にも持たせる。
+SELF="${SELF:-/config/loop.sh}"
+self_digest() { md5sum "${SELF}" 2>/dev/null | cut -d" " -f1; }
+SELF_DIGEST="$(self_digest)"
+
+reexec_if_updated() {
+  now="$(self_digest)"
+  if [ -n "${now}" ] && [ "${now}" != "${SELF_DIGEST}" ]; then
+    log "loop.sh が更新された（${SELF_DIGEST} -> ${now}）。exec し直す"
+    exec bash "${SELF}"
+  fi
+}
+
 main() {
   # HOME は emptyDir 配下を指す（deployment.yaml 参照）。git/npm/claude が
   # ホームに書けるよう、先に実体を作っておく
@@ -142,6 +157,8 @@ main() {
 
   i=0
   while true; do
+    # イテレーションの途中では入れ替えない
+    reexec_if_updated
     i=$((i + 1))
     started_at="$(date -u '+%s')"
     log "iteration #${i} start"


### PR DESCRIPTION
#286 で計画役と実行役を分けたが、**動いている Pod にはまだ反映されていない。**

`configMapGenerator` が `disableNameSuffixHash: true` なので、`loop.sh` を書き換えても Deployment の spec は変わらず Pod は作り直されない。ConfigMap の中身だけが差し替わり、走り続けているプロセスは古い `loop.sh` のままになる。

## 変更

`loop.sh` がイテレーションの境目で自分のダイジェストを見て、変わっていたら `exec` し直す。`prompt-*.md` が再起動なしで効くのと同じ性質を `loop.sh` 自身にも持たせる。イテレーションの途中では入れ替えない。

いま動いている Pod は当然この仕組みを持たないので、**この 1 回だけ** pod template のアノテーションで作り直させる。以降このアノテーションを触る必要はない。

`md5sum` が使えないなど digest が取れないときは `exec` しない（無限ループを避ける）。

（#286 は auto-merge をこの commit が乗る前に有効化してしまい、1 つ目の commit だけで merge された。中身の問題ではない。）