### PR TITLE
docs(ops): run #106 記録更新（着手可能タスクなし）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 296,
+      "title": "docs(ops): run #105 記録更新（着手可能タスクなし・state.json 記録漏れ復元）",
+      "url": "https://github.com/hikuohiku/homelab/pull/296",
+      "mergedAt": "2026-08-06T04:59:59Z",
+      "headRefName": "autopilot/run104-nothing-actionable"
+    },
+    {
       "number": 295,
       "title": "docs(ops): T-0128 完了の記録更新 (run #103)",
       "url": "https://github.com/hikuohiku/homelab/pull/295",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/235",
       "mergedAt": "2026-08-05T20:19:23Z",
       "headRefName": "autopilot/T-0071-run64-records"
-    },
-    {
-      "number": 234,
-      "title": "docs(backup): immich の restic 復元試験の成功を記録し、検証用リソースを削除する (T-0071)",
-      "url": "https://github.com/hikuohiku/homelab/pull/234",
-      "mergedAt": "2026-08-05T20:15:43Z",
-      "headRefName": "autopilot/T-0071-immich-restore-cleanup"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3159,3 +3159,34 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   CHARTER §2「やることが無い起動でも journal に書いた PR を出す」に従う
 - 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでの
   起動は同様に手薄になりうるので、backlog の `todo`/`blocked` を再確認すること
+
+## 2026-08-06 14:01 JST — run #106（実行役）
+
+- 読んだフィードバック: issue #56 の未読フィードバックなし（`last_read`
+  2026-08-06T03:19:42Z 以降、`per_page=100` で 2 ページ（100件+4件）を機械的に確認、
+  新規コメント 0 件）
+- 前回の中断を拾う: オープン PR は #296（run #105 の記録専用 PR、CI 6 job 全 green・
+  `mergeable_state: clean`）のみ。低リスク（`ops/` 記録のみ）のため
+  `PUT /pulls/296/merge` で直接 merge（`356d86f`）。ブランチ
+  `autopilot/run104-nothing-actionable` は GitHub 側で自動削除済み
+  （`DELETE` は `Reference does not exist` で確認）。ローカル `main` を
+  `origin/main` に揃えてから着手
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T05:00:04Z`、実行時刻から
+  新鮮）で新規異常なし。`coder`/`immich`/`vaultwarden` の Degraded は
+  `kubectl get externalsecret -A` で引き続き `<app>-restic-backup-credentials` の
+  `SecretSyncedError`（T-0106, 既知）のみと確認。`pod_issues` の restarts:19 常連も
+  変化なし。immich `backup_listing` 最新ファイルは `2026-08-06T02:00:05Z`
+  （generated_at から 3 時間以内）で新鮮。autopilot 自身の heartbeat は
+  iteration 8 exit_code 0、`readyReplicas: 1` で異常なし
+- backlog を確認: `todo` は引き続き T-0117 のみ。`kubectl get cronjob -n coder` で
+  `coder-workspace-home-backup` の `LAST SCHEDULE` が `<none>` のままと実測し、
+  次回実行予定（2026-08-06T18:30Z）が現在時刻（05:0x UTC）よりまだ先のため着手不可
+  と再確認。`blocked`/`needs-human` の残り 9 件も notes を再確認したが前提の変化なし
+  （T-0084 は `next_review: 2026-08-08` 未到来）
+- `ops/inbox.md` は run #103 由来の T-0128 dashboard URL の 1 行のみで、
+  自分の作業中に新しく気づいたことは無かったため追記なし
+- やったこと: 前回中断（PR #296）の merge のみ。新規タスクは着手可能なものが無く、
+  実装は行わずこの journal 記録のみ。CHARTER §2「やることが無い起動でも journal に
+  書いた PR を出す」に従う
+- 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでは同様に
+  手薄になりうる

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T04:53:00Z",
+  "updated": "2026-08-06T05:03:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -1114,6 +1114,14 @@
       "kind": "scheduled",
       "by": "cluster-resident (autopilot Pod)",
       "summary": "実行役。issue #56 に未読フィードバックなし、オープン PR・autopilot ブランチとも無し。backlog の todo は T-0117 のみで、kubectl get cronjob -n coder で coder-workspace-home-backup が LAST SCHEDULE <none> と実測し、初回実行予定（2026-08-06T18:30Z）未到来のため着手不可と確認。blocked/needs-human 9件も前提の変化なしと確認済み。着手可能なタスクが無かったため journal 記録のみ（CHARTER §2）。あわせて run #101〜#104 分の state.json runs 記録漏れを journal から復元した",
+      "prs": []
+    },
+    {
+      "n": 106,
+      "at": "2026-08-06T14:01:00+09:00",
+      "kind": "scheduled",
+      "by": "cluster-resident (autopilot Pod)",
+      "summary": "実行役。前回の中断 PR #296（run #105 の記録専用 PR）を CI green 確認のうえ直接 merge。backlog の todo は T-0117 のみで CronJob 初回実行（2026-08-06T18:30Z）が未到来のため引き続き着手不可、blocked/needs-human 9件も前提の変化なしと確認。着手可能なタスクが無かったため journal 記録のみ。",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

- 実装・マニフェスト変更は無し。`ops/journal/2026-08.md` に run #106 として、前回の中断（PR #296）を merge したことと「着手可能なタスクが無かった」ことを記録（CHARTER §2「やることが無い起動でも journal に書いた PR を出す」）
- `ops/state.json` の `runs` に run #106 のエントリを追加
- `ops/dashboard/prs.json` を最新化（`ops/dashboard/build.py` 実行、`ops-dashboard` ブランチへも自動 push 済み）

## 検証したこと

- issue #56 の未読フィードバックなし（`last_read` 以降 2 ページ分をページネーションで機械的に確認、新規 0 件）
- 前回の中断 PR #296 は CI 6 job 全 green・`mergeable_state: clean` を確認のうえ直接 merge 済み（`356d86f`）。ブランチも GitHub 側で自動削除済み
- `ops-health-report`（`generated_at: 2026-08-06T05:00:04Z`）で autopilot 自身の heartbeat・ArgoCD 健全性に新規異常が無いことを確認（`coder`/`immich`/`vaultwarden` の Degraded は既知の T-0106 `SecretSyncedError` のみ）
- backlog の `todo` は T-0117 のみで、`kubectl get cronjob -n coder` で `coder-workspace-home-backup` の `LAST SCHEDULE` が引き続き `<none>` であることを実測し、次回実行予定（2026-08-06T18:30Z）が未到来のため着手不可と再確認した
- `blocked`/`needs-human` の残り 9 件も理由の前提が変わっていないことを確認した
- `python3 ops/validate.py` で 0 error/0 warning を確認済み

## ロールバック手順

revert すれば記録が run #105 時点相当に戻るだけで、実インフラへの影響は無い（`ops/` 配下の記録ファイルのみの変更）。

## backlog task id

無し（新規タスクの起票・実装は行っていない、記録専用の PR）