### PR TITLE
docs(ops): run #109 記録更新（計画役、T-0130/T-0131/T-0132 起票）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 130,
+  "next_id": 133,
   "updated": "2026-08-06T04:46:58Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
@@ -2448,6 +2448,69 @@
       "created": "2026-08-06",
       "pr": 287,
       "notes": "run #99: この Pod（autopilot-7786d96c58-nj7sn, 起動 2026-08-05T18:23:23Z）はロールを指定しないプロンプトを受け取っており、CHARTER §3 の計画役/実行役の判別ができない状態で稼働していたことから発覚した。merge 後、この Pod は SIGTERM を受けて終了する見込み（strategy: Recreate, terminationGracePeriodSeconds: 60s）。ops/ 記録の更新は途中で打ち切られる可能性があるため、この run はコード変更のコミットを最優先で push し、journal/state 更新も同じブランチに追加コミットしてから merge する順序で進める。 run #99 続き: PR #287 を CI green 確認後 merge した。孤立していた origin/autopilot/plan-execute-split（main との diff ゼロを確認済み）は削除した。この Pod（autopilot-7786d96c58-nj7sn）は merge 直後もまだ生きており、この記録更新自体を続けて実行できている——ArgoCD の sync 検出にはまだ数分の遅延があると見られる。次回起動（新 Pod）の heartbeat で実際に入れ替わったことを確認すること。"
+    },
+    {
+      "id": "T-0130",
+      "domain": "homelab",
+      "title": "T-0128 の dashboard 配信 URL (ops-dashboard) の実際の MagicDNS ホスト名を確認し ops/state.json に反映する",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "needs-human",
+      "priority": 45,
+      "why": "T-0128（run #100-104, #290/#293/#295）で apps/ops-dashboard/ を実装し kubectl で 2/2 Running を実機確認したが、DoD が求める『ops/state.json の dashboard.artifact_url もしくは新しいフィールドを URL に更新』だけ未達のまま run #104 が ops/inbox.md に引き継ぎを残した（計画役の run #109 がこれを拾った）。autopilot-reader ClusterRole に networking.k8s.io/ingresses の read 権限が無く `kubectl get ingress -n ops-dashboard` が Forbidden、この Pod には tailscale credential も無いため、実際の MagicDNS ホスト名を実測できない。apps/{immich,vaultwarden,dex,argocd,coder}/ingress.yaml の tls.hosts 短縮名パターンから類推すると https://ops-dashboard.tailae6c2.ts.net/ の可能性が高いが未検証",
+      "dod": "構築セッション（Coder ワークスペース、tailscale 到達可能）に issue #56 経由で ops-dashboard の実際の URL（推定: https://ops-dashboard.tailae6c2.ts.net/）への到達性を確かめてもらう。確かめられたら ops/state.json の dashboard フィールド（artifact_url をこの URL に置き換えるか、新フィールドを追加して両方残すかは実装時に判断）に反映し、CHARTER §7.1 の記述もあわせて更新する",
+      "blocked_by": null,
+      "needs_human_reason": "autopilot の ClusterRole（autopilot-reader）に ingresses の read 権限が無く Forbidden、この Pod には tailscale credential も無いため実際の MagicDNS ホスト名を実測できない。構築セッション（Coder ワークスペース、tailscale 到達可能）に issue #56 経由で https://ops-dashboard.tailae6c2.ts.net/ への到達性の実測を依頼する",
+      "refs": [
+        "ops/state.json",
+        "apps/ops-dashboard/",
+        "ops/CHARTER.md"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #109 (計画役): ops/inbox.md の引き継ぎ（run #104 が残した）を起票。恒久対応として autopilot-reader ClusterRole に ingresses read を足す案もあるが、単発の確認で足りるため、まずは構築セッションへの確認依頼で解決を図る。権限追加が必要になったら別タスクにする"
+    },
+    {
+      "id": "T-0131",
+      "domain": "homelab",
+      "title": "ops/state.json の routines / dashboard 表示が『クラウド定期実行 毎時』のまま、実際の常駐ループ（2分間隔）と乖離している",
+      "kind": "chore",
+      "risk": "low",
+      "status": "todo",
+      "priority": 20,
+      "why": "issue #56 (2026-08-05T18:32:03Z) で構築セッションから『autopilot はクラスタ内 Deployment として常駐するようになり、クラウドの routine は enabled: false にした（バックストップとして残置）』と報告されたが、ops/state.json の routines[0] には enabled 相当のフィールドが無いまま cron/cron_human（『1時間ごと（毎時19分）』）だけが残っている。ops/dashboard/build.py の cadence 表示（build.py:600, state['routines'][0]['cron_human'] をそのまま『定期実行』として人間に見せる）はこの値をそのまま使うため、ダッシュボードは実際には無効化されたクラウド routine の頻度を『今の定期実行』として表示し続けている。実際の稼働頻度は apps/autopilot/deployment.yaml の INTERVAL_SECONDS=120（2分間隔、loop.sh 既定と一致）で、ops-health-report の autopilot.heartbeat の last_start/last_end 間隔とも一致する。VISION.md は『人間への報告はダッシュボードに集約する』ことを原則としており、この乖離は CHARTER §1 の健全性基準（実態とドキュメントが乖離していない）に反する",
+      "dod": "ops/state.json の routines[0] に、無効化されたことが分かるフィールド（例: enabled: false, disabled_at, disabled_reason）を追加するか、cluster-resident loop の実際の cadence（INTERVAL_SECONDS 由来、2分間隔）を表す新しいフィールドを追加する。ops/dashboard/build.py の cadence 表示ロジックを、クラウド routine が無効な間は in-cluster loop の間隔を優先して表示するように直す（または両方を区別して表示する）。CHARTER §5.5 か VISION.md のどちらか適切な方に、クラウド routine が現在バックストップとして無効化されている事実を明記する",
+      "blocked_by": null,
+      "refs": [
+        "ops/state.json",
+        "ops/dashboard/build.py",
+        "ops/CHARTER.md",
+        "apps/autopilot/deployment.yaml"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #109 (計画役): CHARTER §3 の指示（backlog の blocked/needs-human の前提が古くないか確かめる）に沿って issue #56 の過去コメントを読み返す過程で発見。routines フィールド自体は substrate 移行後の PR 群のどれでも更新されておらず（git log 確認済み）、2026-08-05T18:32:03Z の実測報告以降ずっとこのまま。ダッシュボード（人間が朝に見る唯一の画面, CHARTER §7.1）に出る値のため優先度は中程度とした"
+    },
+    {
+      "id": "T-0132",
+      "domain": "homelab",
+      "title": "VISION.md の段階表・ops/state.json の vision_stage・CHARTER.md の自己申告が三者で食い違っている",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "todo",
+      "priority": 25,
+      "why": "CHARTER.md 冒頭は『現在の対象ドメインは homelab ひとつ（VISION 段階 2）』と明言しているが、VISION.md 自身の段階表は段階2（homelabドメインで器を安定させる）を依然『未着手』のままにしており、ops/state.json の vision_stage は 1（vision_stage_label: 器を作る）のまま（dashboard の見出しにそのまま表示される, ops/dashboard/build.py:631）。実態としては100件超のタスクが人間の介入なく完遂し、クラスタ内常駐（§5.5）・ダッシュボード自前配信（T-0127/T-0128）まで進んでおり、少なくとも段階2の一部・段階3の一部の実証は既に起きている。3ファイルが同じ事実について異なる状態を主張しているのは CHARTER §1 の健全性基準（同じ事実が2箇所に書かれていない）に反する",
+      "dod": "VISION.md の段階表・ops/state.json の vision_stage/vision_stage_label・CHARTER.md 冒頭の記述を突き合わせ、現時点で各段階のどこまでが実証済みと言えるかを根拠（完了タスク数、実測した健全性確認の継続実績など）とともに判断し、3ファイルを一致させる。VISION.md の『次のドメインの入り口』にある『段階2が済むまで手を出さない』の判断基準に影響するため、段階2を完了と見なせるかどうかは慎重に判断する（見なせないなら、何が欠けているかを VISION.md に具体的に書く）",
+      "blocked_by": null,
+      "refs": [
+        "ops/VISION.md",
+        "ops/state.json",
+        "ops/CHARTER.md",
+        "ops/dashboard/build.py"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #109 (計画役): CHARTER §3 の調査観点探しの一環で発見。判断の中身（段階2は完了と言えるか）はこちらの仕事であり人間に投げない（CHARTER §4 の『判断はこちらの仕事』）。実行役が着手する際は本文の三者を機械的に揃えるだけでなく、実際に何が達成されたか/されていないかを一度書き出してから判定すること"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 299,
+      "title": "docs(ops): run #108 記録更新（着手可能タスクなし）",
+      "url": "https://github.com/hikuohiku/homelab/pull/299",
+      "mergedAt": "2026-08-06T05:21:03Z",
+      "headRefName": "autopilot/run108-nothing-actionable"
+    },
+    {
       "number": 298,
       "title": "docs(ops): run #107 記録更新（着手可能タスクなし）",
       "url": "https://github.com/hikuohiku/homelab/pull/298",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/238",
       "mergedAt": "2026-08-05T20:48:48Z",
       "headRefName": "autopilot/T-0071-coder-postgres-restore-verify"
-    },
-    {
-      "number": 237,
-      "title": "docs(backup): vaultwarden の restic 復元試験の成功を記録し、検証用リソースを削除する (T-0071)",
-      "url": "https://github.com/hikuohiku/homelab/pull/237",
-      "mergedAt": "2026-08-05T20:40:11Z",
-      "headRefName": "autopilot/T-0071-vaultwarden-cleanup"
     }
   ]
 }

--- a/ops/inbox.md
+++ b/ops/inbox.md
@@ -7,5 +7,3 @@
 [`ops/CHARTER.md`](CHARTER.md) の §3「書く権利」。
 
 ---
-
-- T-0128 は実装・実機確認まで完了（run #103, `kubectl get pods -n ops-dashboard` で 2/2 Running）だが、DoD の「ops/state.json の dashboard.artifact_url もしくは新しいフィールドを URL に更新」だけ未了。autopilot-reader ClusterRole に `networking.k8s.io/ingresses` の read が無く `kubectl get ingress -n ops-dashboard` が Forbidden、この Pod には tailscale credential も無いため、実際の MagicDNS ホスト名を実測できない。他アプリ（immich/vaultwarden/dex/argocd/coder）の `ingress.yaml` コメントからは `ops-dashboard.tailae6c2.ts.net` の可能性が高いが未検証。構築セッション（Coder ワークスペース、tailscale 到達可能）に issue #56 経由で実測を頼むか、`autopilot-reader` ClusterRole に ingresses read を足す軽量タスクとして起票するか検討してほしい。

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3237,3 +3237,39 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   CHARTER §2「やることが無い起動でも journal に書いた PR を出す」に従う
 - 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでは同様に
   手薄になりうる
+
+## 2026-08-06 14:23 JST — run #109（計画役）
+
+- 前回の中断を拾う: PR #299（run #108 の記録用 PR）が open のまま残っていたため、
+  CI 6件 green（`mergeable_state: clean`）を確認して merge。ブランチは GitHub 側の
+  自動削除に任せた（`DELETE /git/refs` は 422、既に消えていたと見られる）
+- 読んだフィードバック: issue #56 の未読フィードバックなし（`last_read`
+  2026-08-06T03:19:42Z 以降、`per_page=100` で 2 ページ（100件+4件）を機械的に確認、
+  新規コメント 0 件）
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T05:00:04Z`）で新規異常
+  なし。`coder`/`immich`/`vaultwarden` の Degraded は引き続き T-0106 のみ、autopilot
+  自身の heartbeat も正常
+- `ops/inbox.md` を処理: run #104 が残した「T-0128 の dashboard URL が ingress read
+  権限不足で実測できない」引き継ぎを **T-0130**（needs-human）として起票し、inbox を
+  空にした。あわせて issue #56 に構築セッションへの確認依頼コメントを投稿した
+  （推定 URL: `https://ops-dashboard.tailae6c2.ts.net/`、他アプリの ingress.yaml から
+  類推）
+- backlog の棚卸し（CHARTER §3「blocked/needs-human の前提が古くないか」）: todo/blocked/
+  needs-human 全11件を読み直した。T-0028/T-0029/T-0074/T-0084/T-0106/T-0107/T-0112/
+  T-0116/T-0117/T-0118/T-0120 はいずれも前提の変化なしと確認（T-0117 は
+  `coder-workspace-home-backup` CronJob の初回実行予定 2026-08-06T18:30Z が未到来のまま）
+- 新規起票（VISION から逆算した調査、todo が実質 0 件だったため）:
+  - **T-0131**: issue #56 (2026-08-05T18:32:03Z) で「クラウド routine は
+    `enabled: false` にした（バックストップとして残置）」と報告されていたが、
+    `ops/state.json` の `routines[0]` には反映されておらず、`ops/dashboard/build.py`
+    の cadence 表示がいまだに「1時間ごと」を人間に見せている。実際の稼働間隔は
+    `apps/autopilot/deployment.yaml` の `INTERVAL_SECONDS=120`（2分）で
+    `ops-health-report` の autopilot heartbeat とも一致することを確認した
+  - **T-0132**: `CHARTER.md` は「現在 VISION 段階2」と明言する一方、`VISION.md` 自身の
+    段階表は段階2を「未着手」のままにしており、`ops/state.json` の `vision_stage` も
+    1（`器を作る`）のまま。ダッシュボードの見出しに出る値でもあり、3ファイルの主張が
+    食い違っている状態を解消するタスクとして起票した
+- やったこと: 上記の起票・inbox 処理・PR #299 の後始末・issue #56 への確認依頼投稿。
+  計画役のためコード・マニフェストの変更はしていない（`ops/` の記録のみ）
+- 次の起動へ: todo は T-0117（引き続き 2026-08-06T18:30Z 待ち）・T-0131・T-0132 の
+  3件。needs-human に T-0130 を追加（issue #56 への確認依頼を投稿済み、返信待ち）

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T05:14:00Z",
+  "updated": "2026-08-06T05:23:00Z",
   "vision_stage": 1,
   "vision_stage_label": "器を作る",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T03:19:42Z"
+    "last_read": "2026-08-06T05:23:00Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -1139,6 +1139,16 @@
       "by": "cluster-resident (autopilot Pod)",
       "summary": "実行役。オープン PR・autopilot ブランチとも無く前回の中断なし。backlog の todo は T-0117 のみで CronJob 初回実行（2026-08-06T18:30Z）が未到来のため引き続き着手不可、blocked/needs-human 9件も run #107 から前提の変化なしと確認。着手可能なタスクが無かったため journal 記録のみ。",
       "prs": []
+    },
+    {
+      "n": 109,
+      "at": "2026-08-06T14:23:00+09:00",
+      "kind": "scheduled",
+      "by": "cluster-resident (autopilot Pod)",
+      "summary": "計画役。前回の中断（PR #299, run #108 の記録用 PR）を CI green 確認のうえ merge。issue #56 に新規フィードバックなし、ops-health-report・autopilot heartbeat とも正常。ops/inbox.md の引き継ぎ（T-0128 dashboard URL 未実測）を T-0130 として起票し、issue #56 に構築セッションへの確認依頼を投稿。backlog の blocked/needs-human 全件の前提を棚卸しし変化なしと確認。新たに2件起票: T-0131（ops/state.json の routines がクラウド routine 無効化後も『1時間ごと』のまま表示され、実際の in-cluster loop の2分間隔とダッシュボード表示が乖離）、T-0132（CHARTER.md『VISION段階2』とVISION.md自身の段階表・ops/state.jsonのvision_stage=1が食い違っている）。計画役のためコード・マニフェストは変更していない",
+      "prs": [
+        299
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

計画役として run #109 分の作業を実施。**コード・マニフェストの変更なし**（`ops/` の記録のみ）。

- `ops/inbox.md` の引き継ぎ（T-0128 dashboard URL 未実測）を **T-0130**（needs-human）として起票し、inbox を空にした。issue #56 に構築セッションへの確認依頼コメントを投稿済み
- backlog の `blocked`/`needs-human`（11件）の前提が古くなっていないか棚卸し。全件で前提の変化なしと確認
- 新規起票2件:
  - **T-0131**: `ops/state.json` の `routines[0]` がクラウド routine 無効化（issue #56, 2026-08-05T18:32:03Z 報告）後も更新されておらず、ダッシュボードが実際とは異なる「1時間ごと」の定期実行頻度を表示し続けている
  - **T-0132**: `CHARTER.md`（VISION段階2と自称）・`VISION.md`（段階表は段階2を未着手のまま）・`ops/state.json`（`vision_stage: 1`）の3ファイルが同じ事実について食い違っている
- `python3 ops/dashboard/build.py` を実行し `ops-dashboard` ブランチへ最新版を publish 済み（`ops/dashboard/prs.json` キャッシュも同時に最新化）

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- 新規タスク3件とも既存 id との重複が無いことを確認（`next_id` は 133 に更新）
- issue #56 の未読フィードバックはページネーション込みで機械的に確認し 0 件
- `ops-health-report`（`generated_at: 2026-08-06T05:00:04Z`）で新規異常なし

## ロールバック手順

この PR は記録更新のみ（実インフラ・アプリへの変更なし）。revert すれば `ops/backlog.json`・`ops/state.json`・`ops/journal/2026-08.md`・`ops/inbox.md` は直前の状態に戻る。DB 等の状態を持つコンポーネントの変更は含まない。

## backlog task id

T-0130 / T-0131 / T-0132（起票のみ、実装は次の実行役）