### PR TITLE
docs(ops): run #116 記録更新（着手可能タスクなし）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 306,
+      "title": "docs(ops): T-0112 の未投稿だった構築セッション依頼を issue #56 に投稿",
+      "url": "https://github.com/hikuohiku/homelab/pull/306",
+      "mergedAt": "2026-08-06T06:14:01Z",
+      "headRefName": "autopilot/T-0112-post-pending-ask"
+    },
+    {
       "number": 305,
       "title": "docs(ops): run #114 記録更新（着手可能タスクなし）",
       "url": "https://github.com/hikuohiku/homelab/pull/305",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/246",
       "mergedAt": "2026-08-05T21:57:25Z",
       "headRefName": "autopilot/T-0029-run72-records"
-    },
-    {
-      "number": 244,
-      "title": "feat(immich): postgres (cloudnative-vectorchord) を 16.9-0.4.3 → 16.14-1.1.1 に上げる (T-0029)",
-      "url": "https://github.com/hikuohiku/homelab/pull/244",
-      "mergedAt": "2026-08-05T21:45:46Z",
-      "headRefName": "autopilot/T-0029-immich-vchord-upgrade"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3424,3 +3424,20 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py`（0 error）を実行
 - 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。T-0112 は issue #56 への
   返信待ち（今回初めて実際に依頼が届いた状態）
+
+## 2026-08-06 15:17 JST — run #116（実行役）
+
+- 前回の中断を拾う: オープン PR なし。`git branch -r` に `autopilot/*` の残りブランチなし
+- 読んだフィードバック: issue #56 を `per_page=100` で2ページ（100件+6件）機械的に確認。
+  最新コメントは 2026-08-06T06:10:37Z で `last_read`（06:10:58Z）より古く、新規の人間
+  フィードバックなし
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T06:00:04Z`）で新規異常なし。
+  `coder`/`immich`/`vaultwarden` の Degraded は引き続き `<app>-restic-backup-credentials`
+  の `SecretSyncedError`（T-0106, 既知）のみ、`pod_issues` の restarts:19 常連も変化なし。
+  autopilot 自身の heartbeat は iteration 16 exit_code 0、`readyReplicas: 1` で異常なし
+- backlog を確認: `todo` は引き続き T-0117 のみ。現在時刻 06:17 UTC はまだ次回実行予定
+  （2026-08-06T18:30Z）より前のため着手不可
+- `ops/inbox.md` は空。作業中に新しく気づいたことも無かったため追記なし
+- やったこと: 着手可能なタスクが無かったため、実装は行わずこの journal 記録のみ。
+  `python3 ops/validate.py`（0 error）を実行
+- 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる


### PR DESCRIPTION
## 変更点

run #116（実行役）の journal 記録のみ。実装変更なし。

## 検証したこと

- フィードバック: issue #56 を per_page=100 で2ページ確認、新規コメントなし
- 前回の中断: オープン PR / autopilot/* ブランチともになし
- 健全性: ops-health-report（generated_at 2026-08-06T06:00:04Z）に新規異常なし。coder/immich/vaultwarden の Degraded は T-0106（既知の SecretSyncedError）のみ
- backlog: todo は T-0117 のみで、次回実行予定 2026-08-06T18:30Z より前のため未着手
- ops/inbox.md: 空
- `python3 ops/validate.py` 0 error

## ロールバック手順

journal と PR キャッシュの追記のみのため、revert しても実害はない

## backlog task id

なし（記録のみ、新規タスク起票は計画役の仕事のため実行役では行わない）