### PR TITLE
docs(ops): 計画役 run #102 の記録更新（backlog 見直し・inventory 調査）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 130,
-  "updated": "2026-08-06T03:52:00Z",
+  "updated": "2026-08-06T04:35:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2188,14 +2188,14 @@
       "priority": 43,
       "why": "T-0072（run #82）の判断: T-0065 が挙げた実データ5対象のうち、restic backup + 復元試験まで完了しているのは immich/vaultwarden/coder-postgres 系の4対象のみで、`coder-<workspace-id>-home`（T-0078）が未実装の間は PBS の VM 単位バックアップが唯一の（未確認だが）保険になっている。T-0078 が完了し、workspace home も復元試験まで確認できたら、node01 の全実データがアプリレベルの restic backup でカバーされ、PBS の VM 単位バックアップは完全に冗長になる（node01 VM 自体は Terraform+NixOS で宣言的に再現可能なため）",
       "dod": "T-0078 が done になった後、(1) workspace home の restic backup が実際に成功し復元試験も通ることを確認する、(2) PBS 上に他に依存しているジョブ・データが無いか最終確認する、(3) `terraform/proxmox/pbs.tf.ignore` にこの記録を残しつつ PBS VM (qemu/112) の停止・削除手順を明記する。実際の VM 停止・削除は Proxmox 管理コンソールでの操作が要り、autopilot の Proxmox credential（PVEAuditor、読み取り専用）では実行できないため、この最終手順は needs-human として人間に引き継ぐ",
-      "blocked_by": "T-0078（coder workspace home PVC の backup 実装・復元試験）",
+      "blocked_by": "T-0117（coder workspace home backup の初回実行確認・復元試験）",
       "refs": [
         "docs/backup.md",
         "terraform/proxmox/pbs.tf.ignore"
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "run #82: T-0072（PBS 退役判断）から実行タスクとして分離起票"
+      "notes": "run #82: T-0072（PBS 退役判断）から実行タスクとして分離起票 | run #102 (計画役): blocked_by が T-0078 のままだったが、T-0078 は run #84 で done・PR #264 merge 済み（実装は完了済み）。実際に残っているのは復元試験（分離済みの T-0117、CronJob 初回実行が 2026-08-07 03:30 JST まで到来しないため未実施）で、blocked_by を T-0117 に訂正した（CHARTER §2 計画役の作業『blocked/needs-human の理由が古い前提のままになっていないか確かめる』）。"
     },
     {
       "id": "T-0117",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,43 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 293,
+      "title": "feat(ops-dashboard): httpd を python:3.12-alpine の http.server に置き換えて再実装 (T-0128)",
+      "url": "https://github.com/hikuohiku/homelab/pull/293",
+      "isDraft": false,
+      "createdAt": "2026-08-06T04:22:24Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        }
+      ],
+      "headRefName": "autopilot/T-0128-python-http-server",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 292,
+      "title": "revert: ops-dashboard httpd CrashLoopBackOff を revert (T-0128)",
+      "url": "https://github.com/hikuohiku/homelab/pull/292",
+      "mergedAt": "2026-08-06T04:12:41Z",
+      "headRefName": "autopilot/T-0128-revert-broken-httpd"
+    },
     {
       "number": 291,
       "title": "feat(ops-dashboard): dashboard index.html を tailscale 経由で配信する (T-0128)",
@@ -413,13 +450,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/231",
       "mergedAt": "2026-08-05T19:50:17Z",
       "headRefName": "autopilot/T-0071-immich-restore-chown-fix"
-    },
-    {
-      "number": 230,
-      "title": "fix(immich): restic restore-verify Job に diagnostic 出力を追加する (T-0071)",
-      "url": "https://github.com/hikuohiku/homelab/pull/230",
-      "mergedAt": "2026-08-05T19:42:03Z",
-      "headRefName": "autopilot/T-0071-immich-restore-diagnose"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3020,3 +3020,44 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   再実装 PR に進む
 - ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
   `ops/dashboard/build.py` を実行する
+
+## 2026-08-06 13:31 JST — run #102（計画役）
+
+- この run は `prompt-plan.md`（計画役）で起動した。実装・マニフェスト変更はせず、
+  `ops/` の記録更新のみ行う
+- `ops/inbox.md` を読んだ: 空（実行役からの新規の気づき無し）
+- 読んだフィードバック: issue #56 のコメントを `last_read`（2026-08-06T03:19:42Z）以降で
+  `since` パラメータ指定して取得したところ 1 件のみ返り、内容は last_read を設定した
+  当人（run #100 由来の自分の返信）と一致。新規の人間フィードバック無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T04:00:03Z`）を確認。
+  `coder`/`immich`/`vaultwarden` の Degraded は `kubectl get externalsecret -A` で
+  `<app>-restic-backup-credentials` の `SecretSyncedError` のみが原因（T-0106, 既知）と
+  再確認。`pod_issues` の restarts:19 常連は変化なし（journal 既出、ノード再起動由来と
+  結論済み）。immich の `backup_listing` 最新ファイルは 2026-08-06T02:00:05Z で新鮮。
+  autopilot 自身の heartbeat も iteration 1 で exit_code 0、異常なし
+- 前回の中断確認: オープン PR は #293
+  （`autopilot/T-0128-python-http-server`, T-0128 の busybox 依存を避けた再実装、作成
+  2026-08-06T04:22:24Z）が実行役の直前起動から残っているのみ。計画役はコード変更をしない
+  ため、このまま次の実行役起動に委ねる
+- backlog 見直し（CHARTER §2「blocked/needs-human の理由が古い前提のままになっていないか」）:
+  **T-0116 の `blocked_by` が古いままだった。** `T-0078（coder workspace home PVC の backup
+  実装・復元試験）` を指していたが、T-0078 自体は run #84 で done・PR #264 merge 済み。
+  実際に残っているのは復元試験（T-0078 の副産物として分離済みの T-0117、CronJob 初回実行が
+  2026-08-07 03:30 JST まで到来しないため未実施）で、`blocked_by` を `T-0117` に訂正した。
+  他の blocked/needs-human（T-0028, T-0074, T-0084, T-0106, T-0107, T-0112, T-0118, T-0120）は
+  理由を再確認したが前提の変化なし（T-0084 は `next_review: 2026-08-08` 未到来、T-0106/T-0107/
+  T-0112 は人間・構築セッション側の対応待ちで進展なし、T-0118 は `azure/setup-helm` の
+  リリースページを確認したが v4 系サポートの表明はまだ無い）
+- 着手可能なタスクの確認: `todo` は T-0117（時間ゲートで未着手可）と T-0128（PR #293 で
+  実行役が着手中）のみで手薄だったため、`ops/inventory.json` のうち更新記録がしばらく無い
+  5 件（dex chart, immich の valkey, coder-postgres の postgres イメージ, coder 本体の
+  stable channel, tailscale-operator/k8s-nameserver）を上流と突き合わせて調査した。
+  **5 件とも既に最新で、起票すべき新規タスクは無かった。** 空振りではあるが、
+  「まだ確認していない」から「確認済みで差分なし」に変わった点に意味があると判断し記録する
+  （調査結果は次の同種調査まで backlog に残さない。CHARTER が求めるのは事実の記録であって
+  空振りの追跡ではないため）
+- 次の起動へ: 実行役は PR #293（T-0128）を最優先で拾う。その後 T-0117 が
+  2026-08-06T18:30Z 以降に着手可能になる。次の計画回では T-0116 が
+  `blocked_by: T-0117` のまま解消していないか（T-0117 の進捗と連動して）確認すること
+- ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
+  `ops/dashboard/build.py` を実行する


### PR DESCRIPTION
## 変更点

計画役（run #102）の記録更新のみ。`ops/` 配下のみ変更、コード・マニフェストの変更なし。

- `ops/backlog.json`: **T-0116 の `blocked_by` を訂正**。`T-0078`（coder workspace home
  backup の実装）を指したままだったが、T-0078 自体は run #84 で done・merge 済み。実際に
  残っている依存先は復元試験（T-0078 から分離済みの T-0117、CronJob 初回実行が
  2026-08-07 03:30 JST まで未到来のため未実施）で、`blocked_by` を `T-0117` に訂正した
- `ops/journal/2026-08.md`: run #102 の記録を追記（inbox 確認・フィードバック確認・
  health report 確認・backlog 見直し・inventory 調査の結果）
- `ops/dashboard/prs.json` / `ops/dashboard/index.html`（`ops-dashboard` ブランチへ publish
  済み、このリポジトリには非同梱）: 最新化

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- 上記以外の blocked/needs-human（T-0028, T-0074, T-0084, T-0106, T-0107, T-0112, T-0118,
  T-0120）は理由の前提が変わっていないことを確認済み（T-0118 は `azure/setup-helm` の
  リリースページを実際に確認）
- `ops/inventory.json` のうち更新記録がしばらく無かった5件（dex chart, immich の valkey,
  coder-postgres の postgres イメージ, coder 本体の stable channel, tailscale-operator/
  k8s-nameserver）を上流と突き合わせ、全て最新版であることを確認（新規タスク起票なし）

## ロールバック手順

`ops/backlog.json` と journal のテキストのみの変更で、インフラへの影響は無い。
revert すれば即座に元の記述に戻る。データやスキーマは関与しない。

## backlog task id

T-0116 の記録訂正のみ（新規タスク起票なし）