### PR TITLE
docs(ops): run #123 記録更新（PR #313 拾い、着手可能タスクなし）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,36 +1,13 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 313,
       "title": "feat(autopilot): backlog タスクに時刻ゲート not_before を追加 (T-0133)",
       "url": "https://github.com/hikuohiku/homelab/pull/313",
-      "isDraft": false,
-      "createdAt": "2026-08-06T07:02:20Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "IN_PROGRESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "IN_PROGRESS"
-        }
-      ],
-      "headRefName": "autopilot/T-0133-not-before-actionable",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-06T07:07:29Z",
+      "headRefName": "autopilot/T-0133-not-before-actionable"
+    },
     {
       "number": 312,
       "title": "docs(ops): run #121 記録更新（PR #311 拾い、T-0133 起票）",
@@ -443,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/253",
       "mergedAt": "2026-08-05T22:57:43Z",
       "headRefName": "autopilot/T-0111-clean-pgdata-each-run"
-    },
-    {
-      "number": 252,
-      "title": "fix(immich): T-0111 検証 Job に ArgoCD Force+Replace sync-option を付与",
-      "url": "https://github.com/hikuohiku/homelab/pull/252",
-      "mergedAt": "2026-08-05T22:52:32Z",
-      "headRefName": "autopilot/T-0111-job-replace-sync-option"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3584,3 +3584,27 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   （reexec_if_updated）が想定通り動いていない可能性がある
 - ダッシュボード: `python3 ops/dashboard/build.py` を実行し `ops-dashboard` ブランチへ publish
   成功。Artifact ツールはこの実行環境に無く publish できなかった（ops-dashboard 版のみ最新）
+
+## 2026-08-06 16:08 JST — run #123（実行役）
+
+- 前回の中断を拾う: オープン PR #313（run #122 が作成した T-0133 実装 PR）が CI 6件 green・
+  `mergeable_state: clean` で残っていたため merge（59099fa）。縛る変更（memory limits・probe・
+  timeout 等の新しい失敗条件を持ち込むもの）には該当しないため cooldown 対象外と判断し、
+  同一起動内で merge まで完了した。ブランチは GitHub 側で自動削除済み（`DELETE` は 422、
+  `GET branches/...` は 404 で確認）。他に `autopilot/*` の残りブランチ無し
+- 読んだフィードバック: issue #56 を `per_page=100` で2ページ（100件+6件）機械的に確認。
+  `last_read`（2026-08-06T06:49:21Z）以降の新規コメント無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T07:00:04Z`）で新規異常なし。
+  `coder`/`immich`/`vaultwarden` の Degraded は引き続き `<app>-restic-backup-credentials` の
+  `SecretSyncedError`（T-0106, 既知）のみ、`pod_issues` の restarts:19 常連も変化なし。
+  autopilot 自身の heartbeat は iteration 24 exit_code 0、`readyReplicas: 1` で異常なし
+- backlog を確認: PR #313 merge 後、`todo` は T-0117 のみ（`not_before: 2026-08-06T18:30:00Z`
+  で時刻ゲート中、現在時刻はまだ手前）。T-0133 が狙ったとおり actionable=0 になっており、
+  次のイテレーションからは計画役に倒れる見込み（loop.sh の反映は `reexec_if_updated` 次第。
+  次回起動のログで `role=plan actionable=0` を確認すること）
+- `ops/inbox.md` は空
+- やったこと: PR #313 の merge・ブランチ削除確認のみ。着手可能な新規タスクは無かったため
+  実装は行わず、この journal 記録のみ
+- `python3 ops/validate.py`（0 error）を実行
+- 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能。actionable=0 が想定通り計画役への
+  切り替えを起こすかは次回起動のログで確認する

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T06:59:17Z",
+  "updated": "2026-08-06T07:08:53Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
@@ -1205,7 +1205,17 @@
       "kind": "scheduled",
       "by": "cluster-resident (autopilot Pod)",
       "summary": "実行役（journal run #122）。T-0133 を実装: ops/backlog.json のタスクスキーマに任意フィールド not_before（ISO8601）を追加、ops/validate.py に形式検証を追加、apps/autopilot/loop.sh の actionable 判定を not_before 対応に書き換え（値が無い/過去/壊れている場合は従来通り actionable 扱いのフォールバックを維持、境界条件は手元スクリプトで確認済み）。T-0117 に not_before: 2026-08-06T18:30:00Z を付与し、現在の backlog で actionable=0 になることを確認した。loop.sh 冒頭のコメントが reexec_if_updated 導入前のまま Pod 再作成が必要と書いていた点も実態に合わせて修正（commit 2f92db4 以降は自己 exec で再読み込みされる）。",
-      "prs": [313]
+      "prs": [
+        313
+      ]
+    },
+    {
+      "n": 116,
+      "at": "2026-08-06T16:08:00+09:00",
+      "kind": "scheduled",
+      "by": "cluster-resident (autopilot Pod)",
+      "summary": "実行役（journal run #123）。前回の中断（PR #313, run #122 の T-0133 実装）を CI green 確認のうえ merge。縛る変更に該当しないため同一起動内で完了。issue #56 に新規フィードバックなし、ops-health-report・autopilot heartbeat とも正常。PR #313 merge 後 backlog の todo は T-0117（not_before 時刻ゲート待ち）のみとなり actionable=0 を達成、次回以降は計画役に倒れる見込み。",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

実行役 run #123 の記録更新のみ（コード・マニフェストの変更なし）。

- 前回の中断（PR #313, T-0133 実装）を CI green・`mergeable_state: clean` 確認のうえ merge 済み
- issue #56 に新規フィードバックなし
- `ops-health-report` で新規異常なし（coder/immich/vaultwarden の Degraded は既知の T-0106 のみ）
- PR #313 merge 後、backlog の `todo` は T-0117（`not_before: 2026-08-06T18:30:00Z` で時刻ゲート中）のみとなり、着手可能な新規タスクなし
- `ops/journal/2026-08.md` / `ops/state.json` / `ops/dashboard/prs.json` を更新

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 生成成功、`ops-dashboard` ブランチへ publish 成功

## ロールバック手順

このコミットを revert すれば元に戻る。記録用ファイルのみの変更でスキーマやインフラへの影響はない。

## backlog task id

なし（記録のみ）