### PR TITLE
docs(ops): run #118 記録更新（着手可能タスクなし）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 308,
+      "title": "docs(ops): run #117 記録更新（着手可能タスクなし）",
+      "url": "https://github.com/hikuohiku/homelab/pull/308",
+      "mergedAt": "2026-08-06T06:25:29Z",
+      "headRefName": "autopilot/run117-nothing-actionable"
+    },
+    {
       "number": 307,
       "title": "docs(ops): run #116 記録更新（着手可能タスクなし）",
       "url": "https://github.com/hikuohiku/homelab/pull/307",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/248",
       "mergedAt": "2026-08-05T22:07:30Z",
       "headRefName": "autopilot/T-0029-recovery-records"
-    },
-    {
-      "number": 247,
-      "title": "fix(immich): postgres を vchord 16.14-1.1.1 → 16.9-0.4.3 に revert する (T-0029)",
-      "url": "https://github.com/hikuohiku/homelab/pull/247",
-      "mergedAt": "2026-08-05T22:03:08Z",
-      "headRefName": "autopilot/T-0029-rollback"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3460,3 +3460,21 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - やったこと: 着手可能なタスクが無かったため、実装は行わずこの journal 記録のみ。
   `python3 ops/validate.py`（0 error）を実行
 - 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでは同様に手薄になりうる
+
+## 2026-08-06 15:28 JST — run #118（実行役）
+
+- 前回の中断を拾う: オープン PR なし。`git branch -r` に `autopilot/*` の残りブランチなし
+- 読んだフィードバック: issue #56 を `per_page=100` で確認（100件+6件）。`last_read`
+  （2026-08-06T06:22:39Z）以降の新規コメント無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T06:00:04Z`、更新なし）で新規異常
+  なし。`coder`/`immich`/`vaultwarden` の Degraded は引き続き `<app>-restic-backup-credentials`
+  の `SecretSyncedError`（T-0106, 既知）のみ、`pod_issues` の restarts:19 常連も変化なし。
+  autopilot 自身の heartbeat は iteration 16 exit_code 0、`readyReplicas: 1` で異常なし
+  （`last_start` iteration 17 が進行中）
+- backlog を確認: `todo` は引き続き T-0117 のみ。現在時刻 06:28 UTC はまだ次回実行予定
+  （2026-08-06T18:30Z）より前のため着手不可。`blocked`/`needs-human` 10 件は run #115 で
+  棚卸し済み（依頼の投稿有無まで確認済み）のため今回は再監査せず、変化が無いことのみ確認した
+- `ops/inbox.md` は空。作業中に新しく気づいたことも無かったため追記なし
+- やったこと: 着手可能なタスクが無かったため、実装は行わずこの journal 記録のみ。
+  `python3 ops/validate.py`（0 error）を実行
+- 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでは同様に手薄になりうる

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T06:22:39Z",
+  "updated": "2026-08-06T06:28:24Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T06:22:39Z"
+    "last_read": "2026-08-06T06:28:24Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -1165,6 +1165,14 @@
       "kind": "scheduled",
       "by": "cluster-resident (autopilot Pod)",
       "summary": "実行役（journal run #117）。前回の中断（PR #307, run #116 の記録用 PR）を CI green 確認のうえ merge。issue #56 に新規フィードバックなし、ops-health-report・autopilot heartbeat とも正常。backlog の todo は T-0117 のみで CronJob 初回実行（2026-08-06T18:30Z）が未到来のため引き続き着手不可、blocked/needs-human 10件も run #115 の棚卸しから前提の変化なし。着手可能なタスクが無かったため journal 記録のみ。",
+      "prs": []
+    },
+    {
+      "n": 111,
+      "at": "2026-08-06T15:28:00+09:00",
+      "kind": "scheduled",
+      "by": "cluster-resident (autopilot Pod)",
+      "summary": "実行役（journal run #118）。前回の中断（PR #308, run #117 の記録用 PR）は既に merge 済みでオープン PR・autopilot/* ブランチ残りなし。issue #56 に新規フィードバックなし、ops-health-report・autopilot heartbeat とも正常。backlog の todo は T-0117 のみで CronJob 初回実行（2026-08-06T18:30Z）が未到来のため引き続き着手不可、blocked/needs-human 10件も run #115 の棚卸しから前提の変化なし。着手可能なタスクが無かったため journal 記録のみ。",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

着手可能なタスクが無かった起動の journal / state.json 記録のみ。コード・マニフェストの変更なし。

- backlog の `todo` は T-0117（coder workspace home backup 初回実行確認）のみで、対象 CronJob の次回実行予定 2026-08-06T18:30Z がまだ到来していないため着手不可
- `blocked`/`needs-human` 10件は run #115 で棚卸し済みのため前提の変化なしのみ確認
- issue #56 に新規フィードバックなし
- `ops-health-report` / autopilot heartbeat とも新規異常なし

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 生成成功、`ops-dashboard` ブランチへ publish 成功

## ロールバック手順

revert すれば journal/state.json の記録が元に戻るのみ。実インフラへの影響なし。

## backlog task id

なし（記録のみ、CHARTER §2 の「やることが無い起動でも journal に書いた PR を出す」に基づく）