### PR TITLE
docs(ops): run #114 記録更新（着手可能タスクなし）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 304,
+      "title": "docs(ops): run #113 記録更新（着手可能タスクなし）",
+      "url": "https://github.com/hikuohiku/homelab/pull/304",
+      "mergedAt": "2026-08-06T05:59:45Z",
+      "headRefName": "autopilot/run113-nothing-actionable"
+    },
+    {
       "number": 303,
       "title": "docs(ops): run #112 記録更新（着手可能タスクなし）",
       "url": "https://github.com/hikuohiku/homelab/pull/303",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/243",
       "mergedAt": "2026-08-05T21:28:01Z",
       "headRefName": "autopilot/T-0027-done-followup"
-    },
-    {
-      "number": 242,
-      "title": "feat(immich): server / machine-learning を v2.7.5 → v3.1.0 に上げる (T-0027)",
-      "url": "https://github.com/hikuohiku/homelab/pull/242",
-      "mergedAt": "2026-08-05T21:23:43Z",
-      "headRefName": "autopilot/T-0027-immich-v3.1.0"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3366,3 +3366,25 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   （生成・`ops-dashboard` ブランチへ publish 成功）を実行
 - 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでは同様に
   手薄になりうる
+
+## 2026-08-06 15:00 JST — run #114（実行役）
+
+- 読んだフィードバック: issue #56 を `per_page=100` で2ページ（100件+5件）機械的に確認。
+  最新コメントは 2026-08-06T05:26:03Z（run #109 由来、T-0130 の確認依頼）で
+  `last_read`（05:55:44Z）より古く、新規の人間フィードバックなし
+- 前回の中断を拾う: オープン PR #304（run #113 の記録用 PR）が CI 6件 green
+  （`mergeable_state: clean`）で残っていたため merge。ブランチは GitHub 側の自動削除
+  済み（`DELETE /git/refs` は 422 = 既に消えていた）。他に `autopilot/*` 残りブランチなし
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T06:00:04Z`）で新規異常
+  なし。`coder`/`immich`/`vaultwarden` の Degraded は引き続き `<app>-restic-backup-credentials`
+  の `SecretSyncedError`（T-0106, 既知）のみ、`pod_issues` の restarts:19 常連も変化なし。
+  autopilot 自身の heartbeat は iteration 16 exit_code 0、`readyReplicas: 1` で異常なし
+- backlog を確認: `todo` は引き続き T-0117 のみ。現在時刻 06:00 UTC はまだ次回実行予定
+  （2026-08-06T18:30Z）より前のため着手不可。`blocked`/`needs-human` の残り 10 件は
+  run #109〜#113（数分〜1時間前）で直近棚卸し済みのため今回は再監査せず、変化が
+  無いことのみ確認した
+- `ops/inbox.md` は空。作業中に新しく気づいたことも無かったため追記なし
+- やったこと: 着手可能なタスクが無かったため、実装は行わずこの journal 記録のみ。
+  `python3 ops/validate.py`（0 error）を実行
+- 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでは同様に
+  手薄になりうる

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T05:55:44Z",
+  "updated": "2026-08-06T06:01:34Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T05:55:44Z"
+    "last_read": "2026-08-06T06:01:34Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"


### PR DESCRIPTION
## 変更点

run #114（実行役）の記録更新のみ。コード・マニフェストの変更はありません。

- 前回の中断（PR #304, run #113 の記録用 PR）を CI green 確認後 merge 済み
- backlog の `todo` は T-0117 のみで、対象の `coder-workspace-home-backup` CronJob の次回実行予定（2026-08-06T18:30Z）が未到来のため引き続き着手不可
- `blocked`/`needs-human` の残り 10 件は直近（数分〜1時間前）の run #109〜#113 で棚卸し済みのため今回は変化なしのみ確認
- クラスタ健全性（`ops-health-report`, `generated_at: 2026-08-06T06:00:04Z`）に新規異常なし。`coder`/`immich`/`vaultwarden` の Degraded は引き続き T-0106 の `SecretSyncedError`（既知）のみと確認
- `feedback.last_read` を更新（issue #56 に新規の人間フィードバックなし）
- ダッシュボードを再生成・`ops-dashboard` ブランチへ publish 済み

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 例外なく生成・publish 成功

## ロールバック手順

このコミットを revert すれば journal/state.json/prs.json の記録が元に戻ります。DB やクラスタの状態には触れておらず、revert に伴うデータ不整合はありません。

## backlog task id

なし（記録のみ、CHARTER §2 の「やることが無い起動でも journal に書いた PR を出す」に従う）