### PR TITLE
docs(ops): run #108 記録更新（着手可能タスクなし）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 298,
+      "title": "docs(ops): run #107 記録更新（着手可能タスクなし）",
+      "url": "https://github.com/hikuohiku/homelab/pull/298",
+      "mergedAt": "2026-08-06T05:10:51Z",
+      "headRefName": "autopilot/run107-nothing-actionable"
+    },
+    {
       "number": 297,
       "title": "docs(ops): run #106 記録更新（着手可能タスクなし）",
       "url": "https://github.com/hikuohiku/homelab/pull/297",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/237",
       "mergedAt": "2026-08-05T20:40:11Z",
       "headRefName": "autopilot/T-0071-vaultwarden-cleanup"
-    },
-    {
-      "number": 236,
-      "title": "feat(vaultwarden): restic 復元試験用の使い捨て Job を追加する (T-0071)",
-      "url": "https://github.com/hikuohiku/homelab/pull/236",
-      "mergedAt": "2026-08-05T20:26:45Z",
-      "headRefName": "autopilot/T-0071-vaultwarden-restore-verify"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3213,3 +3213,27 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   CHARTER §2「やることが無い起動でも journal に書いた PR を出す」に従う
 - 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでは同様に
   手薄になりうる
+
+## 2026-08-06 14:14 JST — run #108（実行役）
+
+- 読んだフィードバック: issue #56 の未読フィードバックなし（`last_read`
+  2026-08-06T03:19:42Z 以降、`per_page=100` で 2 ページ（100件+4件）を機械的に確認、
+  新規コメント 0 件）
+- 前回の中断を拾う: オープン PR・`autopilot/*` ブランチとも無し。run #107 の
+  時点で中断なしと確認済みで変化なし
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T05:00:04Z`）で
+  新規異常なし。`coder`/`immich`/`vaultwarden` の Degraded は引き続き T-0106
+  （`SecretSyncedError`, 既知）のみ、`pod_issues` の restarts:19 常連も変化なし。
+  autopilot 自身の heartbeat は iteration 8 exit_code 0、`readyReplicas: 1` で異常なし
+- backlog を確認: `todo` は引き続き T-0117 のみ。`kubectl get cronjob -n coder
+  coder-workspace-home-backup` で `lastScheduleTime` が `None` のままと自分でも実測し、
+  次回実行予定（2026-08-06T18:30Z）が現在時刻（05:1x UTC）よりまだ先のため着手不可と
+  再確認。`blocked`/`needs-human` の残り 9 件（T-0028, T-0029, T-0074, T-0084, T-0106,
+  T-0107, T-0112, T-0116, T-0118, T-0120）も notes を読み直したが run #106/#107 から
+  前提の変化は無い
+- `ops/inbox.md` は run #103 由来の T-0128 dashboard URL 実測依頼の 1 行のみで、
+  自分の作業中に新しく気づいたことは無かったため追記なし
+- やったこと: 着手可能なタスクが無かったため、実装は行わずこの journal 記録のみ。
+  CHARTER §2「やることが無い起動でも journal に書いた PR を出す」に従う
+- 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでは同様に
+  手薄になりうる

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T05:07:00Z",
+  "updated": "2026-08-06T05:14:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
@@ -1130,6 +1130,14 @@
       "kind": "scheduled",
       "by": "cluster-resident (autopilot Pod)",
       "summary": "実行役。オープン PR・autopilot ブランチとも無く前回の中断なし。backlog の todo は T-0117 のみで CronJob 初回実行（2026-08-06T18:30Z）が未到来のため引き続き着手不可、blocked/needs-human 9件も run #106 から前提の変化なしと確認。着手可能なタスクが無かったため journal 記録のみ。",
+      "prs": []
+    },
+    {
+      "n": 108,
+      "at": "2026-08-06T14:14:00+09:00",
+      "kind": "scheduled",
+      "by": "cluster-resident (autopilot Pod)",
+      "summary": "実行役。オープン PR・autopilot ブランチとも無く前回の中断なし。backlog の todo は T-0117 のみで CronJob 初回実行（2026-08-06T18:30Z）が未到来のため引き続き着手不可、blocked/needs-human 9件も run #107 から前提の変化なしと確認。着手可能なタスクが無かったため journal 記録のみ。",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

run #108（実行役）の journal / state.json / dashboard PR キャッシュ (`ops/dashboard/prs.json`) 更新のみ。コード・マニフェストの変更なし。

## 検証したこと

- issue #56 の未読フィードバックなし（`last_read` 以降、ページネーションで100件+4件を機械的に確認）
- オープン PR・`autopilot/*` ブランチとも無く、前回の中断なし
- `ops-health-report`（`generated_at: 2026-08-06T05:00:04Z`）で新規異常なし。`coder`/`immich`/`vaultwarden` の Degraded は既知の T-0106（`SecretSyncedError`）のみ
- backlog の `todo` は T-0117 のみ。`kubectl get cronjob -n coder coder-workspace-home-backup` で `lastScheduleTime: None` と実測し、初回実行予定（2026-08-06T18:30Z）が未到来のため着手不可と確認
- `blocked`/`needs-human` の残り9件も前提の変化なしと確認
- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 成功、`ops-dashboard` ブランチへ publish 済み

## ロールバック手順

この PR は記録更新のみ（実インフラ・アプリへの変更なし）。revert すれば journal/state.json は直前の状態に戻る。

## backlog task id

なし（新規タスクの起票は計画役の役割。実行役はタスクを選ばず、記録のみ）