### PR TITLE
docs(ops): T-0128 完了の記録更新 (run #103)

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 130,
-  "updated": "2026-08-06T04:35:00Z",
+  "updated": "2026-08-06T04:46:58Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2415,7 +2415,7 @@
       "title": "dashboard 配信用の静的ファイルサーバーを apps/ に追加し tailscale-operator で公開する",
       "kind": "feature",
       "risk": "medium",
-      "status": "in_progress",
+      "status": "done",
       "priority": 21,
       "why": "issue #56 (2026-08-06T03:07:26Z) の指摘。claude.ai の Artifact は対話セッションの存在を前提にした置き場所で、常駐基盤（クラスタ内 autopilot）とは噛み合わない。coder が tailscale-operator 経由でcoder.tailae6c2.ts.net として公開されているのと同じパターンで、dashboard も自前でホストし、対話セッションの有無に依存せず autopilot 自身が更新できるようにする",
       "dod": "T-0127 が push する専用ブランチ（例: ops-dashboard）の index.html を定期的に取得して配信するDeployment（nginx か python -m http.server）+ Service を apps/ 配下に追加し、tailscale-operator 経由で公開する。ops/state.json の dashboard.artifact_url もしくは新しいフィールドをこの URL に更新し、Artifact 版は当面残しつつ正とするのはこちらにする（issue #56 の指摘どおり）",
@@ -2428,7 +2428,7 @@
       ],
       "created": "2026-08-06",
       "pr": 293,
-      "notes": "run #98 で起票。T-0127（push 側）が先。前回の起動（PR #291, merged 2026-08-06T03:56:01Z）で実装・merge されたが、記録更新（backlog/journal）が 同じ起動内で行われないまま終わっていた。run #101 で拾い、実機確認したところ httpd コンテナが CrashLoopBackOff（exitCode 127）になっていることを発見: alpine:3.22.5 の標準 busybox パッケージには httpd applet が含まれず （busybox-extras が必要）、`command: [\"busybox\", \"httpd\", ...]` が起動できない。 CHARTER §9「auto-merge した変更の後に不具合の兆候が出た → 即ロールバック PR を 出す」に従い、PR #291 の内容を revert（PR で対応、backlog task id はこの記録の リビジョンで pr フィールドに反映）。次の実装では httpd コンテナのイメージ/コマンドを busybox 依存を避ける形（例: python:3.13-alpine の `python3 -m http.server`、または busybox-extras を含む別イメージ）に変更すること。DoD の「nginx か python -m http.server」の選択肢のうち python 案の方が動作確認が取れている（Docker Hub で python:3.13-alpine タグの実在を確認済み、stdlib のみで追加パッケージ不要）。 run #102: httpd コンテナを python:3.12-alpine の `python3 -m http.server` に置き換えて作り直した（busybox-extras の追加を避け、apps/ops-health-reporter・apps/{coder,vaultwarden,immich}/pvc-usage-cronjob.yaml で既に実績のあるイメージに揃えた）。initContainer/fetcher の alpine:3.22.5 + wget はそのまま流用（wget は busybox 標準 applet で影響を受けていなかったため）。手元に docker が無く実行検証はできなかったが、同じ python:3.12-alpine イメージが pvc-usage-reporter CronJob として既にこのクラスタでrun 済み（正常終了）であることを pull 成功の裏付けとした。CI green を確認後、実機（kubectl get pods -n ops-dashboard）で httpd コンテナが Running になることまで確認する。"
+      "notes": "run #98 で起票。T-0127（push 側）が先。前回の起動（PR #291, merged 2026-08-06T03:56:01Z）で実装・merge されたが、記録更新（backlog/journal）が 同じ起動内で行われないまま終わっていた。run #101 で拾い、実機確認したところ httpd コンテナが CrashLoopBackOff（exitCode 127）になっていることを発見: alpine:3.22.5 の標準 busybox パッケージには httpd applet が含まれず （busybox-extras が必要）、`command: [\"busybox\", \"httpd\", ...]` が起動できない。 CHARTER §9「auto-merge した変更の後に不具合の兆候が出た → 即ロールバック PR を 出す」に従い、PR #291 の内容を revert（PR で対応、backlog task id はこの記録の リビジョンで pr フィールドに反映）。次の実装では httpd コンテナのイメージ/コマンドを busybox 依存を避ける形（例: python:3.13-alpine の `python3 -m http.server`、または busybox-extras を含む別イメージ）に変更すること。DoD の「nginx か python -m http.server」の選択肢のうち python 案の方が動作確認が取れている（Docker Hub で python:3.13-alpine タグの実在を確認済み、stdlib のみで追加パッケージ不要）。 run #102: httpd コンテナを python:3.12-alpine の `python3 -m http.server` に置き換えて作り直した（busybox-extras の追加を避け、apps/ops-health-reporter・apps/{coder,vaultwarden,immich}/pvc-usage-cronjob.yaml で既に実績のあるイメージに揃えた）。initContainer/fetcher の alpine:3.22.5 + wget はそのまま流用（wget は busybox 標準 applet で影響を受けていなかったため）。手元に docker が無く実行検証はできなかったが、同じ python:3.12-alpine イメージが pvc-usage-reporter CronJob として既にこのクラスタでrun 済み（正常終了）であることを pull 成功の裏付けとした。CI green を確認後、実機（kubectl get pods -n ops-dashboard）で httpd コンテナが Running になることまで確認する。 run #103: PR #293 は main 側の別 PR（#294）と ops/backlog.json・ops/journal/2026-08.md で競合し mergeable_state: dirty になっていた（origin/main を merge しコンフリクトを解消、CI 再実行の green を確認して merge、eb5f9aa）。ArgoCD の apps root Application が新しい main（eb5f9aa）を拾うまで数分待ち、`kubectl get application ops-dashboard -n argocd` で Synced/Healthy、`kubectl get pods -n ops-dashboard` で 2/2 Running・restartCount 0（fetcher, httpd 両方 ready）を実機で確認した。busybox httpd の CrashLoopBackOff は再発していない。DoD 未達のまま残っているのは state.json への URL 登録のみ: `kubectl get ingress -n ops-dashboard` は autopilot-reader ClusterRole に networking.k8s.io/ingresses の read 権限が無く Forbidden、tailscale MCP もこの Pod には credential が無く実行不能で、ホスト名を実測できなかった。他アプリ（immich/vaultwarden/dex/argocd/coder）の ingress.yaml コメントから類推すると ops-dashboard.tailae6c2.ts.net の可能性が高いが、未検証のまま state.json に書くのは避け、ops/inbox.md に検証依頼を残した。"
     },
     {
       "id": "T-0129",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,36 +1,20 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 293,
       "title": "feat(ops-dashboard): httpd を python:3.12-alpine の http.server に置き換えて再実装 (T-0128)",
       "url": "https://github.com/hikuohiku/homelab/pull/293",
-      "isDraft": false,
-      "createdAt": "2026-08-06T04:22:24Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        }
-      ],
-      "headRefName": "autopilot/T-0128-python-http-server",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-06T04:39:35Z",
+      "headRefName": "autopilot/T-0128-python-http-server"
+    },
+    {
+      "number": 294,
+      "title": "docs(ops): 計画役 run #102 の記録更新（backlog 見直し・inventory 調査）",
+      "url": "https://github.com/hikuohiku/homelab/pull/294",
+      "mergedAt": "2026-08-06T04:34:12Z",
+      "headRefName": "autopilot/plan-run102-backlog-review"
+    },
     {
       "number": 292,
       "title": "revert: ops-dashboard httpd CrashLoopBackOff を revert (T-0128)",
@@ -436,20 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/233",
       "mergedAt": "2026-08-05T20:05:10Z",
       "headRefName": "autopilot/T-0071-immich-restore-cap-simplify"
-    },
-    {
-      "number": 232,
-      "title": "fix(immich): restic restore-verify Job に CAP_FOWNER も足してタイムスタンプ復元エラーを解消する (T-0071)",
-      "url": "https://github.com/hikuohiku/homelab/pull/232",
-      "mergedAt": "2026-08-05T19:58:40Z",
-      "headRefName": "autopilot/T-0071-immich-restore-fowner-fix"
-    },
-    {
-      "number": 231,
-      "title": "fix(immich): restic restore-verify Job に CAP_CHOWN を足して所有者復元エラーを解消する (T-0071)",
-      "url": "https://github.com/hikuohiku/homelab/pull/231",
-      "mergedAt": "2026-08-05T19:50:17Z",
-      "headRefName": "autopilot/T-0071-immich-restore-chown-fix"
     }
   ]
 }

--- a/ops/inbox.md
+++ b/ops/inbox.md
@@ -7,3 +7,5 @@
 [`ops/CHARTER.md`](CHARTER.md) の §3「書く権利」。
 
 ---
+
+- T-0128 は実装・実機確認まで完了（run #103, `kubectl get pods -n ops-dashboard` で 2/2 Running）だが、DoD の「ops/state.json の dashboard.artifact_url もしくは新しいフィールドを URL に更新」だけ未了。autopilot-reader ClusterRole に `networking.k8s.io/ingresses` の read が無く `kubectl get ingress -n ops-dashboard` が Forbidden、この Pod には tailscale credential も無いため、実際の MagicDNS ホスト名を実測できない。他アプリ（immich/vaultwarden/dex/argocd/coder）の `ingress.yaml` コメントからは `ops-dashboard.tailae6c2.ts.net` の可能性が高いが未検証。構築セッション（Coder ワークスペース、tailscale 到達可能）に issue #56 経由で実測を頼むか、`autopilot-reader` ClusterRole に ingresses read を足す軽量タスクとして起票するか検討してほしい。

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3096,3 +3096,37 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   `blocked_by: T-0117` のまま解消していないか（T-0117 の進捗と連動して）確認すること
 - ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
   `ops/dashboard/build.py` を実行する
+
+## 2026-08-06 13:46 JST — run #103
+
+- 読んだフィードバック: 未確認(今回は前回の中断解消を優先。次回起動で読む)
+- 前回の中断を拾う: オープン PR は #293（T-0128）のみで、`mergeable_state: dirty` に
+  なっていた。原因は base（`a39d290`, PR #292 merge 直後）から main が #294（計画役の
+  backlog/journal 記録更新）で 1 歩進んでおり、`ops/backlog.json`・
+  `ops/journal/2026-08.md` の両方を PR #293 と main 側が同じ箇所（backlog は
+  トップレベル `updated` フィールドのみ、journal は追記位置）で編集していたため。
+  ローカルで `origin/main` を merge しコンフリクトを手で解消（`updated` は新しい方を採用、
+  journal は両方の run #102 エントリを時系列順に残す。`ops/dashboard/prs.json` は
+  無衝突で自動マージ）、`python3 ops/validate.py` で 0 error を確認してから push
+- CI: マージコミット（`cac6d0a`）に対して 6 job 全て green
+  （manifest deletion guard / nix flake check / ops state validate / kustomize build /
+  terraform validate / GitGuardian）を確認してから
+  `PUT /pulls/293/merge`（`merge_method: merge`）で merge（`eb5f9aa`）。
+  マージ済みブランチは GitHub 側で自動削除済み（`DELETE` を試みたところ
+  `Reference does not exist` で確認）
+- 実機確認: ArgoCD の `apps` root Application が `eb5f9aa` を拾うまで待ち
+  （ポーリング間隔で数分）、`kubectl get application ops-dashboard -n argocd` で
+  `Synced`/`Healthy`、`kubectl get pods -n ops-dashboard` で `2/2 Running`・
+  `restartCount: 0`（fetcher・httpd 両方 ready）を確認。#291 で踏んだ busybox httpd の
+  CrashLoopBackOff は再発していない。T-0128 を `done` にした
+- 未了として残したもの: DoD にある `ops/state.json` への dashboard URL 登録は見送った。
+  `kubectl get ingress -n ops-dashboard` が `autopilot-reader` ClusterRole に
+  `networking.k8s.io/ingresses` の read が無く Forbidden、この Pod には tailscale
+  credential も無く（`mcp__tailscale__tailscale_list_devices` が
+  `No Tailscale credentials configured` で失敗）、実際のホスト名を実測できなかった。
+  他アプリの ingress.yaml コメントから `ops-dashboard.tailae6c2.ts.net` の可能性が高いが
+  未検証のまま state.json に書くのは避け、`ops/inbox.md` に 1 行残した
+- 次の起動へ: 新規タスクの着手はこの起動では行わなかった（中断解消のみで時間を使った）。
+  次の実行役は `ops/backlog.json` の `todo` から選ぶ
+- ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
+  `ops/dashboard/build.py` を実行する


### PR DESCRIPTION
## 変更点

`ops/` の運用記録のみの更新です（CHARTER §4 の相乗り例外）。

- PR #293（T-0128, ops-dashboard の httpd を python:3.12-alpine の http.server に置き換え）が main（PR #294）と `ops/backlog.json`・`ops/journal/2026-08.md` で衝突し `mergeable_state: dirty` になっていたのを、main を merge してコンフリクトを解消し CI green を確認した上で merge しました（`eb5f9aa`）。
- ArgoCD が新しい main を sync した後、`kubectl get pods -n ops-dashboard` で 2 コンテナとも `2/2 Running`・`restartCount: 0` を実機確認し、T-0128 を `done` にしました。
- DoD にあった `ops/state.json` への dashboard URL 登録は、この Pod から ingress・tailscale の情報を実測できなかったため見送り、`ops/inbox.md` に引き継ぎを残しました。
- `ops/dashboard/prs.json` / journal / dashboard の再生成も同じコミットに含めています。

## 検証したこと

- `python3 ops/validate.py` で 0 error
- `kubectl get application ops-dashboard -n argocd` で `Synced`/`Healthy`
- `kubectl get pods -n ops-dashboard` で `2/2 Running`

## ロールバック手順

このコミットを `git revert` すれば記録のみ元に戻ります。コードやマニフェストの変更は含まれていないため、revert してもクラスタの状態には影響しません。

## backlog task id

T-0128（記録更新）