### PR TITLE
docs(ops): run #105 記録更新（着手可能タスクなし・state.json 記録漏れ復元）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 295,
+      "title": "docs(ops): T-0128 完了の記録更新 (run #103)",
+      "url": "https://github.com/hikuohiku/homelab/pull/295",
+      "mergedAt": "2026-08-06T04:49:56Z",
+      "headRefName": "autopilot/T-0128-docs-followup"
+    },
+    {
       "number": 293,
       "title": "feat(ops-dashboard): httpd を python:3.12-alpine の http.server に置き換えて再実装 (T-0128)",
       "url": "https://github.com/hikuohiku/homelab/pull/293",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/234",
       "mergedAt": "2026-08-05T20:15:43Z",
       "headRefName": "autopilot/T-0071-immich-restore-cleanup"
-    },
-    {
-      "number": 233,
-      "title": "fix(immich): restic restore-verify Job に CAP_DAC_OVERRIDE を足し、target を毎回クリーンアップする (T-0071)",
-      "url": "https://github.com/hikuohiku/homelab/pull/233",
-      "mergedAt": "2026-08-05T20:05:10Z",
-      "headRefName": "autopilot/T-0071-immich-restore-cap-simplify"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3130,3 +3130,32 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   次の実行役は `ops/backlog.json` の `todo` から選ぶ
 - ダッシュボード: このあと `ops/dashboard/prs.json` を最新化し `ops/validate.py`/
   `ops/dashboard/build.py` を実行する
+
+## 2026-08-06 13:53 JST — run #104（実行役）
+
+- 読んだフィードバック: issue #56 の未読フィードバックなし（`last_read`
+  2026-08-06T03:19:42Z 以降、100件+4件をページネーションで機械的に確認）
+- 前回の中断を拾う: オープン PR・`autopilot/*` ブランチとも無し。run #103 が
+  T-0128 を merge・実機確認まで終えていたので中断なし
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T04:30:04Z`）で
+  autopilot 自身の heartbeat は iteration 5 exit_code 0、異常なし。
+  `coder`/`immich`/`vaultwarden` の Degraded は既知の T-0106
+  （`<app>-restic-backup-credentials` の `SecretSyncedError`）のみで新規異常なし
+- backlog を確認: `todo` は T-0117（coder workspace home backup の初回実行確認・
+  復元試験）1件のみ。`kubectl get cronjob -n coder` で
+  `coder-workspace-home-backup` の `LAST SCHEDULE` が `<none>` と実測し、
+  backlog notes の想定どおり次回実行予定（2026-08-06T18:30Z）がまだ到来して
+  いないことを確認した。DoD の3項目（Job成功確認・復元試験・リソース使用量確認）は
+  いずれも初回実行が前提のため、この起動時点では着手できる部分が無い
+- `blocked`/`needs-human` の残り9件（T-0028, T-0029, T-0074, T-0084, T-0106,
+  T-0107, T-0112, T-0116, T-0118, T-0120）も CHARTER §3「タスク全体ではなく
+  どの部分か」で見直したが、いずれも直前の起動（計画役 run #102 含む）で
+  前提を確認済みで、設計・記述として進められる残り部分は無いと判断した
+  （T-0116 は T-0117 待ちで同型の理由、他は人間・上流・外部サービスの
+  対応待ちで manifest は書き終えている）
+- `ops/inbox.md` は run #103 が残した T-0128 dashboard URL の 1 行のみで、
+  自分の作業中に新しく気づいたことは無かったため追記なし
+- やったこと: 着手可能なタスクが無かったため、実装は行わずこの journal 記録のみ。
+  CHARTER §2「やることが無い起動でも journal に書いた PR を出す」に従う
+- 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでの
+  起動は同様に手薄になりうるので、backlog の `todo`/`blocked` を再確認すること

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T03:40:00Z",
+  "updated": "2026-08-06T04:53:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -1067,6 +1067,54 @@
       "prs": [
         290
       ]
+    },
+    {
+      "n": 101,
+      "at": "2026-08-06T13:12:00+09:00",
+      "kind": "scheduled",
+      "by": "cluster-resident (autopilot Pod)",
+      "summary": "journal 運用のみで state.json 記録が run #104 まで抜けていた（この run 自身が run #104 の一環で事後に埋め合わせ）。実行役。T-0128（run #100, #291）の ops-dashboard Pod が CrashLoopBackOff（httpd コンテナ、alpine busybox に httpd applet が無い）と判明し、CHARTER §9 に従い即ロールバック PR を作成（#292）。T-0128 を todo に戻し、次の実装で busybox を避ける旨を notes に記録",
+      "prs": [
+        292
+      ]
+    },
+    {
+      "n": 102,
+      "at": "2026-08-06T13:21:00+09:00",
+      "kind": "scheduled",
+      "by": "cluster-resident (autopilot Pod)",
+      "summary": "実行役。#292 の revert 反映（ops-dashboard Pod 消滅）を確認し、T-0128 を httpd コンテナを python:3.12-alpine の python3 -m http.server に置き換えて再実装（#293、この時点では未 merge）",
+      "prs": [
+        293
+      ]
+    },
+    {
+      "n": 103,
+      "at": "2026-08-06T13:31:00+09:00",
+      "kind": "scheduled",
+      "by": "cluster-resident (autopilot Pod)",
+      "summary": "計画役（prompt-plan.md）。T-0116 の blocked_by が T-0078（done 済み）のまま古かったのを T-0117 に訂正。inventory.json の更新記録が薄い5件（dex chart, immich valkey, coder-postgres image, coder stable channel, tailscale-operator/k8s-nameserver）を上流と突き合わせ、いずれも最新で新規起票なしと確認（#294）",
+      "prs": [
+        294
+      ]
+    },
+    {
+      "n": 104,
+      "at": "2026-08-06T13:46:00+09:00",
+      "kind": "scheduled",
+      "by": "cluster-resident (autopilot Pod)",
+      "summary": "実行役。前回の中断（PR #293 が #294 merge により mergeable_state: dirty）を rebase で解消し merge（eb5f9aa）。ArgoCD sync 後 kubectl get pods -n ops-dashboard で 2/2 Running・restartCount 0 を確認し T-0128 を done に（#295）。dashboard.artifact_url の tailscale URL 反映は ingress read 権限と tailscale credential が無く実測できず見送り、ops/inbox.md に引き継ぎを残した",
+      "prs": [
+        295
+      ]
+    },
+    {
+      "n": 105,
+      "at": "2026-08-06T13:53:00+09:00",
+      "kind": "scheduled",
+      "by": "cluster-resident (autopilot Pod)",
+      "summary": "実行役。issue #56 に未読フィードバックなし、オープン PR・autopilot ブランチとも無し。backlog の todo は T-0117 のみで、kubectl get cronjob -n coder で coder-workspace-home-backup が LAST SCHEDULE <none> と実測し、初回実行予定（2026-08-06T18:30Z）未到来のため着手不可と確認。blocked/needs-human 9件も前提の変化なしと確認済み。着手可能なタスクが無かったため journal 記録のみ（CHARTER §2）。あわせて run #101〜#104 分の state.json runs 記録漏れを journal から復元した",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

- 実装・マニフェスト変更は無し。`ops/journal/2026-08.md` に「着手可能なタスクが無かった」ことを記録（CHARTER §2「やることが無い起動でも journal に書いた PR を出す」）
- `ops/state.json` の `runs` 配列が run #100 以降 4 run 分（journal 上の run #101〜#104）記録漏れになっていたのを journal から復元し、今回分（run #105 相当）を追記
- `ops/dashboard/prs.json` を最新化（`ops/dashboard/build.py` 実行）

## 検証したこと

- backlog の `todo` は T-0117（coder workspace home backup の初回実行確認・復元試験）のみで、`kubectl get cronjob -n coder` で対象 CronJob の `LAST SCHEDULE` が `<none>` であることを実測し、初回実行予定（2026-08-06T18:30Z）が未到来のため着手不可と確認した
- `blocked`/`needs-human` の残り9件（T-0028, T-0029, T-0074, T-0084, T-0106, T-0107, T-0112, T-0116, T-0118, T-0120）も理由の前提が変わっていないことを確認した
- `ops-health-report`（`generated_at: 2026-08-06T04:30:04Z`）で autopilot 自身の heartbeat・ArgoCD 健全性に新規異常が無いことを確認した
- `python3 ops/validate.py` で 0 error/0 warning を確認済み

## ロールバック手順

revert すれば記録が run #100 時点相当に戻るだけで、実インフラへの影響は無い（`ops/` 配下の記録ファイルのみの変更）。

## backlog task id

無し（新規タスクの起票・実装は行っていない、記録専用の PR）