### PR TITLE
docs(ops): run #113 記録更新（着手可能タスクなし）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 303,
+      "title": "docs(ops): run #112 記録更新（着手可能タスクなし）",
+      "url": "https://github.com/hikuohiku/homelab/pull/303",
+      "mergedAt": "2026-08-06T05:53:42Z",
+      "headRefName": "autopilot/run112-nothing-actionable"
+    },
+    {
       "number": 302,
       "title": "fix(ops): VISION の段階表・state.json・CHARTER の自己申告を一致させる (T-0132)",
       "url": "https://github.com/hikuohiku/homelab/pull/302",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/242",
       "mergedAt": "2026-08-05T21:23:43Z",
       "headRefName": "autopilot/T-0027-immich-v3.1.0"
-    },
-    {
-      "number": 241,
-      "title": "feat(coder): coder を v2.34.7 → v2.35.3 (stable) に上げる (T-0023)",
-      "url": "https://github.com/hikuohiku/homelab/pull/241",
-      "mergedAt": "2026-08-05T21:10:06Z",
-      "headRefName": "autopilot/T-0023-coder-v2.35.3"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3341,3 +3341,28 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   CHARTER §2「やることが無い起動でも journal に書いた PR を出す」に従う
 - 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでは同様に
   手薄になりうる
+
+## 2026-08-06 14:55 JST — run #113（実行役）
+
+- 読んだフィードバック: issue #56 を `per_page=100` で2ページ（100件+5件）機械的に確認。
+  最新コメントは 2026-08-06T05:26:03Z（run #109 由来、T-0130 の確認依頼）で
+  `last_read`（05:49:05Z）より古く、新規の人間フィードバックなし
+- 前回の中断を拾う: オープン PR #303（run #112 の記録用 PR）が CI 6件 green
+  （`mergeable_state: clean`）で残っていたため merge。ブランチは GitHub 側の自動削除
+  済み（`DELETE /git/refs` は 422 = 既に消えていた）。他に `autopilot/*` 残りブランチなし
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T05:30:04Z`）で新規異常
+  なし。`coder`/`immich`/`vaultwarden` の Degraded は `kubectl get externalsecret`
+  で実測し、引き続き `<app>-restic-backup-credentials` の `SecretSyncedError`
+  （T-0106, 既知）のみと確認。3 namespace とも他の Pod は全て `Running`/`Completed`
+  で異常なし。autopilot 自身の heartbeat は iteration 12 exit_code 0、
+  `readyReplicas: 1` で異常なし
+- backlog を確認: `todo` は引き続き T-0117 のみ。現在時刻 05:55 UTC はまだ次回実行予定
+  （2026-08-06T18:30Z）より前のため着手不可。`blocked`/`needs-human` の残り 10 件は
+  run #109〜#112（数分〜1時間前）で直近棚卸し済みのため今回は再監査せず、変化が
+  無いことのみ確認した
+- `ops/inbox.md` は空。作業中に新しく気づいたことも無かったため追記なし
+- やったこと: 着手可能なタスクが無かったため、実装は行わずこの journal 記録のみ。
+  `python3 ops/validate.py`（0 error）・`python3 ops/dashboard/build.py`
+  （生成・`ops-dashboard` ブランチへ publish 成功）を実行
+- 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでは同様に
+  手薄になりうる

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T05:40:19Z",
+  "updated": "2026-08-06T05:55:44Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T05:49:05Z"
+    "last_read": "2026-08-06T05:55:44Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"


### PR DESCRIPTION
## 変更点

run #113（実行役）の記録更新のみ。コード・マニフェストの変更はありません。

- 前回の中断（PR #303, run #112 の記録用 PR）を CI green 確認後 merge 済み
- backlog の `todo` は T-0117 のみで、対象の `coder-workspace-home-backup` CronJob の次回実行予定（2026-08-06T18:30Z）が未到来のため引き続き着手不可
- `blocked`/`needs-human` の残り 10 件は直近（数分〜1時間前）の run #109〜#112 で棚卸し済みのため変化なしのみ確認
- クラスタ健全性（`ops-health-report`, `generated_at: 2026-08-06T05:30:04Z`）に新規異常なし。`coder`/`immich`/`vaultwarden` の Degraded は `kubectl get externalsecret` で実測し、引き続き T-0106 の `SecretSyncedError`（既知）のみと確認
- `feedback.last_read` を更新（issue #56 に新規の人間フィードバックなし）
- ダッシュボードを再生成・`ops-dashboard` ブランチへ publish 済み

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 例外なく生成・publish 成功

## ロールバック手順

このコミットを revert すれば journal/state.json/prs.json の記録が元に戻ります。DB やクラスタの状態には触れておらず、revert に伴うデータ不整合はありません。

## backlog task id

なし（記録のみ、CHARTER §2 の「やることが無い起動でも journal に書いた PR を出す」に従う）