### PR TITLE
docs(ops): run #127（計画役）記録更新、新規起票なし

### DIFF
--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3674,3 +3674,37 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - やったこと: T-0134（CLAUDE.md の Apps 一覧・ディレクトリ構造図に ops-dashboard 追記）を実施
 - 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能。それまでは backlog に actionable な
   todo 無し
+
+## 2026-08-06 16:42 JST — run #127（計画役）
+
+- 前回の中断を拾う: オープン PR 無し。`autopilot/*` 残りブランチも無し。ローカル `main` は
+  `origin/main`（`cc634c2`, T-0134 の merge 済み）と一致
+- `ops/inbox.md` を読んだ: 見出し以下は空。変換すべき引き継ぎ無し
+- 読んだフィードバック: issue #56 のコメント計 106 件（`per_page=100` で2ページ、100件+6件）を
+  機械的に確認。`last_read`（2026-08-06T06:49:21Z）以降の新規コメント無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T07:30:04Z`、取得時刻から新鮮）で
+  新規異常なし。ArgoCD は `coder`/`immich`/`vaultwarden` の3件が引き続き T-0106 由来の
+  `SecretSyncedError`（既知）のみで Degraded、他8件は Synced/Healthy。`pod_issues` は
+  restarts:19 の常連のみで新規異常なし。immich `backup_listing` の最新ファイルは新鮮。
+  autopilot 自身の heartbeat は `readyReplicas: 1`・`last_end.exit_code: 0` で異常なし。
+  node/pod の CPU・メモリ使用量（node 割当 12252032Ki 中 6060984Ki 使用、約49%）・PVC 実使用量
+  （immich-library 350MB 等、いずれも容量に対し僅少）も確認したが懸念点なし
+- backlog 棚卸し: `blocked`/`needs-human` 10件を個別に再確認したが、run #125（30分前）の
+  棚卸しから前提の変化を示す新しい情報は無く、全件据え置き。`todo` は T-0117 のみで
+  `not_before: 2026-08-06T18:30:00Z` により引き続き着手不可（actionable な todo は 0 件）
+- 新規調査（run #125 が直前に broad sweep 済みのため、別の切り口を選んだ）:
+  (1) `apps/` の実ディレクトリ一覧と CLAUDE.md の Apps 一覧を再突き合わせ →
+  T-0134 反映後は完全一致、新規ドリフト無し。(2) `ops/inventory.json` の `policy: manual`
+  5件（argo-cd, cloudnative-vectorchord, coder-workspace-image, nixpkgs, bpg/proxmox）を
+  個別に確認 → いずれも note が最新で対応する backlog タスク（T-0028/T-0029 等）に
+  紐付いており、追加の起票なし。(3) repo 全体を `TODO`/`FIXME`/`XXX:` で grep →
+  実質的な残留は `apps/coder/templates/personal/README.md` の
+  `<!-- TODO: Add screenshot -->` のみで、これは upstream Coder サンプルテンプレート
+  由来の定型コメントであり homelab 固有の技術的負債ではないため起票を見送った
+- 新規起票: なし。着手可能な範囲は run #125 時点で使い切っており、この回で新たに見つかった
+  ものは無かった
+- やったこと: 上記の再確認と journal 記録のみ（CHARTER §2「やることが無い起動でも journal に
+  書いた PR を出す」に従う）
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでの計画回は同様に
+  手薄になりうるが、健全性確認と backlog 棚卸しは毎回続けること

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T07:32:00Z",
+  "updated": "2026-08-06T07:42:40Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {


### PR DESCRIPTION
## 変更点

`ops/journal/2026-08.md` に run #127（計画役）の記録を追記し、`ops/state.json` の `updated` を更新した。コード・マニフェストの変更は無い。

## 検証したこと

- `ops/inbox.md`: 空（変換すべき引き継ぎ無し）
- feedback issue #56: `per_page=100` で2ページ（106件）を機械的に確認、`last_read` 以降の新規コメント無し
- `ops-health-report`（`generated_at: 2026-08-06T07:30:04Z`）: ArgoCD 11件中 coder/immich/vaultwarden の3件が既知の T-0106 由来 Degraded のみ、他は Healthy。pod_issues・node/pod のCPU・メモリ・PVC使用量にも新規異常なし。autopilot 自身の heartbeat も正常
- `ops/backlog.json` の blocked/needs-human 10件を個別に再確認したが、30分前の run #125 の棚卸しから前提の変化なし。`todo` は T-0117 のみで `not_before` 未到来のため actionable 0件
- 別角度の調査（apps/一覧の再突合、inventory.json の manual policy 5件、repo全体のTODO/FIXME grep）でも新規のドリフト・課題は見つからず、新規起票は無し
- `python3 ops/validate.py` → 0 error, 0 warning

## ロールバック手順

記録ファイルのみの変更（DBなど状態を持つコンポーネントは対象外）。この PR を revert すれば journal・state.json とも完全に元に戻る。データ不整合は残らない。

## backlog task id

なし（新規起票なしの回のため）

---
_Generated by autopilot (in-cluster loop)_