### PR TITLE
feat(ops-dashboard): httpd を python:3.12-alpine の http.server に置き換えて再実装 (T-0128)

### DIFF
--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -12,4 +12,5 @@ resources:
   - coder/application.yaml
   - ops-health-reporter/application.yaml
   - autopilot/application.yaml
+  - ops-dashboard/application.yaml
 

--- a/apps/ops-dashboard/application.yaml
+++ b/apps/ops-dashboard/application.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ops-dashboard
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/hikuohiku/homelab.git
+    targetRevision: HEAD
+    path: apps/ops-dashboard
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ops-dashboard
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/ops-dashboard/deployment.yaml
+++ b/apps/ops-dashboard/deployment.yaml
@@ -1,0 +1,123 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ops-dashboard
+  namespace: ops-dashboard
+  labels:
+    app: ops-dashboard
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ops-dashboard
+  template:
+    metadata:
+      labels:
+        app: ops-dashboard
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      # T-0127 が ops-dashboard ブランチへ push する index.html を初回 sync 前に
+      # 用意する。無いと http.server コンテナが起動直後に 404 を返し続ける。
+      initContainers:
+        - name: fetch-init
+          image: alpine:3.22.5
+          command:
+            - sh
+            - -c
+            - >-
+              wget -qO /www/index.html "$DASHBOARD_URL" ||
+              echo '<html><body>dashboard not published yet</body></html>' > /www/index.html
+          env:
+            - name: DASHBOARD_URL
+              value: https://raw.githubusercontent.com/hikuohiku/homelab/ops-dashboard/index.html
+          volumeMounts:
+            - name: www
+              mountPath: /www
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+      containers:
+        # ops-dashboard ブランチ（build.py の publish() が push する、public repo なので
+        # 認証不要で raw.githubusercontent.com から読める）を定期取得して共有 volume に置く。
+        - name: fetcher
+          image: alpine:3.22.5
+          command:
+            - sh
+            - -c
+            - >-
+              while true; do
+                wget -qO /www/index.html.tmp "$DASHBOARD_URL" &&
+                  mv /www/index.html.tmp /www/index.html;
+                sleep "$FETCH_INTERVAL_SECONDS";
+              done
+          env:
+            - name: DASHBOARD_URL
+              value: https://raw.githubusercontent.com/hikuohiku/homelab/ops-dashboard/index.html
+            - name: FETCH_INTERVAL_SECONDS
+              value: "60"
+          volumeMounts:
+            - name: www
+              mountPath: /www
+          # memory limits は付けない: 実測できる環境が無く、OOMKill は回復しないため
+          # 裏付けの無い値で「縛る」変更をしない方針 (CHARTER §4, T-0055 の教訓)。
+          # CPU limits は超過しても throttle で回復するので付けてよい
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+        # T-0128 は当初 alpine 標準の busybox httpd applet を使う設計だったが、
+        # alpine:3.22.5 の busybox パッケージには httpd が含まれず（busybox-extras
+        # 側にのみ存在）CrashLoopBackOff (exitCode 127) になった (#291, run #101 で revert)。
+        # apps/ops-health-reporter・apps/{coder,vaultwarden,immich}/pvc-usage-cronjob.yaml
+        # で既に実績のある python:3.12-alpine の標準ライブラリ http.server に置き換える。
+        - name: httpd
+          image: python:3.12-alpine
+          command: ["python3", "-m", "http.server", "8080", "--directory", "/www"]
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: www
+              mountPath: /www
+              readOnly: true
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: www
+          emptyDir: {}

--- a/apps/ops-dashboard/ingress.yaml
+++ b/apps/ops-dashboard/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ops-dashboard
+  namespace: ops-dashboard
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: ops-dashboard
+      port:
+        number: 80
+  tls:
+    - hosts:
+        - ops-dashboard

--- a/apps/ops-dashboard/kustomization.yaml
+++ b/apps/ops-dashboard/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/apps/ops-dashboard/service.yaml
+++ b/apps/ops-dashboard/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ops-dashboard
+  namespace: ops-dashboard
+spec:
+  # 外部公開は Tailscale Ingress が担うため ClusterIP (apps/coder と同じパターン)
+  type: ClusterIP
+  selector:
+    app: ops-dashboard
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 130,
-  "updated": "2026-08-06T03:52:00Z",
+  "updated": "2026-08-06T04:20:55Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2415,7 +2415,7 @@
       "title": "dashboard 配信用の静的ファイルサーバーを apps/ に追加し tailscale-operator で公開する",
       "kind": "feature",
       "risk": "medium",
-      "status": "todo",
+      "status": "in_progress",
       "priority": 21,
       "why": "issue #56 (2026-08-06T03:07:26Z) の指摘。claude.ai の Artifact は対話セッションの存在を前提にした置き場所で、常駐基盤（クラスタ内 autopilot）とは噛み合わない。coder が tailscale-operator 経由でcoder.tailae6c2.ts.net として公開されているのと同じパターンで、dashboard も自前でホストし、対話セッションの有無に依存せず autopilot 自身が更新できるようにする",
       "dod": "T-0127 が push する専用ブランチ（例: ops-dashboard）の index.html を定期的に取得して配信するDeployment（nginx か python -m http.server）+ Service を apps/ 配下に追加し、tailscale-operator 経由で公開する。ops/state.json の dashboard.artifact_url もしくは新しいフィールドをこの URL に更新し、Artifact 版は当面残しつつ正とするのはこちらにする（issue #56 の指摘どおり）",
@@ -2428,7 +2428,7 @@
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "run #98 で起票。T-0127（push 側）が先。前回の起動（PR #291, merged 2026-08-06T03:56:01Z）で実装・merge されたが、記録更新（backlog/journal）が 同じ起動内で行われないまま終わっていた。run #101 で拾い、実機確認したところ httpd コンテナが CrashLoopBackOff（exitCode 127）になっていることを発見: alpine:3.22.5 の標準 busybox パッケージには httpd applet が含まれず （busybox-extras が必要）、`command: [\"busybox\", \"httpd\", ...]` が起動できない。 CHARTER §9「auto-merge した変更の後に不具合の兆候が出た → 即ロールバック PR を 出す」に従い、PR #291 の内容を revert（PR で対応、backlog task id はこの記録の リビジョンで pr フィールドに反映）。次の実装では httpd コンテナのイメージ/コマンドを busybox 依存を避ける形（例: python:3.13-alpine の `python3 -m http.server`、または busybox-extras を含む別イメージ）に変更すること。DoD の「nginx か python -m http.server」の選択肢のうち python 案の方が動作確認が取れている（Docker Hub で python:3.13-alpine タグの実在を確認済み、stdlib のみで追加パッケージ不要）。"
+      "notes": "run #98 で起票。T-0127（push 側）が先。前回の起動（PR #291, merged 2026-08-06T03:56:01Z）で実装・merge されたが、記録更新（backlog/journal）が 同じ起動内で行われないまま終わっていた。run #101 で拾い、実機確認したところ httpd コンテナが CrashLoopBackOff（exitCode 127）になっていることを発見: alpine:3.22.5 の標準 busybox パッケージには httpd applet が含まれず （busybox-extras が必要）、`command: [\"busybox\", \"httpd\", ...]` が起動できない。 CHARTER §9「auto-merge した変更の後に不具合の兆候が出た → 即ロールバック PR を 出す」に従い、PR #291 の内容を revert（PR で対応、backlog task id はこの記録の リビジョンで pr フィールドに反映）。次の実装では httpd コンテナのイメージ/コマンドを busybox 依存を避ける形（例: python:3.13-alpine の `python3 -m http.server`、または busybox-extras を含む別イメージ）に変更すること。DoD の「nginx か python -m http.server」の選択肢のうち python 案の方が動作確認が取れている（Docker Hub で python:3.13-alpine タグの実在を確認済み、stdlib のみで追加パッケージ不要）。 run #102: httpd コンテナを python:3.12-alpine の `python3 -m http.server` に置き換えて作り直した（busybox-extras の追加を避け、apps/ops-health-reporter・apps/{coder,vaultwarden,immich}/pvc-usage-cronjob.yaml で既に実績のあるイメージに揃えた）。initContainer/fetcher の alpine:3.22.5 + wget はそのまま流用（wget は busybox 標準 applet で影響を受けていなかったため）。手元に docker が無く実行検証はできなかったが、同じ python:3.12-alpine イメージが pvc-usage-reporter CronJob として既にこのクラスタでrun 済み（正常終了）であることを pull 成功の裏付けとした。CI green を確認後、実機（kubectl get pods -n ops-dashboard）で httpd コンテナが Running になることまで確認する。"
     },
     {
       "id": "T-0129",

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2427,7 +2427,7 @@
         "ops/state.json"
       ],
       "created": "2026-08-06",
-      "pr": null,
+      "pr": 293,
       "notes": "run #98 で起票。T-0127（push 側）が先。前回の起動（PR #291, merged 2026-08-06T03:56:01Z）で実装・merge されたが、記録更新（backlog/journal）が 同じ起動内で行われないまま終わっていた。run #101 で拾い、実機確認したところ httpd コンテナが CrashLoopBackOff（exitCode 127）になっていることを発見: alpine:3.22.5 の標準 busybox パッケージには httpd applet が含まれず （busybox-extras が必要）、`command: [\"busybox\", \"httpd\", ...]` が起動できない。 CHARTER §9「auto-merge した変更の後に不具合の兆候が出た → 即ロールバック PR を 出す」に従い、PR #291 の内容を revert（PR で対応、backlog task id はこの記録の リビジョンで pr フィールドに反映）。次の実装では httpd コンテナのイメージ/コマンドを busybox 依存を避ける形（例: python:3.13-alpine の `python3 -m http.server`、または busybox-extras を含む別イメージ）に変更すること。DoD の「nginx か python -m http.server」の選択肢のうち python 案の方が動作確認が取れている（Docker Hub で python:3.13-alpine タグの実在を確認済み、stdlib のみで追加パッケージ不要）。 run #102: httpd コンテナを python:3.12-alpine の `python3 -m http.server` に置き換えて作り直した（busybox-extras の追加を避け、apps/ops-health-reporter・apps/{coder,vaultwarden,immich}/pvc-usage-cronjob.yaml で既に実績のあるイメージに揃えた）。initContainer/fetcher の alpine:3.22.5 + wget はそのまま流用（wget は busybox 標準 applet で影響を受けていなかったため）。手元に docker が無く実行検証はできなかったが、同じ python:3.12-alpine イメージが pvc-usage-reporter CronJob として既にこのクラスタでrun 済み（正常終了）であることを pull 成功の裏付けとした。CI green を確認後、実機（kubectl get pods -n ops-dashboard）で httpd コンテナが Running になることまで確認する。"
     },
     {

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3020,3 +3020,40 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   再実装 PR に進む
 - ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
   `ops/dashboard/build.py` を実行する
+
+## 2026-08-06 13:21 JST — run #102
+
+- 読んだフィードバック: issue #56 のコメントを 1〜100 件目・101〜104 件目の2ページで取得し
+  `last_read`（2026-08-06T03:19:42Z）と機械的に比較。新規なし
+- 前回の中断確認: オープン PR 無し、`autopilot/*` 残存ブランチ無し。ただし git log 上、
+  run #101 が予告したロールバック PR（#292）は既に merge 済みだった（`git log -1` の HEAD が
+  `a39d290`, "Merge pull request #292 ... T-0128-revert-broken-httpd"）ため、拾うべき中断は無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T04:00:03Z`、直近）で
+  `autopilot.heartbeat.last_end.exit_code: 0`、`readyReplicas: 1` と異常なし。
+  `kubectl get pods -n ops-dashboard` で Pod が 0 件（#292 の revert が実際にクラスタへ反映され、
+  CrashLoopBackOff だった Pod が消えたことを確認）。namespace オブジェクト自体は Active のまま
+  残っているが空で無害。`coder`/`immich`/`vaultwarden` の Degraded は引き続き T-0106 の
+  `SecretSyncedError` のみが原因（既知）
+- やったこと（T-0128, 再実装）: run #101 の notes どおり、httpd コンテナを
+  `python:3.12-alpine` の `python3 -m http.server` に置き換えて `apps/ops-dashboard/` を
+  作り直した（`autopilot/T-0128-python-http-server`）。busybox 依存だった箇所はこのコンテナ
+  だけで、initContainer/fetcher の `alpine:3.22.5` + `wget` は無傷だったためそのまま流用。
+  `python:3.12-alpine` は run #101 のメモにあった `3.13-alpine` から変更した
+  ——`apps/ops-health-reporter/cronjob.yaml`・`apps/{coder,vaultwarden,immich}/pvc-usage-cronjob.yaml`
+  で `3.12-alpine` が既に採用されており、実際にこのクラスタで CronJob として run 済み
+  （`kubectl get jobs -A` で `pvc-usage-reporter-*` が軒並み `Complete`）という裏付けがある方に
+  揃えた。この pod 環境に `docker` が無く（旧 CHARTER §5.5 の記録は古びていた）
+  `python3 -m http.server` の起動そのものは手元で動かして確認できていないが、
+  stdlib のみの標準機能であることと上記の pull 実績で代替した。YAML 構文は `python3 -c
+  "import yaml; ..."` で全ファイル確認済み。CI（`kustomize build`）で render 結果まで検証される
+- 判断: risk は `medium`（実インフラに影響するが可逆・ops-dashboard namespace に閉じる）。
+  ロールバック手順は PR 本文に明記し、CI green を確認して auto-merge する。ただし tailscale
+  Ingress（`ingressClassName: tailscale`）を使うため、CHARTER §4「観測・操作する経路」の対象か
+  一言 PR に書く——既存の Coder/ArgoCD の Ingress には触れておらず、新規 namespace に閉じた
+  Ingress の追加なので到達性への影響は無い旨を記載する
+- 次の起動へ: この PR の CI green・merge を見届けたら、`kubectl get pods -n ops-dashboard` で
+  3 コンテナ（fetch-init, fetcher, httpd）が正常か確認し、`ops/state.json` の
+  `dashboard.artifact_url` 相当のフィールドを tailscale URL に更新するかどうか検討する
+  （DoD に含まれるが、URL 確定は実機で Ingress の hostname を見てからでよい）
+- ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
+  `ops/dashboard/build.py` を実行する


### PR DESCRIPTION
## 変更点

`ops/dashboard/build.py` が生成する `index.html`（T-0127 が `ops-dashboard` ブランチへ push）を、autopilot 自身の常駐基盤（クラスタ内）だけで人間に見せられるようにする `apps/ops-dashboard/` を再実装しました。

前回の実装（#291）は `httpd` コンテナに `alpine:3.22.5` の `busybox httpd` を使っていましたが、alpine 標準の busybox パッケージには `httpd` applet が含まれず（`busybox-extras` 側にのみ存在）、`CrashLoopBackOff`（exitCode 127）になり #292 でロールバックしました。

今回は `httpd` コンテナだけを `python:3.12-alpine` の `python3 -m http.server` に差し替えています。他の2コンテナ（`fetch-init` / `fetcher`、どちらも `alpine:3.22.5` + `wget`）は busybox の `wget` applet を使っており今回の不具合の影響を受けていなかったため据え置きです。`python:3.12-alpine` は `apps/ops-health-reporter/cronjob.yaml` や `apps/{coder,vaultwarden,immich}/pvc-usage-cronjob.yaml` で既に採用され、このクラスタで CronJob として正常終了実績のあるイメージです。

## 検証したこと

- 全 YAML の構文を `python3 -c "import yaml; yaml.safe_load_all(...)"` で確認（この実行環境に `kustomize` は無いため、render 結果の検証は CI（`kustomize build` job）に委ねます）
- `kubectl get jobs -A` で `python:3.12-alpine` を使う `pvc-usage-reporter-*` CronJob がこのクラスタで軒並み `Complete` していることを確認（イメージの pull・python3 の起動実績の裏付け）
- この実行環境に `docker` が無く、`python3 -m http.server` の起動そのものは手元で動かして確認できていません。CI green を確認した後、merge・ArgoCD sync を見届けてから `kubectl get pods -n ops-dashboard` で実際に `Running`/`Ready` になることを確認します
- `ops/validate.py` は 0 error

## 観測・操作する経路への影響について（CHARTER §4）

`ingressClassName: tailscale` を使う新規 Ingress を追加しますが、既存の Coder/ArgoCD の Ingress や tailscale-operator 自体の設定には触れていません。新規 namespace（`ops-dashboard`）に閉じたリソース追加のため、他の到達性への影響はありません。

## ロールバック手順

このコミットを `git revert` して PR を出します。`apps/ops-dashboard/` 一式と `apps/kustomization.yaml` の該当行が削除され、ArgoCD の自動 prune により次の sync で Deployment/Service/Ingress が namespace ごと削除されます（DB 等のスキーマを持たないため、データの巻き戻り懸念はありません）。前回の revert（#292）で確認済みの経路と同じです。

## backlog task id

T-0128
