### PR TITLE
docs(ops): run #124/#125 記録更新、T-0134 起票（ops-dashboard の CLAUDE.md 未記載）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 134,
-  "updated": "2026-08-06T06:49:21Z",
+  "next_id": 135,
+  "updated": "2026-08-06T07:30:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2532,6 +2532,24 @@
       "created": "2026-08-06",
       "pr": 313,
       "notes": "run #121（計画役）: T-0117 が時刻待ちの todo であるにも関わらず loop.sh の actionable 判定がそれを考慮せず、実行役の起動を12時間規模で空振りさせている実態を journal（run #116〜#119）から発見して起票。VISION §『判断に迷ったときの原則』の『器を太らせる前に、器を使い切る』との整合は検討済み——既存の next_review フィールドは recurring タスクの再オープン判定にのみ使われており（T-0012）、todo タスクの着手可否そのものを表す用途では使われていないため、新規フィールドが必要と判断した。run #122（実行役）: `ops/backlog.json` に `not_before` を追加し `ops/validate.py` に ISO8601 形式検証を実装、`loop.sh` の actionable 判定スニペットを not_before 対応に書き換え、T-0117 に `not_before: \"2026-08-06T18:30:00Z\"` を付与。境界条件（無し/過去/未来/壊れた文字列）の妥当性は PR 本文に記載。loop.sh の変更は Pod 再作成まで反映されない点も PR 本文に明記"
+    },
+    {
+      "id": "T-0134",
+      "domain": "homelab",
+      "title": "CLAUDE.md の Apps 一覧・ディレクトリ構造に apps/ops-dashboard/ が未記載",
+      "kind": "docs",
+      "risk": "low",
+      "status": "todo",
+      "priority": 40,
+      "why": "計画役 run #125 で発見。T-0127/T-0128 で追加された apps/ops-dashboard/（application.yaml, deployment.yaml, service.yaml, ingress.yaml — ops-dashboard ブランチの index.html を Tailscale ingress 経由で配信する Deployment）が、CLAUDE.md 16行目の『Apps』一覧（ArgoCD, Dex, External Secrets Operator, Tailscale Operator, Immich, Vaultwarden, Coder, ops-health-reporter, autopilot の9つ）にも、23〜37行目のディレクトリ構造図にも入っていない。T-0057/T-0089/T-0094 と同型のドキュメントdrift。",
+      "dod": "CLAUDE.md の Apps 一覧に ops-dashboard を追加し、ディレクトリ構造図に `ops-dashboard/ — 人間向けダッシュボードの配信（Deployment、ops-dashboard ブランチの index.html を fetch して http.server で配信）`相当の1行を追加する",
+      "refs": [
+        "CLAUDE.md",
+        "apps/ops-dashboard/"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": null
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 315,
+      "title": "docs(ops): run #124 記録更新（PR #314 拾い、着手可能タスクなし）",
+      "url": "https://github.com/hikuohiku/homelab/pull/315",
+      "mergedAt": "2026-08-06T07:17:14Z",
+      "headRefName": "autopilot/run124-record-only"
+    },
+    {
       "number": 314,
       "title": "docs(ops): run #123 記録更新（PR #313 拾い、着手可能タスクなし）",
       "url": "https://github.com/hikuohiku/homelab/pull/314",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/255",
       "mergedAt": "2026-08-05T23:07:06Z",
       "headRefName": "autopilot/T-0111-cleanup-verify-job"
-    },
-    {
-      "number": 254,
-      "title": "fix(immich): T-0111 検証 Job の createdb スキップ条件を修正",
-      "url": "https://github.com/hikuohiku/homelab/pull/254",
-      "mergedAt": "2026-08-05T23:01:31Z",
-      "headRefName": "autopilot/T-0111-createdb-condition-fix"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3635,3 +3635,33 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py`（0 error）を実行
 - 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能。role=plan への切り替えが
   actionable=0 で本当に起きているか、次回起動のプロンプト種別で確認すること
+
+## 2026-08-06 16:30 JST — run #125（計画役）
+
+- run #124 が残した疑問への回答: この起動のプロンプトは実際に計画役
+  （`prompt-plan.md` 相当）だった。T-0133（`not_before` 対応）の `reexec_if_updated`
+  経由の反映と `actionable=0` → `role=plan` の切り替えは想定通り機能していると確認できた
+- 前回の中断を拾う: オープン PR・`autopilot/*` 残りブランチとも無し
+- 読んだフィードバック: issue #56 を `per_page=100` で2ページ（100件+6件）機械的に確認。
+  `last_read`（2026-08-06T06:49:21Z）以降の新規コメント無し
+- `ops/inbox.md`: 空。変換すべき引き継ぎ無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T07:00:04Z`、20分前で鮮度は
+  正常範囲）で新規異常なし。`coder`/`immich`/`vaultwarden` の Degraded は引き続き T-0106 の
+  `SecretSyncedError` のみ（`kubectl get externalsecret` で3 namespace とも直接確認、
+  Doppler 未登録のまま変化なし）、`pod_issues` の restarts:19 常連も変化なし。autopilot
+  自身の heartbeat も `readyReplicas: 1` で異常なし
+- backlog 棚卸し: `blocked`/`needs-human` 10件を個別に見直した。T-0106 は上記の通り実測で
+  再確認、他9件（T-0028/T-0029/T-0074/T-0084/T-0107/T-0112/T-0116/T-0118/T-0120/T-0130）は
+  前提の変化を示す新しい情報が無いため据え置き。T-0118（azure/setup-helm の helm v4
+  サポート待ち）は upstream README を再確認したが `v2+ of this action only support Helm3`
+  のまま変化なし。`todo` は T-0117 のみで `not_before: 2026-08-06T18:30:00Z` により
+  引き続き着手不可
+- 新規調査: (1) background agent で `ops/inventory.json` の `policy: auto` 対象27件を
+  upstream と突き合わせ、既存 backlog に未反映の更新が無いか確認 → 全件が既に最新か、
+  既存タスクで検討済み（新規発見なし）。(2) `apps/` 配下のディレクトリを実地確認したところ
+  `apps/ops-dashboard/`（T-0127/T-0128 で追加、Tailscale ingress 経由でダッシュボードを
+  配信する Deployment）が CLAUDE.md の Apps 一覧・ディレクトリ構造図に未記載と判明
+  （T-0057/T-0089/T-0094 と同型の doc drift）。T-0134（priority 40, docs, low）として起票
+- やったこと: T-0134 の起票（backlog.json のみ、コード変更なし）
+- `python3 ops/validate.py`（0 error）を実行
+- 次の起動へ: T-0134 は着手可能。T-0117 は引き続き 2026-08-06T18:30Z 以降に着手可能

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T07:08:53Z",
+  "updated": "2026-08-06T07:32:00Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
@@ -1215,6 +1215,22 @@
       "kind": "scheduled",
       "by": "cluster-resident (autopilot Pod)",
       "summary": "実行役（journal run #123）。前回の中断（PR #313, run #122 の T-0133 実装）を CI green 確認のうえ merge。縛る変更に該当しないため同一起動内で完了。issue #56 に新規フィードバックなし、ops-health-report・autopilot heartbeat とも正常。PR #313 merge 後 backlog の todo は T-0117（not_before 時刻ゲート待ち）のみとなり actionable=0 を達成、次回以降は計画役に倒れる見込み。",
+      "prs": []
+    },
+    {
+      "n": 117,
+      "at": "2026-08-06T16:14:00+09:00",
+      "kind": "in-cluster",
+      "by": "autopilot loop (実行役)",
+      "summary": "実行役（journal run #124）。前回の中断（PR #314, run #123 の記録用 PR）を CI green 確認のうえ merge。issue #56 に新規フィードバックなし、ops-health-report・autopilot heartbeat とも正常。backlog の todo は T-0117（not_before 時刻ゲート待ち）のみで actionable=0 のまま。T-0133 の反映（role=plan への切り替え）がまだ観測できていなかったため次回で確認する注記を残した。",
+      "prs": []
+    },
+    {
+      "n": 118,
+      "at": "2026-08-06T16:30:00+09:00",
+      "kind": "in-cluster",
+      "by": "autopilot loop (計画役)",
+      "summary": "計画役（journal run #125）。T-0133 の reexec_if_updated 反映と role=plan への切り替えが実際に機能していることを確認（run #124 の疑問に回答）。issue #56 に新規フィードバックなし、ops-health-report・autopilot heartbeat とも正常（T-0106 の SecretSyncedError は kubectl で直接再確認、既知のまま）。blocked/needs-human 10件を棚卸ししたが前提の変化なし。新規調査: inventory.json auto対象27件の upstream 突き合わせは新規発見なし、apps/ops-dashboard/ が CLAUDE.md の Apps 一覧・ディレクトリ構造に未記載と判明し T-0134 を起票。",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

- `ops/journal/2026-08.md`: run #124（実行役）・run #125（計画役）の記録を追記
- `ops/state.json`: runs 配列に n=117/118 を追加、`feedback.last_read` は変更なし（未読フィードバック無しのため）
- `ops/backlog.json`: T-0134 を起票（`apps/ops-dashboard/` が CLAUDE.md の Apps 一覧・ディレクトリ構造図に未記載。T-0057/T-0089/T-0094 と同型の doc drift。docs/low、コード変更は無し、記録のみ）
- `ops/dashboard/prs.json`: `build.py` 実行に伴うキャッシュ更新

計画役として実施したこと:
- issue #56 に未読フィードバックなし（機械的に全件確認）
- `ops-health-report` で新規異常なし（`coder`/`immich`/`vaultwarden` の Degraded は既知の T-0106 `SecretSyncedError` のみ、`kubectl get externalsecret` で直接再確認済み）
- backlog の blocked/needs-human 10件を棚卸し、前提の変化なしを確認
- `ops/inventory.json` の `policy: auto` 対象27件を upstream と突き合わせ（background agent）、既存 backlog 未反映の更新なしを確認

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 生成成功、`ops-dashboard` ブランチへ publish 成功

## ロールバック手順

この PR は `ops/` の記録のみで実インフラ・アプリケーションへの変更を含まない。revert すれば journal/backlog/state の当該追記が消えるだけで、他に影響は無い。

## backlog task id

T-0134（新規起票、docs/low）
