### PR TITLE
feat(ops): dashboard HTML を ops-dashboard ブランチへ自動 push する (T-0127)

### DIFF
--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -667,9 +667,18 @@ commit していたが、全タスク PR がこのファイルに触るため相
 （issue #56 2026-08-04 20:54:53。直列化はこちらの中でしか効かず、構築セッションなど他の主体との
 衝突までは防げなかった）。
 
+**T-0127（run #99）以降**、`AUTOPILOT_GITHUB_TOKEN` があれば `build.py` は生成した
+`index.html` を `ops-dashboard` ブランチ（`ops-health-report` と同型の専用ブランチ、main へは
+直 push しない）へ自分で push する。`python3 ops/dashboard/build.py` を実行するだけで完結し、
+別途 publish の手順を踏む必要は無い。token が無い環境（CI、手元実行）では push を静かに
+スキップし、HTML の生成自体は成功のまま終える。
+
 Artifact ツールが使えるときは、`ops/state.json` の `dashboard.artifact_url` を `url` に渡して
-同じ URL へ再公開する（新しい URL を発行しないこと。人間はブックマークしている）。
-使えないときは journal に「publish できなかった」と一行だけ書けばよい。**ここで止まらないこと。**
+同じ URL へ再公開する（新しい URL を発行しないこと。人間はブックマークしている）。これは
+`ops-dashboard` ブランチへの push とは独立した経路で、当面どちらも並行して更新する
+（T-0128 で `ops-dashboard` ブランチを配信する経路が整うまでは、人間が実際に見られるのは
+Artifact 版だけ）。Artifact が使えない・失敗した場合は journal に「publish できなかった」と
+一行だけ書けばよい。**ここで止まらないこと。**
 
 HTML を repo に置かなくなった代わりに、CI (`ops` job) が `python3 ops/dashboard/build.py` を実行して
 例外なく終わることだけを毎回検証する。壊れたまま気づかない事態を防ぐのはこれで十分で、

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2395,7 +2395,7 @@
       "title": "autopilot が生成した dashboard HTML を専用ブランチへ push する仕組みを追加",
       "kind": "feature",
       "risk": "medium",
-      "status": "todo",
+      "status": "done",
       "priority": 20,
       "why": "issue #56 (2026-08-06T03:07:26Z) の指摘。クラスタ内常駐 (§5.5) の autopilot には Artifact ツールが無く、毎イテレーション ops/dashboard/build.py で HTML は作れているのに公開できず、journal に一行残して先へ進んでいた（CHARTER §7.1 どおりの正しい振る舞いだが、結果としてダッシュボードは常駐化直前（2026-08-05 17:32 UTC 版）で 9 時間半以上止まっていた）。ops-health-reporter が ops-health-reportブランチへ書き戻す（CHARTER §2）のと同型のパターンを、autopilot 自身の dashboard 生成にも適用する。T-0128（配信側）の前提",
       "dod": "autopilot の loop（apps/autopilot/、または各イテレーションの Claude セッション）が ops/dashboard/build.py 実行後、生成された index.html を ops-dashboard のような専用ブランチへ commit・push する。push は既存の git credential（loop.sh の setup_git()）を使い、main への直 push にはならないことを確認する。100KB 近いファイルなので ConfigMap には埋めない（issue #56 の指摘どおり）",
@@ -2407,7 +2407,7 @@
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "run #98 で起票。T-0128（配信側の Deployment/tailscale-operator 公開）とセットだが CHARTER §3 の起票の粒度（1 タスク = 1 PR = 1 論点）に従い分割した。この T-0127 が先。"
+      "notes": "run #98 で起票。T-0128（配信側の Deployment/tailscale-operator 公開）とセットだが CHARTER §3 の起票の粒度（1 タスク = 1 PR = 1 論点）に従い分割した。この T-0127 が先。 run #100 で実装。build.py に publish() を追加し、AUTOPILOT_GITHUB_TOKEN があれば生成した index.html を ops-dashboard ブランチへ Contents API で push する（ops-health-report と同型）。token が無い環境（CI・手元実行）では静かにスキップする。実機で ops-dashboard ブランチへの push を確認済み。T-0128（配信側）が次点。"
     },
     {
       "id": "T-0128",

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2406,7 +2406,7 @@
         "ops/CHARTER.md"
       ],
       "created": "2026-08-06",
-      "pr": null,
+      "pr": 290,
       "notes": "run #98 で起票。T-0128（配信側の Deployment/tailscale-operator 公開）とセットだが CHARTER §3 の起票の粒度（1 タスク = 1 PR = 1 論点）に従い分割した。この T-0127 が先。 run #100 で実装。build.py に publish() を追加し、AUTOPILOT_GITHUB_TOKEN があれば生成した index.html を ops-dashboard ブランチへ Contents API で push する（ops-health-report と同型）。token が無い環境（CI・手元実行）では静かにスキップする。実機で ops-dashboard ブランチへの push を確認済み。T-0128（配信側）が次点。"
     },
     {

--- a/ops/dashboard/build.py
+++ b/ops/dashboard/build.py
@@ -3,7 +3,12 @@
 
     python3 ops/dashboard/build.py
 
-出力: ops/dashboard/index.html （Artifact として publish される）
+出力: ops/dashboard/index.html。`AUTOPILOT_GITHUB_TOKEN` があれば
+`ops-dashboard` ブランチの index.html へも push する（T-0127。クラスタ内常駐の
+autopilot には Artifact ツールが無いため、ops-health-reporter が
+ops-health-report ブランチへ書き戻すのと同型の経路で人間に公開する）。
+token が無い環境（CI、手元実行）では push をスキップし、HTML の生成自体は
+従来どおり成功として扱う。
 
 設計方針:
   - 主役は「人間が何をすればいいか」と「何が動いているか」。個々のタスクは既定で隠す
@@ -16,6 +21,7 @@
 
 from __future__ import annotations
 
+import base64
 import html
 import json
 import os
@@ -1034,6 +1040,81 @@ footer {{ color:var(--muted); font-size:.75rem; font-family:var(--mono);
 """
 
 
+DASHBOARD_BRANCH = os.environ.get("DASHBOARD_BRANCH", "ops-dashboard")
+
+
+def _gh_write(method: str, path: str, token: str, body: dict | None = None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        f"{API}{path}",
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "homelab-autopilot-dashboard",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+            raw = resp.read()
+            return resp.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        return e.code, (json.loads(raw) if raw else None)
+
+
+def _ensure_branch(token: str, branch: str, base_branch: str = "main") -> None:
+    status, _ = _gh_write("GET", f"/repos/{REPO}/git/ref/heads/{branch}", token)
+    if status == 200:
+        return
+    status, base = _gh_write("GET", f"/repos/{REPO}/git/ref/heads/{base_branch}", token)
+    if status != 200:
+        raise RuntimeError(f"base branch ref の取得に失敗: {status} {base}")
+    base_sha = base["object"]["sha"]
+    status, resp = _gh_write(
+        "POST", f"/repos/{REPO}/git/refs", token,
+        {"ref": f"refs/heads/{branch}", "sha": base_sha},
+    )
+    if status not in (200, 201):
+        raise RuntimeError(f"branch 作成に失敗: {status} {resp}")
+
+
+def publish(html_bytes: bytes) -> None:
+    """生成した index.html を DASHBOARD_BRANCH へ push する（T-0127）。
+
+    main へは直 push せず、ops-health-report と同じ「専用ブランチへの Contents API
+    書き込み」パターンを使う。token が無ければ静かに何もしない（CI・手元実行対策）。
+    """
+    token = os.environ.get("AUTOPILOT_GITHUB_TOKEN")
+    if not token:
+        return
+    _ensure_branch(token, DASHBOARD_BRANCH)
+    status, existing = _gh_write(
+        "GET", f"/repos/{REPO}/contents/index.html?ref={DASHBOARD_BRANCH}", token
+    )
+    sha = existing.get("sha") if status == 200 and isinstance(existing, dict) else None
+    payload = {
+        "message": f"dashboard {datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}",
+        "content": base64.b64encode(html_bytes).decode(),
+        "branch": DASHBOARD_BRANCH,
+    }
+    if sha:
+        payload["sha"] = sha
+    status, resp = _gh_write("PUT", f"/repos/{REPO}/contents/index.html", token, payload)
+    if status not in (200, 201):
+        raise RuntimeError(f"index.html の push に失敗: {status} {resp}")
+
+
 if __name__ == "__main__":
-    OUT.write_text(build())
+    rendered = build()
+    OUT.write_text(rendered)
     print(f"wrote {OUT.relative_to(ROOT)} ({OUT.stat().st_size} bytes)")
+    if os.environ.get("AUTOPILOT_GITHUB_TOKEN"):
+        try:
+            publish(rendered.encode("utf-8"))
+        except Exception as e:  # noqa: BLE001 — push 失敗させても HTML 生成自体は成功のまま終える
+            print(f"warning: {DASHBOARD_BRANCH} への publish に失敗 ({e})", file=sys.stderr)
+        else:
+            print(f"published to {DASHBOARD_BRANCH} branch")

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 289,
+      "title": "chore(ops): T-0129 を done に、記録更新 (run #99)",
+      "url": "https://github.com/hikuohiku/homelab/pull/289",
+      "mergedAt": "2026-08-06T03:37:54Z",
+      "headRefName": "autopilot/T-0129-mark-done"
+    },
+    {
       "number": 287,
       "title": "feat(autopilot): loop.sh が自分の更新を拾って exec し直す (T-0129)",
       "url": "https://github.com/hikuohiku/homelab/pull/287",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/228",
       "mergedAt": "2026-08-05T19:20:27Z",
       "headRefName": "autopilot/ops-dashboard-cache-refresh"
-    },
-    {
-      "number": 227,
-      "title": "feat(ops-health-reporter): autopilot 自身の健全性を latest.json に追加する (T-0110)",
-      "url": "https://github.com/hikuohiku/homelab/pull/227",
-      "mergedAt": "2026-08-05T19:18:04Z",
-      "headRefName": "autopilot/T-0110-autopilot-self-health"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -2963,3 +2963,31 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   ときは、着手前に GitHub 側で他のブランチ・PR が同時に動いていないか一呼吸置いて
   再確認する余地があった、と次回への教訓として記録する（CHARTER 改訂は次回以降の
   判断に委ねる）
+
+## 2026-08-06 12:42 JST — run #100
+
+- この run は `prompt-execute.md`（実行役）で起動した。T-0129（run #99）の Recreate が
+  実際に効き、新しい Pod（`autopilot-55f99669bc-br2n4`）に入れ替わったことを確認した
+  （旧 Pod は `autopilot-7786d96c58-nj7sn`）
+- 読んだフィードバック: issue #56 は last_read（2026-08-06T03:19:42Z）が最新コメント自身と
+  一致しており新規なし
+- 前回の中断確認: オープン PR 無し、`autopilot/*` 残存ブランチ無し
+- 健全性確認: `ops-health-report` の `generated_at` は 03:30:04Z（直近）。
+  `autopilot.deployment.readyReplicas: 1`、`heartbeat.last_end.exit_code: 0`で異常なし
+  （ただしこの断面は旧 Pod 時点のもの）。`coder`/`immich`/`vaultwarden` の Degraded は
+  `kubectl get externalsecret` で確認し、想定どおり `<app>-restic-backup-credentials`
+  （T-0106, 引き続き needs-human）のみが原因で新規異常ではないと確認した
+- やったこと（T-0127, 実装・実機確認済み）: `ops/dashboard/build.py` に `publish()` を追加。
+  `AUTOPILOT_GITHUB_TOKEN` があれば生成した `index.html` を `ops-dashboard` ブランチへ
+  Contents API で push する（`ops-health-reporter` が `ops-health-report` ブランチへ書き戻す
+  のと同型のパターン）。token が無い環境（CI・手元実行）では静かにスキップし、HTML 生成自体は
+  従来どおり成功扱いにする。実機で `python3 ops/dashboard/build.py` を実行し、
+  `ops-dashboard` ブランチに `index.html`（101935 bytes）が実際に push されたことを
+  GitHub Contents API で確認済み。CHARTER §7.1 を更新し、Artifact 版と `ops-dashboard`
+  ブランチ版が当面並行することを明記した
+- 次の起動へ: T-0128（`ops-dashboard` ブランチを tailscale-operator 経由で配信する
+  Deployment）が次点で着手可能（`blocked_by: T-0127` は解消）。T-0117 は
+  2026-08-06T18:30Z まで引き続き着手不能
+- ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
+  `ops/dashboard/build.py` を実行する（今回の build.py 実行で `ops-dashboard` ブランチへの
+  実 push も兼ねる）

--- a/ops/state.json
+++ b/ops/state.json
@@ -1057,6 +1057,14 @@
       "prs": [
         287
       ]
+    },
+    {
+      "n": 100,
+      "at": "2026-08-06T12:42:00+09:00",
+      "kind": "scheduled",
+      "by": "cluster-resident (autopilot Pod)",
+      "summary": "prompt-execute.md（実行役）で起動。T-0129（run #99）の Recreate が実際に効き、Pod が autopilot-7786d96c58-nj7sn から autopilot-55f99669bc-br2n4 へ入れ替わったことを確認した。issue #56 に未読フィードバックなし、オープン PR・autopilot ブランチとも無し。coder/immich/vaultwarden の Degraded は既知の T-0106（restic backup credentials 未登録）のみが原因と kubectl get externalsecret で確認し新規異常ではないと判断した。T-0127（dashboard HTML を専用ブランチへ push する仕組み）を実装: build.py に publish() を追加し AUTOPILOT_GITHUB_TOKEN があれば ops-dashboard ブランチへ Contents API で push する。token が無い環境（CI・手元実行）では静かにスキップ。実機で push を確認済み",
+      "prs": []
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -1064,7 +1064,9 @@
       "kind": "scheduled",
       "by": "cluster-resident (autopilot Pod)",
       "summary": "prompt-execute.md（実行役）で起動。T-0129（run #99）の Recreate が実際に効き、Pod が autopilot-7786d96c58-nj7sn から autopilot-55f99669bc-br2n4 へ入れ替わったことを確認した。issue #56 に未読フィードバックなし、オープン PR・autopilot ブランチとも無し。coder/immich/vaultwarden の Degraded は既知の T-0106（restic backup credentials 未登録）のみが原因と kubectl get externalsecret で確認し新規異常ではないと判断した。T-0127（dashboard HTML を専用ブランチへ push する仕組み）を実装: build.py に publish() を追加し AUTOPILOT_GITHUB_TOKEN があれば ops-dashboard ブランチへ Contents API で push する。token が無い環境（CI・手元実行）では静かにスキップ。実機で push を確認済み",
-      "prs": []
+      "prs": [
+        290
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`ops/dashboard/build.py` に `publish()` を追加した。`AUTOPILOT_GITHUB_TOKEN` が環境にあれば、生成した `index.html` を `ops-dashboard` ブランチへ GitHub Contents API で push する（`ops-health-reporter` が `ops-health-report` ブランチへ書き戻すのと同型のパターン）。`main` へは直 push しない。

これまで、クラスタ内常駐の autopilot には Artifact ツールが無いため、毎イテレーション `build.py` で HTML は作れているのに公開できず、ダッシュボードが常駐化直前の版で 9 時間半以上止まっていた（issue #56 の指摘）。この変更で `python3 ops/dashboard/build.py` を実行するだけで公開まで完結する。

token が無い環境（CI・手元実行）では push を静かにスキップし、HTML 生成自体の成否には影響しない。

## 検証したこと

- 構文確認（`ast.parse`）
- token 無しで実行 → push がスキップされ、HTML 生成は従来どおり成功することを確認
- token ありで実行 → `ops-dashboard` ブランチが作成され、`index.html`（約100KB）が実際に push されたことを GitHub Contents API のレスポンス（sha 一致）で確認済み

## ロールバック手順

このコミットを revert すれば `build.py` は従来どおり push を行わなくなる。`ops-dashboard` ブランチ自体は残るが、他のどのアプリケーションもまだこのブランチを消費していない（配信側の Deployment は T-0128 が別 PR で追加する）ため、放置しても実害はない。DB やスキーマは関与しないため、revert 後の不整合は無い。

## backlog

T-0127（同じコミットで `done` に更新済み）。次点は T-0128（`ops-dashboard` ブランチを tailscale-operator 経由で配信する Deployment、`blocked_by: T-0127` は本 PR の merge で解消）。
