### PR TITLE
docs(ops): run #120 記録更新（着手可能タスクなし）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 310,
+      "title": "docs(ops): run #119 記録更新（着手可能タスクなし）",
+      "url": "https://github.com/hikuohiku/homelab/pull/310",
+      "mergedAt": "2026-08-06T06:39:02Z",
+      "headRefName": "autopilot/run119-nothing-actionable"
+    },
+    {
       "number": 309,
       "title": "docs(ops): run #118 記録更新（着手可能タスクなし）",
       "url": "https://github.com/hikuohiku/homelab/pull/309",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/250",
       "mergedAt": "2026-08-05T22:36:31Z",
       "headRefName": "autopilot/T-0111-postgres-bootstrap-verify"
-    },
-    {
-      "number": 249,
-      "title": "chore(ops): T-0029 の再着手前提を調べ、initdb ブートストラップ消失を T-0111 として起票する（run #73）",
-      "url": "https://github.com/hikuohiku/homelab/pull/249",
-      "mergedAt": "2026-08-05T22:21:21Z",
-      "headRefName": "autopilot/T-0111-records"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3496,3 +3496,23 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - やったこと: 着手可能なタスクが無かったため、実装は行わずこの journal 記録のみ。
   `python3 ops/validate.py`（0 error）を実行
 - 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでは同様に手薄になりうる
+
+## 2026-08-06 15:40 JST — run #120（実行役）
+
+- 前回の中断を拾う: オープン PR #310（run #119 の記録用 PR）が CI 6件 green
+  （`mergeable_state: clean`）で残っていたため merge。ブランチは GitHub 側の自動削除
+  待ちだったため `DELETE /git/refs` は 422（既に削除済み）
+- 読んだフィードバック: issue #56 を `per_page=100` で2ページ（100件+6件）機械的に確認。
+  `last_read`（2026-08-06T06:28:24Z）以降の新規コメント無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T06:30:04Z`、更新なし）で新規異常
+  なし。`coder`/`immich`/`vaultwarden` の Degraded は引き続き `<app>-restic-backup-credentials`
+  の `SecretSyncedError`（T-0106, 既知）のみ、`pod_issues` の restarts:19 常連も変化なし。
+  autopilot 自身の heartbeat は iteration 20 exit_code 0、`readyReplicas: 1` で異常なし
+  （`last_start` iteration 21 が進行中）
+- backlog を確認: `todo` は引き続き T-0117 のみ。現在時刻 06:40 UTC はまだ次回実行予定
+  （2026-08-06T18:30Z）より前のため着手不可。`blocked`/`needs-human` 10 件は run #115 で
+  棚卸し済み（依頼の投稿有無まで確認済み）のため今回は再監査せず、変化が無いことのみ確認した
+- `ops/inbox.md` は空。作業中に新しく気づいたことも無かったため追記なし
+- やったこと: 着手可能なタスクが無かったため、実装は行わずこの journal 記録のみ。
+  `python3 ops/validate.py`（0 error）を実行
+- 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでは同様に手薄になりうる

--- a/ops/state.json
+++ b/ops/state.json
@@ -1182,6 +1182,14 @@
       "by": "cluster-resident (autopilot Pod)",
       "summary": "実行役（journal run #119）。オープン PR・autopilot/* ブランチとも無く前回の中断なし。issue #56 に新規フィードバックなし、ops-health-report・autopilot heartbeat とも正常。backlog の todo は T-0117 のみで CronJob 初回実行（2026-08-06T18:30Z）が未到来のため引き続き着手不可、blocked/needs-human 10件も run #115 の棚卸しから前提の変化なし。着手可能なタスクが無かったため journal 記録のみ。",
       "prs": []
+    },
+    {
+      "n": 113,
+      "at": "2026-08-06T15:40:00+09:00",
+      "kind": "scheduled",
+      "by": "cluster-resident (autopilot Pod)",
+      "summary": "実行役（journal run #120）。前回の中断（PR #310, run #119 の記録用 PR）は merge 済み、autopilot/* ブランチ残りなし。issue #56 に新規フィードバックなし、ops-health-report・autopilot heartbeat とも正常。backlog の todo は T-0117 のみで CronJob 初回実行（2026-08-06T18:30Z）が未到来のため引き続き着手不可、blocked/needs-human 10件も run #115 の棚卸しから前提の変化なし。着手可能なタスクが無かったため journal 記録のみ。",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

実行役として1イテレーション分の作業を行ったが、着手可能なタスクが無かったため journal/state.json の記録更新のみ。

- 前回の中断: オープン PR #310（run #119 の記録用 PR）が CI green で残っていたため merge 済み。`autopilot/*` の残りブランチなし
- issue #56 に新規フィードバックなし（`per_page=100` で2ページ、106件全件確認、`last_read` 以降の新規コメント無し）
- `ops-health-report`（`generated_at: 2026-08-06T06:30:04Z`）で新規異常なし。`coder`/`immich`/`vaultwarden` の Degraded は既知の T-0106（`SecretSyncedError`）のみ、`pod_issues` の restarts:19 常連も変化なし
- autopilot 自身の heartbeat（iteration 20, exit_code 0, `readyReplicas: 1`）も異常なし
- `ops/backlog.json` の `todo` は T-0117 のみで、CronJob 初回実行予定（2026-08-06T18:30Z）がまだ先のため着手不可。`blocked`/`needs-human` 10件は直近の run #115 の棚卸しから前提の変化なし
- `ops/inbox.md` は空

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 生成成功、`ops-dashboard` ブランチへ publish 成功

## ロールバック手順

記録用の変更のみ（journal / state.json / dashboard の PR キャッシュ）。revert すれば元に戻る。実インフラへの影響なし。

## backlog task id

なし（記録のみ）