### PR TITLE
docs(ops): run #121 記録更新（PR #311 拾い、T-0133 起票）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 133,
-  "updated": "2026-08-06T06:10:58Z",
+  "next_id": 134,
+  "updated": "2026-08-06T06:49:21Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2511,6 +2511,26 @@
       "created": "2026-08-06",
       "pr": 302,
       "notes": "run #109 (計画役): CHARTER §3 の調査観点探しの一環で発見。判断の中身（段階2は完了と言えるか）はこちらの仕事であり人間に投げない（CHARTER §4 の『判断はこちらの仕事』）。実行役が着手する際は本文の三者を機械的に揃えるだけでなく、実際に何が達成されたか/されていないかを一度書き出してから判定すること。run #111 (実行役): 段階2を『完了』とは判定しなかった。in-cluster 常駐（§5.5）開始から2026-08-06時点でまだ1〜2日しか経っておらず、『成果が出続けることを実証する』の実績期間が無い。VISION.md の段階表を『完了/進行中/未着手』の3値に揃え、段階1=完了・段階2=進行中とし、段階2の完了基準（4週間程度の継続稼働・CHARTER §9 相当の事態が起きていないこと・人間の関与が2種類に収まり続けていること）を明文化した。ops/state.json の vision_stage を 1→2、vision_stage_label を『器を安定させる』に更新。CHARTER.md 冒頭に『進行中。完了基準は VISION.md 参照』を追記して3ファイルを一致させた"
+    },
+    {
+      "id": "T-0133",
+      "domain": "homelab",
+      "title": "backlog タスクに時刻ゲート（not_before）を持たせ、loop.sh の actionable 判定が『時刻待ちの todo』を実行役に空振りさせないようにする",
+      "kind": "feature",
+      "risk": "medium",
+      "status": "todo",
+      "priority": 35,
+      "why": "T-0117 は CronJob の初回実行時刻（2026-08-06T18:30Z）まで着手できない todo だが、`apps/autopilot/loop.sh` の actionable 判定（status が todo/in_progress の件数のみを見る python スニペット）はこの時刻ゲートを知らない。backlog の todo が T-0117 だけの間、実行役に倒れた起動は毎回 issue #56 の全件スキャン・health report 取得・journal 記録だけを行って終わる（run #116〜#120 で実測、INTERVAL_SECONDS=120 なので 18:30Z まで実測時点で残り約12時間・350回超が同型になる見込み）。T-0117 のような『時刻が来るまで着手できない todo』はこれまで notes の自由記述でしか表現されておらず機械可読ではなかったため、loop.sh 側で区別できなかった",
+      "dod": "backlog タスクスキーマに任意フィールド `not_before`（ISO8601 文字列、着手可能になる時刻）を追加し、`ops/validate.py` に形式検証（パース可能な ISO8601 であること）を足す。`loop.sh` の actionable 判定を、`not_before` が現在時刻より未来のタスクを除外するように直す（`not_before` の値が壊れている・パースできない場合は安全側＝そのタスクを actionable 扱いのまま、つまり現状と同じ挙動にフォールバックし、role 判定用スニペット全体が例外で落ちて `[ \"\" -eq 0 ]` のような不定形の比較にならないようにする）。既存の T-0117 に `not_before: \"2026-08-06T18:30:00Z\"` を付与し、backlog の todo がこのタスクのみの間は actionable=0 になり計画役に倒れることを次回起動のログ（`role=plan actionable=0`）で確認する。loop.sh の変更は Pod 起動時に一度だけ読み込まれ、変更を反映するには Pod の再作成が要る（ファイル冒頭のコメント参照）ため、PR 本文にその旨と反映タイミングを明記する。自分自身の運用ループ（CHARTER §4 の『自分や人間がこの homelab を観測・操作する経路』に該当）を変更するため、actionable の計算ロジックの単体的な妥当性（真偽の境界条件: not_before なし/過去/未来/壊れた文字列の4パターン）を PR 本文に書き出してから着手する",
+      "blocked_by": null,
+      "refs": [
+        "apps/autopilot/loop.sh",
+        "ops/validate.py",
+        "ops/backlog.json"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #120（計画役）: T-0117 が時刻待ちの todo であるにも関わらず loop.sh の actionable 判定がそれを考慮せず、実行役の起動を12時間規模で空振りさせている実態を journal（run #116〜#119）から発見して起票。VISION §『判断に迷ったときの原則』の『器を太らせる前に、器を使い切る』との整合は検討済み——既存の next_review フィールドは recurring タスクの再オープン判定にのみ使われており（T-0012）、todo タスクの着手可否そのものを表す用途では使われていないため、新規フィールドが必要と判断した"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 311,
+      "title": "docs(ops): run #120 記録更新（着手可能タスクなし）",
+      "url": "https://github.com/hikuohiku/homelab/pull/311",
+      "mergedAt": "2026-08-06T06:50:15Z",
+      "headRefName": "autopilot/run120-nothing-actionable"
+    },
+    {
       "number": 310,
       "title": "docs(ops): run #119 記録更新（着手可能タスクなし）",
       "url": "https://github.com/hikuohiku/homelab/pull/310",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/251",
       "mergedAt": "2026-08-05T22:41:13Z",
       "headRefName": "autopilot/T-0111-socket-dir-fix"
-    },
-    {
-      "number": 250,
-      "title": "feat(immich): T-0111 postgres 手動 initdb ブートストラップの検証 Job (16.14-1.1.1)",
-      "url": "https://github.com/hikuohiku/homelab/pull/250",
-      "mergedAt": "2026-08-05T22:36:31Z",
-      "headRefName": "autopilot/T-0111-postgres-bootstrap-verify"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3516,3 +3516,42 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - やったこと: 着手可能なタスクが無かったため、実装は行わずこの journal 記録のみ。
   `python3 ops/validate.py`（0 error）を実行
 - 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでは同様に手薄になりうる
+
+## 2026-08-06 15:49 JST — run #121（計画役）
+
+- 前回の中断を拾う: オープン PR #311（別セッションの run #120, 実行役の記録用 PR）が
+  CI 6件 green・`mergeable_state: clean` で残っていたため merge（e09d92f）。`autopilot/*`
+  残りブランチなし
+- 読んだフィードバック: issue #56 を `per_page=100` で2ページ機械的に確認。`last_read`
+  以降の新規コメント無し
+- `ops/inbox.md`: 空。変換すべき引き継ぎ無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T06:30:04Z`）で新規異常なし。
+  `coder`/`immich`/`vaultwarden` の Degraded は引き続き `<app>-restic-backup-credentials` の
+  `SecretSyncedError`（T-0106, 既知）のみ、`pod_issues` の restarts:19 常連も変化なし。
+  autopilot 自身の heartbeat は異常なし
+- backlog 棚卸し: `todo` は T-0117 のみ（次回実行予定 2026-08-06T18:30Z 待ち、未到来）。
+  `blocked`/`needs-human` 10件は run #115 の棚卸しから前提の変化なし（今回は再監査していない）
+- T-0084（履歴ファイルサイズが GitHub Contents API 上限に近づいていないか）の `blocked_by`
+  （数日分蓄積するまで意味が無い）を実データで確認: `ops-health-report` ブランチの
+  `ops/health/history/` に 2026-08-05.jsonl（32件・約330KB、08:00〜23:30の部分日）と
+  2026-08-06.jsonl（14件・約169KB、進行中）が存在。1エントリ平均約1万〜1.1万バイトで
+  緩やかに増加傾向（機能追加に伴う想定内）だが、1日48回分に外挿しても約550KB程度で
+  1MB上限の約53%と見積もられ、直近で上限に達する兆候は無い。ただし `next_review`
+  （2026-08-08）が示す「数日分」にはまだ届いていない（実質1.5日分）ため、status は
+  blocked のまま据え置いた。次回 next_review 到達時にこの見積もりを引き継げるよう notes は
+  更新せず、この journal に事実として残す
+- 見つけたこと・起票: `ops/backlog.json` の `todo` が T-0117 のみで、かつ T-0117 は
+  2026-08-06T18:30Z まで着手不可なのに、`apps/autopilot/loop.sh` の actionable 判定は
+  この時刻ゲートを知らず「todo が1件ある」= actionable として実行役に倒し続けている。
+  run #116〜#120（実行役、2分間隔）はいずれも issue #56 の全件スキャン・health report
+  取得・journal 記録だけで終わっており、T-0117 の解禁（18:30Z）まで残り約12時間・
+  350回超がこの空振りパターンで続く見込みと判明した。backlog タスクに機械可読な時刻ゲート
+  （`not_before`）が無く、これまで notes の自由記述でしか表現されていなかったのが原因。
+  T-0133 として起票し、loop.sh の actionable 判定・`ops/validate.py`・T-0117 自身への
+  `not_before` 付与までを DoD に含めた（自分自身の運用ループの変更のため risk は medium とし、
+  境界条件を PR 本文に書き出してから着手するよう指示を添えた）
+- やったこと: PR #311 の merge、T-0084 の実データ確認（status 変更なし）、T-0133 の起票、
+  backlog/journal/state.json の更新
+- `python3 ops/validate.py`（0 error）を実行
+- 次の起動へ: T-0133（priority 35）は T-0117（priority 41）より優先度が高いため、次の実行役は
+  T-0133 に着手できる。T-0117 は引き続き 2026-08-06T18:30Z 以降に着手可能

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T06:34:03Z",
+  "updated": "2026-08-06T06:49:21Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T06:34:03Z"
+    "last_read": "2026-08-06T06:49:21Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -1189,6 +1189,14 @@
       "kind": "scheduled",
       "by": "cluster-resident (autopilot Pod)",
       "summary": "実行役（journal run #120）。前回の中断（PR #310, run #119 の記録用 PR）は merge 済み、autopilot/* ブランチ残りなし。issue #56 に新規フィードバックなし、ops-health-report・autopilot heartbeat とも正常。backlog の todo は T-0117 のみで CronJob 初回実行（2026-08-06T18:30Z）が未到来のため引き続き着手不可、blocked/needs-human 10件も run #115 の棚卸しから前提の変化なし。着手可能なタスクが無かったため journal 記録のみ。",
+      "prs": []
+    },
+    {
+      "n": 114,
+      "at": "2026-08-06T15:49:00+09:00",
+      "kind": "scheduled",
+      "by": "cluster-resident (autopilot Pod)",
+      "summary": "計画役（journal run #121）。前回の中断（PR #311, run #120 の記録用 PR）を CI green 確認のうえ merge。issue #56 に新規フィードバックなし。T-0084 の blocked_by（履歴が数日分蓄積するまで意味が無い）を ops-health-report ブランチの実データ（2日分・約330KB/169KB、1日分に外挿して約550KB≒1MB上限の53%）で確認したが、next_review（2026-08-08）が示す期間にはまだ届いていないため status は据え置いた。backlog の todo が T-0117（時刻ゲート待ち）のみで、loop.sh の actionable 判定がその時刻ゲートを知らないために実行役が12時間規模で空振りし続ける構造的な無駄を発見し、T-0133（priority 35, not_before フィールドの導入）として起票した。",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

計画役（`prompt-plan.md`）として1イテレーション分を実施した、`ops/` 配下の記録のみの PR。

- 前回の中断（PR #311, 別セッションの実行役が残した記録更新 PR）を CI green・
  `mergeable_state: clean` を確認のうえ merge 済み（e09d92f）
- issue #56 のフィードバックを機械的に全件確認したが新規コメント無し
- `ops-health-report` ブランチで異常なし（既知の Degraded 3件・restarts:19 常連のみ）
- T-0084（`ops/health/history/*.jsonl` のファイルサイズが GitHub Contents API の
  上限に近づいていないか）の `blocked_by` を実データで再確認: 2日分の履歴（約330KB・
  169KB）から1日分に外挿すると約550KB、1MB上限の約53%。直近で上限に達する兆候は無いが、
  `next_review`（2026-08-08）が想定する「数日分」にはまだ届いていないため status は
  据え置いた
- **T-0133 を新規起票**: backlog の `todo` が時刻ゲート待ちの T-0117（次回実行可能
  2026-08-06T18:30Z）のみの間、`apps/autopilot/loop.sh` の actionable 判定がこの
  時刻ゲートを考慮せず、実行役の起動を空振りさせ続けている（run #116〜#120 で実測、
  2分間隔・残り約12時間で350回超がこのパターンになる見込み）。backlog タスクに
  機械可読な `not_before` フィールドを導入し、loop.sh の役選択がそれを考慮するように
  する提案。自分自身の運用ループの変更のため risk は medium とした

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 生成成功、`ops-dashboard` ブランチへ publish 済み
- 本 PR に含まれるのは `ops/` 配下の記録のみ（backlog.json / journal / state.json /
  dashboard/prs.json キャッシュ）。マニフェスト・コードの変更は無し

## ロールバック手順

`ops/` の記録のみの変更のため、revert すれば元に戻る。インフラへの影響は無い。

## backlog task id

T-0133（新規起票、次回実行役が着手可能）