### PR TITLE
docs(ops): run #107 記録更新（着手可能タスクなし）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 297,
+      "title": "docs(ops): run #106 記録更新（着手可能タスクなし）",
+      "url": "https://github.com/hikuohiku/homelab/pull/297",
+      "mergedAt": "2026-08-06T05:03:23Z",
+      "headRefName": "autopilot/run106-nothing-actionable"
+    },
+    {
       "number": 296,
       "title": "docs(ops): run #105 記録更新（着手可能タスクなし・state.json 記録漏れ復元）",
       "url": "https://github.com/hikuohiku/homelab/pull/296",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/236",
       "mergedAt": "2026-08-05T20:26:45Z",
       "headRefName": "autopilot/T-0071-vaultwarden-restore-verify"
-    },
-    {
-      "number": 235,
-      "title": "chore(ops): run #64 の記録更新（journal/state/CHARTER/prs cache）",
-      "url": "https://github.com/hikuohiku/homelab/pull/235",
-      "mergedAt": "2026-08-05T20:19:23Z",
-      "headRefName": "autopilot/T-0071-run64-records"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3190,3 +3190,26 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   書いた PR を出す」に従う
 - 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでは同様に
   手薄になりうる
+
+## 2026-08-06 14:07 JST — run #107（実行役）
+
+- 読んだフィードバック: issue #56 の未読フィードバックなし（`last_read`
+  2026-08-06T03:19:42Z 以降、`per_page=100` で 2 ページ（100件+4件）を機械的に確認、
+  新規コメント 0 件）
+- 前回の中断を拾う: オープン PR・`autopilot/*` ブランチとも無し。run #106 が
+  前回の中断（PR #296）を merge 済みで中断なし
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T05:00:04Z`）で
+  新規異常なし。`coder`/`immich`/`vaultwarden` の Degraded は引き続き T-0106
+  （`SecretSyncedError`, 既知）のみ、`pod_issues` の restarts:19 常連も変化なし。
+  autopilot 自身の heartbeat は iteration 8 exit_code 0、`readyReplicas: 1` で異常なし
+- backlog を確認: `todo` は引き続き T-0117 のみ。`kubectl get cronjob -n coder
+  coder-workspace-home-backup` で `LAST SCHEDULE` が `<none>` のままと自分でも実測し、
+  次回実行予定（2026-08-06T18:30Z）が現在時刻（05:1x UTC）よりまだ先のため着手不可と
+  再確認。`blocked`/`needs-human` の残り 9 件も run #106 から状況が変わっていないため
+  再着手可能な部分は無いと判断した
+- `ops/inbox.md` は run #103 由来の T-0128 dashboard URL の 1 行のみで、
+  自分の作業中に新しく気づいたことは無かったため追記なし
+- やったこと: 着手可能なタスクが無かったため、実装は行わずこの journal 記録のみ。
+  CHARTER §2「やることが無い起動でも journal に書いた PR を出す」に従う
+- 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでは同様に
+  手薄になりうる

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T05:03:00Z",
+  "updated": "2026-08-06T05:07:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -1122,6 +1122,14 @@
       "kind": "scheduled",
       "by": "cluster-resident (autopilot Pod)",
       "summary": "実行役。前回の中断 PR #296（run #105 の記録専用 PR）を CI green 確認のうえ直接 merge。backlog の todo は T-0117 のみで CronJob 初回実行（2026-08-06T18:30Z）が未到来のため引き続き着手不可、blocked/needs-human 9件も前提の変化なしと確認。着手可能なタスクが無かったため journal 記録のみ。",
+      "prs": []
+    },
+    {
+      "n": 107,
+      "at": "2026-08-06T14:07:00+09:00",
+      "kind": "scheduled",
+      "by": "cluster-resident (autopilot Pod)",
+      "summary": "実行役。オープン PR・autopilot ブランチとも無く前回の中断なし。backlog の todo は T-0117 のみで CronJob 初回実行（2026-08-06T18:30Z）が未到来のため引き続き着手不可、blocked/needs-human 9件も run #106 から前提の変化なしと確認。着手可能なタスクが無かったため journal 記録のみ。",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

run #107（実行役）の記録更新のみ。コード・マニフェストの変更は無い。

## 検証したこと

- issue #56 のフィードバック未読なし（`last_read` 以降、ページネーションで機械的に確認、新規 0 件）
- オープン PR・`autopilot/*` ブランチとも無く、前回の中断なし
- `ops-health-report`（`generated_at: 2026-08-06T05:00:04Z`）で新規異常なし。既知の T-0106（`SecretSyncedError`）・restarts:19 常連のみ
- backlog の `todo` は T-0117 のみ。`kubectl get cronjob -n coder coder-workspace-home-backup` で `LAST SCHEDULE` が `<none>` のままと実測し、次回実行予定（2026-08-06T18:30Z）が未到来のため引き続き着手不可
- `blocked`/`needs-human` の残り9件も run #106 から前提の変化なし
- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 成功、`ops-dashboard` ブランチへ publish 済み

## ロールバック手順

この PR は `ops/journal/2026-08.md`・`ops/state.json`・`ops/dashboard/prs.json` の記録のみで、実インフラへの変更は無い。revert すれば記録上の履歴が1件減るだけで実害はない。

## backlog task id

なし（新規タスクの着手はこの回では無し）