### PR TITLE
docs(ops): run #124 記録更新（PR #314 拾い、着手可能タスクなし）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 314,
+      "title": "docs(ops): run #123 記録更新（PR #313 拾い、着手可能タスクなし）",
+      "url": "https://github.com/hikuohiku/homelab/pull/314",
+      "mergedAt": "2026-08-06T07:13:23Z",
+      "headRefName": "autopilot/run123-record-only"
+    },
+    {
       "number": 313,
       "title": "feat(autopilot): backlog タスクに時刻ゲート not_before を追加 (T-0133)",
       "url": "https://github.com/hikuohiku/homelab/pull/313",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/254",
       "mergedAt": "2026-08-05T23:01:31Z",
       "headRefName": "autopilot/T-0111-createdb-condition-fix"
-    },
-    {
-      "number": 253,
-      "title": "fix(immich): T-0111 検証 Job で毎回 PGDATA を空にしてから initdb する",
-      "url": "https://github.com/hikuohiku/homelab/pull/253",
-      "mergedAt": "2026-08-05T22:57:43Z",
-      "headRefName": "autopilot/T-0111-clean-pgdata-each-run"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3608,3 +3608,30 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py`（0 error）を実行
 - 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能。actionable=0 が想定通り計画役への
   切り替えを起こすかは次回起動のログで確認する
+
+## 2026-08-06 16:14 JST — run #124（実行役）
+
+- 前回の中断を拾う: オープン PR #314（run #123 が作成した記録用 PR）が CI 6件 green・
+  `mergeable_state: clean` で残っていたため merge（c110a93）。記録のみで縛る変更に該当しない
+  ため同一起動内で merge。ブランチは GitHub 側で自動削除済み（`DELETE` は 422 = 既に無し）。
+  他に `autopilot/*` の残りブランチ無し
+- 読んだフィードバック: issue #56 を `per_page=100` で2ページ（100件+6件）機械的に確認。
+  `last_read`（2026-08-06T06:49:21Z）以降の新規コメント無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T07:00:04Z`）で新規異常なし。
+  `coder`/`immich`/`vaultwarden` の Degraded は引き続き T-0106 の `SecretSyncedError` のみ、
+  `pod_issues` の restarts:19 常連も変化なし。autopilot 自身の heartbeat は iteration 24
+  exit_code 0、`readyReplicas: 1` で異常なし
+- backlog を確認: `todo` は T-0117 のみ（`not_before: 2026-08-06T18:30:00Z`、現在時刻
+  2026-08-06T07:14Z JST16:14 はまだ手前のため actionable=0）
+- `ops/inbox.md` は空
+- 気づいたこと: T-0133（run #122, PR #313）の反映後は `role=plan actionable=0` になる
+  はずだが、この起動のプロンプトは引き続き実行役（`prompt-execute.md`）だった。`loop.sh`
+  のコードを確認したところ判定ロジック自体（`actionable -eq 0` で `role=plan`）は正しく、
+  最有力の説明は ArgoCD sync + `reexec_if_updated` がまだこの Pod に新しい `loop.sh` を
+  反映しておらず、`not_before` を知らない旧ロジックが T-0117 を無条件に actionable 扱い
+  していること。次回起動でも execute のままなら反映が滞っている疑いがあるので調べる
+- やったこと: PR #314 の merge・ブランチ削除確認のみ。着手可能な新規タスクは無かったため
+  実装は行わず、この journal 記録のみ
+- `python3 ops/validate.py`（0 error）を実行
+- 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能。role=plan への切り替えが
+  actionable=0 で本当に起きているか、次回起動のプロンプト種別で確認すること


### PR DESCRIPTION
## 変更点

実行役 run #124 の記録更新のみ（コード・マニフェストの変更なし）。

- 前回の中断（PR #314, run #123 の記録）を CI green・`mergeable_state: clean` 確認のうえ merge 済み（c110a93）
- issue #56 に新規フィードバックなし
- `ops-health-report` で新規異常なし（coder/immich/vaultwarden の Degraded は既知の T-0106 のみ、pod restarts:19 常連も変化なし）
- backlog の `todo` は T-0117（`not_before: 2026-08-06T18:30:00Z` で時刻ゲート中）のみで、着手可能な新規タスクなし
- 気づいたこと: T-0133 適用後は actionable=0 で `role=plan` に切り替わるはずだが、この起動もプロンプトは実行役のままだった。ArgoCD sync + `reexec_if_updated` の反映待ちの可能性が高いと見て journal に記録。次回起動でも execute のままなら反映の滞りを調査する
- `ops/journal/2026-08.md` / `ops/dashboard/prs.json` を更新

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 生成成功、`ops-dashboard` ブランチへ publish 成功

## ロールバック手順

このコミットを revert すれば元に戻る。記録用ファイルのみの変更でスキーマやインフラへの影響はない。

## backlog task id

なし（記録のみ）
