### PR TITLE
fix(ops): dashboard の定期実行間隔表示をクラスタ内常駐の実態に合わせる (T-0131)

### DIFF
--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -530,8 +530,11 @@ upstream リポジトリのファイル（例: `deploy/crds/bundle.yaml` のよ�
 2026-08-05 17:46:27「クラスタ内にサービスを立てていい」）を受け、autopilot は `apps/autopilot/`
 （Deployment + `loop.sh` の常駐ループ、`claude -p --permission-mode bypassPermissions` を
 `INTERVAL_SECONDS` ごとに回す）に移った。**この節を読んでいる自分は、そのクラスタ内 Pod の中で
-動いている。** クラウド routine（`ops/state.json` の `routines`）は「保険」として残る想定だが、
-まだ頻度は下げられていない（着手すればできる。VISION 段階3の一部）。
+動いている。** クラウド routine（`ops/state.json` の `routines`）は 2026-08-05 に `enabled: false`
+にして無効化済み（クラスタが壊れたときのバックストップとして残置、issue #56, 2026-08-05T18:32:03Z）。
+実際の稼働間隔は `ops/state.json` の `in_cluster_loop`（`apps/autopilot/deployment.yaml` の
+`INTERVAL_SECONDS` 由来、現行 120 秒）であり、ダッシュボードの cadence 表示（`ops/dashboard/build.py`
+の `resolve_cadence()`）もこちらを優先する（T-0131, run #110）。
 
 旧サンドボックスとの違いで、他の節の前提を崩すもの:
 

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2488,7 +2488,7 @@
         "apps/autopilot/deployment.yaml"
       ],
       "created": "2026-08-06",
-      "pr": null,
+      "pr": 301,
       "notes": "run #109 (計画役): CHARTER §3 の指示（backlog の blocked/needs-human の前提が古くないか確かめる）に沿って issue #56 の過去コメントを読み返す過程で発見。routines フィールド自体は substrate 移行後の PR 群のどれでも更新されておらず（git log 確認済み）、2026-08-05T18:32:03Z の実測報告以降ずっとこのまま。ダッシュボード（人間が朝に見る唯一の画面, CHARTER §7.1）に出る値のため優先度は中程度とした。run #110 (実行役): ops/state.json の routines[0] に enabled/disabled_at/disabled_reason を追加し、新規フィールド in_cluster_loop（interval_seconds: 120, interval_human）を追加。ops/dashboard/build.py に resolve_cadence() を追加し、無効化された routine があれば in_cluster_loop を優先しつつクラウド routine をバックストップとして併記するよう修正。CHARTER §5.5 の該当箇所（『まだ頻度は下げられていない』という古い記述）を実態に合わせて訂正"
     },
     {

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2476,7 +2476,7 @@
       "title": "ops/state.json の routines / dashboard 表示が『クラウド定期実行 毎時』のまま、実際の常駐ループ（2分間隔）と乖離している",
       "kind": "chore",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 20,
       "why": "issue #56 (2026-08-05T18:32:03Z) で構築セッションから『autopilot はクラスタ内 Deployment として常駐するようになり、クラウドの routine は enabled: false にした（バックストップとして残置）』と報告されたが、ops/state.json の routines[0] には enabled 相当のフィールドが無いまま cron/cron_human（『1時間ごと（毎時19分）』）だけが残っている。ops/dashboard/build.py の cadence 表示（build.py:600, state['routines'][0]['cron_human'] をそのまま『定期実行』として人間に見せる）はこの値をそのまま使うため、ダッシュボードは実際には無効化されたクラウド routine の頻度を『今の定期実行』として表示し続けている。実際の稼働頻度は apps/autopilot/deployment.yaml の INTERVAL_SECONDS=120（2分間隔、loop.sh 既定と一致）で、ops-health-report の autopilot.heartbeat の last_start/last_end 間隔とも一致する。VISION.md は『人間への報告はダッシュボードに集約する』ことを原則としており、この乖離は CHARTER §1 の健全性基準（実態とドキュメントが乖離していない）に反する",
       "dod": "ops/state.json の routines[0] に、無効化されたことが分かるフィールド（例: enabled: false, disabled_at, disabled_reason）を追加するか、cluster-resident loop の実際の cadence（INTERVAL_SECONDS 由来、2分間隔）を表す新しいフィールドを追加する。ops/dashboard/build.py の cadence 表示ロジックを、クラウド routine が無効な間は in-cluster loop の間隔を優先して表示するように直す（または両方を区別して表示する）。CHARTER §5.5 か VISION.md のどちらか適切な方に、クラウド routine が現在バックストップとして無効化されている事実を明記する",
@@ -2489,7 +2489,7 @@
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "run #109 (計画役): CHARTER §3 の指示（backlog の blocked/needs-human の前提が古くないか確かめる）に沿って issue #56 の過去コメントを読み返す過程で発見。routines フィールド自体は substrate 移行後の PR 群のどれでも更新されておらず（git log 確認済み）、2026-08-05T18:32:03Z の実測報告以降ずっとこのまま。ダッシュボード（人間が朝に見る唯一の画面, CHARTER §7.1）に出る値のため優先度は中程度とした"
+      "notes": "run #109 (計画役): CHARTER §3 の指示（backlog の blocked/needs-human の前提が古くないか確かめる）に沿って issue #56 の過去コメントを読み返す過程で発見。routines フィールド自体は substrate 移行後の PR 群のどれでも更新されておらず（git log 確認済み）、2026-08-05T18:32:03Z の実測報告以降ずっとこのまま。ダッシュボード（人間が朝に見る唯一の画面, CHARTER §7.1）に出る値のため優先度は中程度とした。run #110 (実行役): ops/state.json の routines[0] に enabled/disabled_at/disabled_reason を追加し、新規フィールド in_cluster_loop（interval_seconds: 120, interval_human）を追加。ops/dashboard/build.py に resolve_cadence() を追加し、無効化された routine があれば in_cluster_loop を優先しつつクラウド routine をバックストップとして併記するよう修正。CHARTER §5.5 の該当箇所（『まだ頻度は下げられていない』という古い記述）を実態に合わせて訂正"
     },
     {
       "id": "T-0132",

--- a/ops/dashboard/build.py
+++ b/ops/dashboard/build.py
@@ -583,6 +583,24 @@ def render_now(prs, health, runs, cadence_min):
             f'</p>')
 
 
+def resolve_cadence(state):
+    """人間に見せる実行間隔。無効化されたクラウド routine の頻度をそのまま出さない。"""
+    routines = state.get("routines") or []
+    active = [r for r in routines if r.get("enabled", True)]
+    if active:
+        return active[0].get("cron_human") or active[0].get("cron")
+    loop_cfg = state.get("in_cluster_loop") or {}
+    cadence = loop_cfg.get("interval_human")
+    if not cadence:
+        return None
+    disabled = [r for r in routines if not r.get("enabled", True)]
+    if disabled:
+        backup = disabled[0].get("cron_human") or disabled[0].get("cron")
+        if backup:
+            cadence = f"{cadence} ・ バックストップ: {backup}"
+    return cadence
+
+
 def build() -> str:
     state = load("state.json", {}) or {}
     backlog = load("backlog.json", {"tasks": []}) or {"tasks": []}
@@ -596,8 +614,7 @@ def build() -> str:
     asks_html, n_asks = render_asks(tasks)
     auto_merged = [p for p in merged if str(p.get("headRefName", "")).startswith("autopilot/")]
     last_run = runs[-1] if runs else {}
-    routines = state.get("routines") or []
-    cadence = (routines[0].get("cron_human") or routines[0].get("cron")) if routines else None
+    cadence = resolve_cadence(state)
     fb = state.get("feedback", {}) or {}
 
     alive_tone, alive_text = "idle", "起動の記録がありません"

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 300,
+      "title": "docs(ops): run #109 記録更新（計画役、T-0130/T-0131/T-0132 起票）",
+      "url": "https://github.com/hikuohiku/homelab/pull/300",
+      "mergedAt": "2026-08-06T05:28:24Z",
+      "headRefName": "autopilot/run109-plan-T-0130-T-0131-T-0132"
+    },
+    {
       "number": 299,
       "title": "docs(ops): run #108 記録更新（着手可能タスクなし）",
       "url": "https://github.com/hikuohiku/homelab/pull/299",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/239",
       "mergedAt": "2026-08-05T20:53:33Z",
       "headRefName": "autopilot/T-0071-run67-records"
-    },
-    {
-      "number": 238,
-      "title": "feat(coder): restic 復元試験用の使い捨て Job を追加する (T-0071)",
-      "url": "https://github.com/hikuohiku/homelab/pull/238",
-      "mergedAt": "2026-08-05T20:48:48Z",
-      "headRefName": "autopilot/T-0071-coder-postgres-restore-verify"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3273,3 +3273,26 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   計画役のためコード・マニフェストの変更はしていない（`ops/` の記録のみ）
 - 次の起動へ: todo は T-0117（引き続き 2026-08-06T18:30Z 待ち）・T-0131・T-0132 の
   3件。needs-human に T-0130 を追加（issue #56 への確認依頼を投稿済み、返信待ち）
+
+## 2026-08-06 14:34 JST — run #110（実行役）
+
+- 読んだフィードバック: issue #56 の未読フィードバックなし。`per_page=100` で
+  ページネーションし 2 ページ（100件+5件）を機械的に確認。新規コメントは
+  T-0130（run #109 が投稿した構築セッションへの確認依頼）のみで、これは前回の
+  自分の投稿であり返信は無し
+- 前回の中断を拾う: オープン PR 0 件、`autopilot/*` 残りブランチ 0 件。中断なし
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T05:30:04Z`）で新規異常
+  なし。`coder`/`immich`/`vaultwarden` の Degraded は `kubectl get externalsecret`
+  で実測し、引き続き `<app>-restic-backup-credentials` の `SecretSyncedError`
+  （T-0106, 既知）のみと確認。autopilot 自身の heartbeat は iteration 12 exit_code 0、
+  `readyReplicas: 1` で異常なし
+- やったこと: **T-0131** 完遂（`ops/state.json` の `routines[0]` に
+  `enabled: false`/`disabled_at`/`disabled_reason` を追加し、実際の稼働間隔を表す
+  新フィールド `in_cluster_loop`（`interval_seconds: 120`）を追加。
+  `ops/dashboard/build.py` に `resolve_cadence()` を追加し、無効化された routine が
+  あれば `in_cluster_loop` を優先しつつクラウド routine をバックストップとして
+  併記するよう修正。`CHARTER.md` §5.5 の「まだ頻度は下げられていない」という
+  古い記述を実態（2026-08-05 に無効化済み）に合わせて訂正）
+- 見つけたこと: 特になし。`ops/inbox.md` は空のまま
+- 次の起動へ: todo は T-0117（引き続き 2026-08-06T18:30Z 待ち）・T-0132。
+  needs-human の T-0130 は issue #56 への確認依頼が返信待ちのまま

--- a/ops/state.json
+++ b/ops/state.json
@@ -19,9 +19,18 @@
       "cron_human": "1 時間ごと（毎時 19 分）",
       "model": "claude-sonnet-5",
       "url": "https://claude.ai/code/routines/trig_01LyC3zdzPCF8WLSpLpWDVsr",
-      "note": "立ち上げ期は頻度を上げて安定性を見る。落ち着いたら間隔を空ける"
+      "note": "立ち上げ期は頻度を上げて安定性を見る。落ち着いたら間隔を空ける",
+      "enabled": false,
+      "disabled_at": "2026-08-05T18:32:03Z",
+      "disabled_reason": "autopilot が autopilot namespace の Deployment として常駐するようになったため無効化。クラスタが壊れたときのバックストップとして残置（issue #56, 2026-08-05T18:32:03Z）"
     }
   ],
+  "in_cluster_loop": {
+    "substrate": "in-cluster Deployment (apps/autopilot/deployment.yaml)",
+    "interval_seconds": 120,
+    "interval_human": "2 分間隔",
+    "since": "2026-08-05"
+  },
   "runs": [
     {
       "n": 0,


### PR DESCRIPTION
## 変更点

ダッシュボード（`ops/dashboard/build.py`）の「定期実行」表示が、2026-08-05 に無効化済みのクラウド routine（`1 時間ごと（毎時 19 分）`）を表示し続けていた問題を修正した（T-0131）。

- `ops/state.json` の `routines[0]` に `enabled: false` / `disabled_at` / `disabled_reason` を追加し、クラウド routine が無効化済み（クラスタ内常駐のバックストップとして残置）であることを明示
- `ops/state.json` に新フィールド `in_cluster_loop`（`interval_seconds: 120`、`apps/autopilot/deployment.yaml` の `INTERVAL_SECONDS` 由来）を追加し、実際の稼働間隔を記録
- `ops/dashboard/build.py` に `resolve_cadence()` を追加し、有効な routine が無ければ `in_cluster_loop` を優先表示（クラウド routine はバックストップとして併記）するよう修正
- `ops/CHARTER.md` §5.5 の「まだ頻度は下げられていない」という古い記述を、実態（2026-08-05 に無効化済み）に合わせて訂正

## 検証したこと

- `python3 ops/validate.py` → `0 error, 0 warning`
- `python3 ops/dashboard/build.py` を実行し `resolve_cadence()` の出力が `2 分間隔 ・ バックストップ: 1 時間ごと（毎時 19 分）` になることを確認
- `kubectl get externalsecret -A` 等で現在のクラスタ健全性に新規異常が無いことを確認済み（本 PR の変更範囲外）

## ロールバック手順

このコミットを revert すれば `ops/state.json` / `ops/dashboard/build.py` / `ops/CHARTER.md` は元の状態に戻る。DB・スキーマの変更は無く、データを失う操作も無いため revert のみで完全に元に戻る。

## backlog task id

T-0131
