### PR TITLE
docs(ops): run #117 記録更新（着手可能タスクなし）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 307,
+      "title": "docs(ops): run #116 記録更新（着手可能タスクなし）",
+      "url": "https://github.com/hikuohiku/homelab/pull/307",
+      "mergedAt": "2026-08-06T06:22:18Z",
+      "headRefName": "autopilot/run116-nothing-actionable"
+    },
+    {
       "number": 306,
       "title": "docs(ops): T-0112 の未投稿だった構築セッション依頼を issue #56 に投稿",
       "url": "https://github.com/hikuohiku/homelab/pull/306",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/247",
       "mergedAt": "2026-08-05T22:03:08Z",
       "headRefName": "autopilot/T-0029-rollback"
-    },
-    {
-      "number": 246,
-      "title": "chore(ops): T-0029 の PR #244 merge を記録し、ブランチ分岐タイミングの教訓を CHARTER に追記する（run #72）",
-      "url": "https://github.com/hikuohiku/homelab/pull/246",
-      "mergedAt": "2026-08-05T21:57:25Z",
-      "headRefName": "autopilot/T-0029-run72-records"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3441,3 +3441,22 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - やったこと: 着手可能なタスクが無かったため、実装は行わずこの journal 記録のみ。
   `python3 ops/validate.py`（0 error）を実行
 - 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる
+
+## 2026-08-06 15:22 JST — run #117（実行役）
+
+- 前回の中断を拾う: オープン PR #307（run #116 の記録用 PR）が CI 6件 green
+  （`mergeable_state: clean`）で残っていたため merge。ブランチは GitHub 側の自動削除済み
+  （`DELETE /git/refs` は 422）。他に `autopilot/*` 残りブランチなし
+- 読んだフィードバック: issue #56 を `per_page=100` で2ページ（100件+6件）機械的に確認。
+  `last_read`（2026-08-06T06:10:58Z）以降の新規コメント無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T06:00:04Z`、更新なし）で新規異常
+  なし。`coder`/`immich`/`vaultwarden` の Degraded は引き続き `<app>-restic-backup-credentials`
+  の `SecretSyncedError`（T-0106, 既知）のみ、`pod_issues` の restarts:19 常連も変化なし。
+  autopilot 自身の heartbeat は iteration 16 exit_code 0、`readyReplicas: 1` で異常なし
+- backlog を確認: `todo` は引き続き T-0117 のみ。現在時刻 06:22 UTC はまだ次回実行予定
+  （2026-08-06T18:30Z）より前のため着手不可。`blocked`/`needs-human` 10 件は run #115 で
+  棚卸し済み（依頼の投稿有無まで確認済み）のため今回は再監査せず、変化が無いことのみ確認した
+- `ops/inbox.md` は空。作業中に新しく気づいたことも無かったため追記なし
+- やったこと: 着手可能なタスクが無かったため、実装は行わずこの journal 記録のみ。
+  `python3 ops/validate.py`（0 error）を実行
+- 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでは同様に手薄になりうる

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T06:10:58Z",
+  "updated": "2026-08-06T06:22:39Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T06:10:58Z"
+    "last_read": "2026-08-06T06:22:39Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -1158,6 +1158,14 @@
       "prs": [
         299
       ]
+    },
+    {
+      "n": 110,
+      "at": "2026-08-06T15:22:00+09:00",
+      "kind": "scheduled",
+      "by": "cluster-resident (autopilot Pod)",
+      "summary": "実行役（journal run #117）。前回の中断（PR #307, run #116 の記録用 PR）を CI green 確認のうえ merge。issue #56 に新規フィードバックなし、ops-health-report・autopilot heartbeat とも正常。backlog の todo は T-0117 のみで CronJob 初回実行（2026-08-06T18:30Z）が未到来のため引き続き着手不可、blocked/needs-human 10件も run #115 の棚卸しから前提の変化なし。着手可能なタスクが無かったため journal 記録のみ。",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

run #117（実行役）の journal 記録のみ。実装変更なし。

## 検証したこと

- フィードバック: issue #56 を per_page=100 で2ページ確認、新規コメントなし
- 前回の中断: オープン PR #307（run #116 の記録用 PR）を CI green 確認のうえ merge済み
- 健全性: ops-health-report（generated_at 2026-08-06T06:00:04Z）に新規異常なし。coder/immich/vaultwarden の Degraded は T-0106（既知の SecretSyncedError）のみ、pod_issues の restarts:19 常連も変化なし
- backlog: todo は T-0117 のみで、次回実行予定 2026-08-06T18:30Z より前のため未着手。blocked/needs-human 10件は run #115 で棚卸し済みのため前提の変化のみ確認
- ops/inbox.md: 空
- `python3 ops/validate.py` 0 error

## ロールバック手順

journal と state.json・PR キャッシュの追記のみのため、revert しても実害はない

## backlog task id

なし（記録のみ、新規タスク起票は計画役の仕事のため実行役では行わない）