### PR TITLE
feat(ops-dashboard): dashboard index.html を tailscale 経由で配信する (T-0128)

### DIFF
--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -12,4 +12,5 @@ resources:
   - coder/application.yaml
   - ops-health-reporter/application.yaml
   - autopilot/application.yaml
+  - ops-dashboard/application.yaml
 

--- a/apps/ops-dashboard/application.yaml
+++ b/apps/ops-dashboard/application.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ops-dashboard
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/hikuohiku/homelab.git
+    targetRevision: HEAD
+    path: apps/ops-dashboard
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ops-dashboard
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/ops-dashboard/deployment.yaml
+++ b/apps/ops-dashboard/deployment.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ops-dashboard
+  namespace: ops-dashboard
+  labels:
+    app: ops-dashboard
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ops-dashboard
+  template:
+    metadata:
+      labels:
+        app: ops-dashboard
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      # T-0127 が ops-dashboard ブランチへ push する index.html を初回 sync 前に
+      # 用意する。無いと httpd コンテナが起動直後に 404 を返し続ける。
+      initContainers:
+        - name: fetch-init
+          image: alpine:3.22.5
+          command:
+            - sh
+            - -c
+            - >-
+              wget -qO /www/index.html "$DASHBOARD_URL" ||
+              echo '<html><body>dashboard not published yet</body></html>' > /www/index.html
+          env:
+            - name: DASHBOARD_URL
+              value: https://raw.githubusercontent.com/hikuohiku/homelab/ops-dashboard/index.html
+          volumeMounts:
+            - name: www
+              mountPath: /www
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+      containers:
+        # ops-dashboard ブランチ（build.py の publish() が push する、public repo なので
+        # 認証不要で raw.githubusercontent.com から読める）を定期取得して共有 volume に置く。
+        - name: fetcher
+          image: alpine:3.22.5
+          command:
+            - sh
+            - -c
+            - >-
+              while true; do
+                wget -qO /www/index.html.tmp "$DASHBOARD_URL" &&
+                  mv /www/index.html.tmp /www/index.html;
+                sleep "$FETCH_INTERVAL_SECONDS";
+              done
+          env:
+            - name: DASHBOARD_URL
+              value: https://raw.githubusercontent.com/hikuohiku/homelab/ops-dashboard/index.html
+            - name: FETCH_INTERVAL_SECONDS
+              value: "60"
+          volumeMounts:
+            - name: www
+              mountPath: /www
+          # memory limits は付けない: 実測できる環境が無く、OOMKill は回復しないため
+          # 裏付けの無い値で「縛る」変更をしない方針 (CHARTER §4, T-0055 の教訓)。
+          # CPU limits は超過しても throttle で回復するので付けてよい
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+        - name: httpd
+          image: alpine:3.22.5
+          command: ["busybox", "httpd", "-f", "-v", "-p", "8080", "-h", "/www"]
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: www
+              mountPath: /www
+              readOnly: true
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: www
+          emptyDir: {}

--- a/apps/ops-dashboard/ingress.yaml
+++ b/apps/ops-dashboard/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ops-dashboard
+  namespace: ops-dashboard
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: ops-dashboard
+      port:
+        number: 80
+  tls:
+    - hosts:
+        - ops-dashboard

--- a/apps/ops-dashboard/kustomization.yaml
+++ b/apps/ops-dashboard/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/apps/ops-dashboard/service.yaml
+++ b/apps/ops-dashboard/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ops-dashboard
+  namespace: ops-dashboard
+spec:
+  # 外部公開は Tailscale Ingress が担うため ClusterIP (apps/coder と同じパターン)
+  type: ClusterIP
+  selector:
+    app: ops-dashboard
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP


### PR DESCRIPTION
## 変更点

`ops/dashboard/build.py` の `publish()`（T-0127）が push する `ops-dashboard` ブランチの
`index.html` を、クラスタ内で常時取得・配信する新しい ArgoCD Application
`apps/ops-dashboard/` を追加した。

- `Deployment`: alpine ベースの2コンテナ + initContainer
  - `fetch-init`（initContainer）: 初回 sync 時に `index.html` を取得しておく（無いと httpd が起動直後 404 を返し続ける）
  - `fetcher`: `wget` で 60 秒毎に `https://raw.githubusercontent.com/hikuohiku/homelab/ops-dashboard/index.html`
    を取得し、共有 `emptyDir` へ書き込む。このリポジトリは public のため認証不要（`AUTOPILOT_GITHUB_TOKEN` 等は使わない）
  - `httpd`: busybox 内蔵の `httpd` で `emptyDir` を静的配信（port 8080）
- `Service`（ClusterIP）+ `Ingress`（`ingressClassName: tailscale`）は `apps/coder/` と同じパターンをそのまま踏襲。
  `coder.tailae6c2.ts.net` と同型で `ops-dashboard.tailae6c2.ts.net` として公開される想定
- `apps/kustomization.yaml` に `ops-dashboard/application.yaml` を追加し、App-of-Apps に登録

**到達性経路への影響**: 新しい Tailscale Ingress を追加するが、既存の `coder`/他アプリの
Ingress・tailscale-operator の設定には一切触れていない（追加のみ）。この変更自体が失敗しても
既存の到達経路（Tailscale 全体、coder 等）には影響しない。

## 検証したこと

- `kubectl kustomize apps/ops-dashboard` で単体レンダリングを確認（この環境に `kustomize` 単体は無いが `kubectl kustomize` はローカルで動く）
- `kubectl kustomize apps` で App-of-Apps 全体のレンダリングが壊れていないこと（Application が 10→11 件になったことを確認）
- `python3 ops/validate.py` → 0 error
- `alpine:3.22.5` タグの実在を Docker Hub registry API で確認済み
- リポジトリが public であること、`raw.githubusercontent.com/hikuohiku/homelab/ops-dashboard/index.html` が認証無しで 200 を返すことを実機 curl で確認済み（ops-dashboard ブランチの `index.html` はリポジトリ直下にある。`ops/dashboard/index.html` ではない）
- **未確認（cluster への実 sync 後に確認する）**: Pod が実際に Ready になること、`ops-dashboard.tailae6c2.ts.net` が実際に到達可能であること。merge 後にこのセッション内で `kubectl get pods -n ops-dashboard` と `curl https://ops-dashboard.tailae6c2.ts.net`（この Pod からは cluster 内 DNS 経由で `*.ts.net` が解決できることを `coder.tailae6c2.ts.net` で確認済み）で追って確認し、結果を journal に記録する

## 縛る変更について（CHARTER §4）

readiness/liveness probe と CPU limits を新設しているが、**memory limits は付けていない**
（実測できる環境が無く、OOMKill は回復しないため。CHARTER §4 T-0055 の教訓）。プロセスは
busybox 単体（`wget` ループ / 静的 `httpd`）で footprint が極小のため memory limits 無しでも
実運用上のリスクは低いと判断した。CPU limits（throttle のみで回復可能）と requests は設定済み。

## ロールバック手順

`apps/ops-dashboard/` ディレクトリと `apps/kustomization.yaml` の該当 1 行を revert すれば、
ArgoCD の `apps` Application が `prune: true` のため次の sync で `ops-dashboard` namespace 一式
（Deployment/Service/Ingress/Application 自体）が自動的に削除される。ステートフルなデータは
一切持たない（`emptyDir` のみ）ため、revert によるデータ不整合は発生しない。

## backlog task id

T-0128
