### PR TITLE
feat(autopilot): backlog タスクに時刻ゲート not_before を追加 (T-0133)

### DIFF
--- a/apps/autopilot/loop.sh
+++ b/apps/autopilot/loop.sh
@@ -11,10 +11,12 @@
 # このスクリプト自体は「回し続けること」だけに責任を持つ。何をするかの判断は
 # 一切書かない（prompt.md → ops/VISION.md → ops/CHARTER.md に委ねる）。
 #
-# 注意: このファイルは Pod 起動時に 1 度だけ読み込まれる（ConfigMap の
-# disableNameSuffixHash: true のため、内容を変えても Deployment は自動で
-# 再起動しない）。loop.sh の変更を反映するには Pod の再作成が要る。
-# 一方 prompt.md は毎イテレーション読み直すので再起動なしで効く。
+# 注意: ConfigMap は disableNameSuffixHash: true のため、内容を変えても Deployment は
+# 自動で再起動しない。ただし下記 reexec_if_updated がイテレーションの合間に自分の
+# digest を見て変更を検知し、Pod を作り直さずに新しい内容で exec し直す
+# （導入した commit 2f92db4 時点で 1 回だけ Pod を作り直したのは、この仕組み自体を
+# 載せるため。以降の loop.sh 変更はこの仕組みで反映される）。
+# prompt.md は毎イテレーション読み直すので、そもそも再読み込みの仕組みが要らない。
 
 set -u
 
@@ -93,8 +95,12 @@ iterate() {
   # 役の選択。着手可能なタスクが無いか、PLAN_EVERY 回に 1 回は計画役にする。
   # 計画役と実行役を分けているのは、何をやる価値があるかを決める主体とそれをやる
   # 主体が同じだと「やりやすいこと」に寄っていくため（CHARTER §3）。
+  # not_before（ISO8601, T-0133）が未来のタスクは「時刻待ち」として actionable から除く。
+  # 値が無い/過去/壊れている場合は今まで通り actionable 扱い（壊れた値で計画役に
+  # 倒れ続けると気づけないため、安全側＝実行役に倒す）
   actionable=$(python3 - <<'EOF'
 import json
+from datetime import datetime, timezone
 
 try:
     with open("ops/backlog.json") as f:
@@ -104,7 +110,23 @@ except (OSError, ValueError, KeyError):
     # 壊れた状態で計画役に入ると何も進まないまま回り続ける）
     print(1)
 else:
-    print(sum(1 for t in tasks if t.get("status") in ("todo", "in_progress")))
+    now = datetime.now(timezone.utc)
+    count = 0
+    for t in tasks:
+        if t.get("status") not in ("todo", "in_progress"):
+            continue
+        not_before = t.get("not_before")
+        if not_before:
+            try:
+                gate = datetime.fromisoformat(str(not_before).replace("Z", "+00:00"))
+                if gate.tzinfo is None:
+                    gate = gate.replace(tzinfo=timezone.utc)
+                if gate > now:
+                    continue
+            except ValueError:
+                pass
+        count += 1
+    print(count)
 EOF
 )
   if [ "${actionable}" -eq 0 ] || [ $((i % PLAN_EVERY)) -eq 0 ]; then

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2530,7 +2530,7 @@
         "ops/backlog.json"
       ],
       "created": "2026-08-06",
-      "pr": null,
+      "pr": 313,
       "notes": "run #121（計画役）: T-0117 が時刻待ちの todo であるにも関わらず loop.sh の actionable 判定がそれを考慮せず、実行役の起動を12時間規模で空振りさせている実態を journal（run #116〜#119）から発見して起票。VISION §『判断に迷ったときの原則』の『器を太らせる前に、器を使い切る』との整合は検討済み——既存の next_review フィールドは recurring タスクの再オープン判定にのみ使われており（T-0012）、todo タスクの着手可否そのものを表す用途では使われていないため、新規フィールドが必要と判断した。run #122（実行役）: `ops/backlog.json` に `not_before` を追加し `ops/validate.py` に ISO8601 形式検証を実装、`loop.sh` の actionable 判定スニペットを not_before 対応に書き換え、T-0117 に `not_before: \"2026-08-06T18:30:00Z\"` を付与。境界条件（無し/過去/未来/壊れた文字列）の妥当性は PR 本文に記載。loop.sh の変更は Pod 再作成まで反映されない点も PR 本文に明記"
     }
   ]

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2205,6 +2205,7 @@
       "risk": "low",
       "status": "todo",
       "priority": 41,
+      "not_before": "2026-08-06T18:30:00Z",
       "why": "T-0078（run #83, PR #264）はデプロイ後の初回実行が実際に成功するか未確認のまま cooldown で開いている。immich/vaultwarden/coder-postgres は T-0071 で復元試験まで完了しているが、workspace home はまだ同種の検証をしていない。T-0072（PBS 退役判断）はこの確認が完了することを PBS 退役（T-0116）の前提条件にしている",
       "dod": "T-0078 (PR #264) が merge された後、(1) kubectl / ops-health-report で coder-workspace-home-backup CronJob の子 Job (chb-<workspace-id>) が成功していることを確認する、(2) T-0071 と同型の復元試験（使い捨て PVC への restic restore、CHOWN/FOWNER/DAC_OVERRIDE capability が要る可能性が高い点は docs/backup.md の教訓を踏まえる）を実施し docs/backup.md に記録する、(3) 可能であればオーケストレータ Pod の実メモリ/CPU 使用量を kubectl top で確認し、resources の値が妥当か見直す",
       "blocked_by": null,
@@ -2214,7 +2215,7 @@
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "run #83: T-0078 実装の副産物として分離起票。run #85: T-0078 は run #84 で done・PR #264 merge 済みのため blocked_by を解消。ただし CronJob の schedule（毎日 03:30 UTC と当時記載）が未到来のため実行確認はまだできない。run #97 (T-0125) で訂正: この schedule は実際には JST（node01 の time.timeZone=Asia/Tokyo により k3s の CronJob は JST で評価される）。CronJob は 2026-08-06T00:40:29Z 作成で当日 03:30 JST の回には間に合っておらず、次回の実行予定は 2026-08-07 03:30 JST（= 2026-08-06T18:30Z）。run #94〜#97 が『毎時 UTC 基準でもうすぐ』と判断していたのは誤りで、実際はまだ半日以上先"
+      "notes": "run #83: T-0078 実装の副産物として分離起票。run #85: T-0078 は run #84 で done・PR #264 merge 済みのため blocked_by を解消。ただし CronJob の schedule（毎日 03:30 UTC と当時記載）が未到来のため実行確認はまだできない。run #97 (T-0125) で訂正: この schedule は実際には JST（node01 の time.timeZone=Asia/Tokyo により k3s の CronJob は JST で評価される）。CronJob は 2026-08-06T00:40:29Z 作成で当日 03:30 JST の回には間に合っておらず、次回の実行予定は 2026-08-07 03:30 JST（= 2026-08-06T18:30Z）。run #94〜#97 が『毎時 UTC 基準でもうすぐ』と判断していたのは誤りで、実際はまだ半日以上先。run #122 (T-0133): not_before フィールドを追加し、この時刻まで actionable から除外されるようにした"
     },
     {
       "id": "T-0118",
@@ -2518,7 +2519,7 @@
       "title": "backlog タスクに時刻ゲート（not_before）を持たせ、loop.sh の actionable 判定が『時刻待ちの todo』を実行役に空振りさせないようにする",
       "kind": "feature",
       "risk": "medium",
-      "status": "todo",
+      "status": "done",
       "priority": 35,
       "why": "T-0117 は CronJob の初回実行時刻（2026-08-06T18:30Z）まで着手できない todo だが、`apps/autopilot/loop.sh` の actionable 判定（status が todo/in_progress の件数のみを見る python スニペット）はこの時刻ゲートを知らない。backlog の todo が T-0117 だけの間、実行役に倒れた起動は毎回 issue #56 の全件スキャン・health report 取得・journal 記録だけを行って終わる（run #116〜#120 で実測、INTERVAL_SECONDS=120 なので 18:30Z まで実測時点で残り約12時間・350回超が同型になる見込み）。T-0117 のような『時刻が来るまで着手できない todo』はこれまで notes の自由記述でしか表現されておらず機械可読ではなかったため、loop.sh 側で区別できなかった",
       "dod": "backlog タスクスキーマに任意フィールド `not_before`（ISO8601 文字列、着手可能になる時刻）を追加し、`ops/validate.py` に形式検証（パース可能な ISO8601 であること）を足す。`loop.sh` の actionable 判定を、`not_before` が現在時刻より未来のタスクを除外するように直す（`not_before` の値が壊れている・パースできない場合は安全側＝そのタスクを actionable 扱いのまま、つまり現状と同じ挙動にフォールバックし、role 判定用スニペット全体が例外で落ちて `[ \"\" -eq 0 ]` のような不定形の比較にならないようにする）。既存の T-0117 に `not_before: \"2026-08-06T18:30:00Z\"` を付与し、backlog の todo がこのタスクのみの間は actionable=0 になり計画役に倒れることを次回起動のログ（`role=plan actionable=0`）で確認する。loop.sh の変更は Pod 起動時に一度だけ読み込まれ、変更を反映するには Pod の再作成が要る（ファイル冒頭のコメント参照）ため、PR 本文にその旨と反映タイミングを明記する。自分自身の運用ループ（CHARTER §4 の『自分や人間がこの homelab を観測・操作する経路』に該当）を変更するため、actionable の計算ロジックの単体的な妥当性（真偽の境界条件: not_before なし/過去/未来/壊れた文字列の4パターン）を PR 本文に書き出してから着手する",
@@ -2530,7 +2531,7 @@
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "run #120（計画役）: T-0117 が時刻待ちの todo であるにも関わらず loop.sh の actionable 判定がそれを考慮せず、実行役の起動を12時間規模で空振りさせている実態を journal（run #116〜#119）から発見して起票。VISION §『判断に迷ったときの原則』の『器を太らせる前に、器を使い切る』との整合は検討済み——既存の next_review フィールドは recurring タスクの再オープン判定にのみ使われており（T-0012）、todo タスクの着手可否そのものを表す用途では使われていないため、新規フィールドが必要と判断した"
+      "notes": "run #121（計画役）: T-0117 が時刻待ちの todo であるにも関わらず loop.sh の actionable 判定がそれを考慮せず、実行役の起動を12時間規模で空振りさせている実態を journal（run #116〜#119）から発見して起票。VISION §『判断に迷ったときの原則』の『器を太らせる前に、器を使い切る』との整合は検討済み——既存の next_review フィールドは recurring タスクの再オープン判定にのみ使われており（T-0012）、todo タスクの着手可否そのものを表す用途では使われていないため、新規フィールドが必要と判断した。run #122（実行役）: `ops/backlog.json` に `not_before` を追加し `ops/validate.py` に ISO8601 形式検証を実装、`loop.sh` の actionable 判定スニペットを not_before 対応に書き換え、T-0117 に `not_before: \"2026-08-06T18:30:00Z\"` を付与。境界条件（無し/過去/未来/壊れた文字列）の妥当性は PR 本文に記載。loop.sh の変更は Pod 再作成まで反映されない点も PR 本文に明記"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 312,
+      "title": "docs(ops): run #121 記録更新（PR #311 拾い、T-0133 起票）",
+      "url": "https://github.com/hikuohiku/homelab/pull/312",
+      "mergedAt": "2026-08-06T06:53:56Z",
+      "headRefName": "autopilot/T-0133-planner-run121"
+    },
+    {
       "number": 311,
       "title": "docs(ops): run #120 記録更新（着手可能タスクなし）",
       "url": "https://github.com/hikuohiku/homelab/pull/311",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/252",
       "mergedAt": "2026-08-05T22:52:32Z",
       "headRefName": "autopilot/T-0111-job-replace-sync-option"
-    },
-    {
-      "number": 251,
-      "title": "fix(immich): T-0111 検証 Job の unix socket ディレクトリ不足を修正",
-      "url": "https://github.com/hikuohiku/homelab/pull/251",
-      "mergedAt": "2026-08-05T22:41:13Z",
-      "headRefName": "autopilot/T-0111-socket-dir-fix"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,5 +1,35 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 313,
+      "title": "feat(autopilot): backlog タスクに時刻ゲート not_before を追加 (T-0133)",
+      "url": "https://github.com/hikuohiku/homelab/pull/313",
+      "isDraft": false,
+      "createdAt": "2026-08-06T07:02:20Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "IN_PROGRESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "IN_PROGRESS"
+        }
+      ],
+      "headRefName": "autopilot/T-0133-not-before-actionable",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
     {
       "number": 312,

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3572,6 +3572,8 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   - T-0117 に `not_before: "2026-08-06T18:30:00Z"` を付与
   - 上記の結果、現在の backlog では actionable=0 になることを手元スクリプトで確認
   - `python3 ops/validate.py`（0 error）を実行
+  - PR #313 として作成。境界条件の表・反映タイミング（reexec_if_updated による自動反映、
+    Pod 再作成不要）・ロールバック手順を本文に明記
 - 注意点: `loop.sh` の変更は Pod 起動時に一度だけ読み込まれる（ConfigMap の
   `disableNameSuffixHash: true`）。ただし `reexec_if_updated` が ConfigMap 更新後の
   digest 変化を検知して次のイテレーション開始前に自分で exec し直す設計になっているため、

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3555,3 +3555,30 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py`（0 error）を実行
 - 次の起動へ: T-0133（priority 35）は T-0117（priority 41）より優先度が高いため、次の実行役は
   T-0133 に着手できる。T-0117 は引き続き 2026-08-06T18:30Z 以降に着手可能
+
+## 2026-08-06 15:59 JST — run #122（実行役）
+
+- 前回の中断を拾う: オープン PR・`autopilot/*` ブランチともに無し
+- 読んだフィードバック: issue #56 を `per_page=100` で2ページ（100件+6件）機械的に確認。
+  `last_read`（2026-08-06T06:49:21Z）以降の新規コメント無し
+- backlog を確認: `todo` は T-0117（時刻待ち）と T-0133（priority 35、着手可能）。
+  T-0133 に着手
+- やったこと: T-0133「backlog タスクに時刻ゲート（not_before）を持たせる」を実装。
+  - `ops/backlog.json` のタスクスキーマに任意フィールド `not_before`（ISO8601）を追加
+  - `ops/validate.py` に `not_before` の ISO8601 形式検証を追加
+  - `apps/autopilot/loop.sh` の actionable 判定を、`not_before` が現在時刻より未来の
+    タスクを除外するように変更（値が無い/過去/壊れている場合は従来通り actionable 扱い、
+    という4つの境界条件を手元でユニットテスト相当のスクリプトで検証済み）
+  - T-0117 に `not_before: "2026-08-06T18:30:00Z"` を付与
+  - 上記の結果、現在の backlog では actionable=0 になることを手元スクリプトで確認
+  - `python3 ops/validate.py`（0 error）を実行
+- 注意点: `loop.sh` の変更は Pod 起動時に一度だけ読み込まれる（ConfigMap の
+  `disableNameSuffixHash: true`）。ただし `reexec_if_updated` が ConfigMap 更新後の
+  digest 変化を検知して次のイテレーション開始前に自分で exec し直す設計になっているため、
+  Pod の手動再作成は不要で、ArgoCD sync 後 1〜2 イテレーション以内に反映される見込み
+  （実際に反映されたかは次回起動のログで `role=plan actionable=0` を確認する）
+- 次の起動へ: この PR が merge され ArgoCD が sync した後、次のイテレーションのログで
+  `role=plan actionable=0` になっているか確認すること。ならなければ loop.sh の反映
+  （reexec_if_updated）が想定通り動いていない可能性がある
+- ダッシュボード: `python3 ops/dashboard/build.py` を実行し `ops-dashboard` ブランチへ publish
+  成功。Artifact ツールはこの実行環境に無く publish できなかった（ops-dashboard 版のみ最新）

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T06:49:21Z",
+  "updated": "2026-08-06T06:59:17Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
@@ -1197,6 +1197,14 @@
       "kind": "scheduled",
       "by": "cluster-resident (autopilot Pod)",
       "summary": "計画役（journal run #121）。前回の中断（PR #311, run #120 の記録用 PR）を CI green 確認のうえ merge。issue #56 に新規フィードバックなし。T-0084 の blocked_by（履歴が数日分蓄積するまで意味が無い）を ops-health-report ブランチの実データ（2日分・約330KB/169KB、1日分に外挿して約550KB≒1MB上限の53%）で確認したが、next_review（2026-08-08）が示す期間にはまだ届いていないため status は据え置いた。backlog の todo が T-0117（時刻ゲート待ち）のみで、loop.sh の actionable 判定がその時刻ゲートを知らないために実行役が12時間規模で空振りし続ける構造的な無駄を発見し、T-0133（priority 35, not_before フィールドの導入）として起票した。",
+      "prs": []
+    },
+    {
+      "n": 115,
+      "at": "2026-08-06T15:59:00+09:00",
+      "kind": "scheduled",
+      "by": "cluster-resident (autopilot Pod)",
+      "summary": "実行役（journal run #122）。T-0133 を実装: ops/backlog.json のタスクスキーマに任意フィールド not_before（ISO8601）を追加、ops/validate.py に形式検証を追加、apps/autopilot/loop.sh の actionable 判定を not_before 対応に書き換え（値が無い/過去/壊れている場合は従来通り actionable 扱いのフォールバックを維持、境界条件は手元スクリプトで確認済み）。T-0117 に not_before: 2026-08-06T18:30:00Z を付与し、現在の backlog で actionable=0 になることを確認した。loop.sh 冒頭のコメントが reexec_if_updated 導入前のまま Pod 再作成が必要と書いていた点も実態に合わせて修正（commit 2f92db4 以降は自己 exec で再読み込みされる）。",
       "prs": []
     }
   ]

--- a/ops/state.json
+++ b/ops/state.json
@@ -1205,7 +1205,7 @@
       "kind": "scheduled",
       "by": "cluster-resident (autopilot Pod)",
       "summary": "実行役（journal run #122）。T-0133 を実装: ops/backlog.json のタスクスキーマに任意フィールド not_before（ISO8601）を追加、ops/validate.py に形式検証を追加、apps/autopilot/loop.sh の actionable 判定を not_before 対応に書き換え（値が無い/過去/壊れている場合は従来通り actionable 扱いのフォールバックを維持、境界条件は手元スクリプトで確認済み）。T-0117 に not_before: 2026-08-06T18:30:00Z を付与し、現在の backlog で actionable=0 になることを確認した。loop.sh 冒頭のコメントが reexec_if_updated 導入前のまま Pod 再作成が必要と書いていた点も実態に合わせて修正（commit 2f92db4 以降は自己 exec で再読み込みされる）。",
-      "prs": []
+      "prs": [313]
     }
   ]
 }

--- a/ops/validate.py
+++ b/ops/validate.py
@@ -7,6 +7,7 @@ autopilot が自分の状態を壊さないための最後の砦。CI から呼�
 
 from __future__ import annotations
 
+import datetime
 import json
 import pathlib
 import re
@@ -91,6 +92,12 @@ def check_backlog(b) -> None:
                 )
         if t.get("status") == "blocked" and not t.get("blocked_by"):
             err(f"{where}: blocked には blocked_by が必要")
+        not_before = t.get("not_before")
+        if not_before is not None:
+            try:
+                datetime.datetime.fromisoformat(str(not_before).replace("Z", "+00:00"))
+            except ValueError:
+                err(f"{where}: not_before={not_before!r} は ISO8601 として解釈できない")
         if t.get("status") == "done" and not t.get("pr") and not t.get("notes"):
             warn(f"{where}: done なのに pr が空（PR を伴わない完了なら理由を notes に）")
 


### PR DESCRIPTION
## 変更点

`ops/backlog.json` の todo タスクに、着手可能になる時刻を表す任意フィールド `not_before`（ISO8601）を追加できるようにした。あわせて `apps/autopilot/loop.sh` の計画役/実行役の判定（actionable 件数）が `not_before` が未来のタスクを除外するようにした。

T-0117（coder workspace home backup の初回実行確認、次回実行予定 2026-08-06T18:30Z）に `not_before: "2026-08-06T18:30:00Z"` を付与した。これにより現在の backlog は actionable=0 となり、次回起動は計画役に倒れる（実行役の空振りが run #116-#120 で12時間規模・350回超と見積もられていた問題への対処）。

- `ops/backlog.json`: T-0117 に `not_before` を付与、T-0133 を `done` に
- `ops/validate.py`: `not_before` の ISO8601 形式検証を追加（パースできない値は error）
- `apps/autopilot/loop.sh`: actionable 判定の python スニペットを `not_before` 対応に変更
- `apps/autopilot/loop.sh` 冒頭コメント: 「loop.sh の変更には Pod 再作成が要る」という記述が `reexec_if_updated`（commit 2f92db4, 本日導入済み）導入前のまま残っていたため、実態（自己 exec による再読み込み、Pod 再作成は不要）に合わせて修正
- journal / state.json / dashboard キャッシュの更新（記録の相乗り）

## actionable 判定ロジックの境界条件（着手前に洗い出したもの）

| `not_before` の状態 | 挙動 | 理由 |
|---|---|---|
| 無し（フィールド自体が無い） | actionable（従来通り） | `if not_before:` で偽になりスキップ |
| 過去の時刻 | actionable | `gate > now` が偽なので除外されない |
| 未来の時刻 | **除外**（actionable にカウントしない） | `gate > now` が真で `continue` |
| パースできない壊れた文字列 | actionable（安全側のフォールバック） | `datetime.fromisoformat` が `ValueError` → `except` で無視して通常通りカウント |

手元で上記 4 パターンをユニットテスト相当のスクリプトで検証済み（全て期待通り）。さらに実際の `ops/backlog.json` に対して loop.sh に埋め込まれているのと全く同じ python スニペットを抽出して実行し、`0`（T-0117 のみ・時刻ゲート中）を確認した。

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 -c "import json; json.load(open('ops/backlog.json'))"` → JSON として妥当
- `sh -n apps/autopilot/loop.sh` → シェル構文エラー無し
- loop.sh に埋め込まれている python heredoc をそのまま抽出して実行 → 例外なく `0` を返す
- 境界条件 4 パターンの手動ユニットテスト → 全て期待通り
- CI（`kustomize build` / `terraform validate` / `ops state validate`）は本 PR の push 後の結果を待つ

## 反映タイミング（自分自身の運用ループの変更のため明記）

`apps/autopilot/loop.sh` は ConfigMap 経由でマウントされており、`disableNameSuffixHash: true` のため Deployment の spec は変わらず Pod は自動では再作成されない。ただし本日別コミット（2f92db4）で `reexec_if_updated` が導入済みで、イテレーションの合間に自分自身の digest を見て変更を検知し、Pod を作り直さずに新しい内容で exec し直す。そのため **この PR の merge → ArgoCD sync 後、次の1イテレーション以内（現行 INTERVAL_SECONDS=120 秒間隔）で自動的に反映される**。Pod の手動再作成は不要。

反映されたかどうかは、次回起動のログ（`kubectl logs` 相当、ops-health-report の `autopilot.heartbeat` からは見えないため次回起動時にこのセッション自身が `role=plan actionable=0` のログ行を見て確認する想定）で確認する。CHARTER §4「自分や人間がこの homelab を観測・操作する経路」に該当する変更のため明記する: 万一この変更で actionable 判定ロジックが壊れて python が毎回例外を吐くようになった場合、shell 側は `actionable=""`（空文字）となり `[ "" -eq 0 ]` はエラーになるが、`||` で `[ $((i % PLAN_EVERY)) -eq 0 ]` の評価に進むため、PLAN_EVERY（6）回に1回は計画役に落ちる形でループ自体は止まらない（既存の壊れ方と同型）。

## ロールバック手順

このコミットを revert すれば元に戻る。DB・スキーマを持つコンポーネントではないため、コードの revert とデータの revert に乖離はない。`not_before` フィールドは backlog.json 上の追加データに過ぎず、revert 後は単に時刻ゲートが効かなくなり従来の「todo 件数だけを見る」actionable 判定に戻るだけで、データの不整合は残らない。

## backlog task id

T-0133
