### PR TITLE
docs(ops): run #128（計画役）記録更新、新規起票なし

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,20 @@
   "open": [],
   "merged": [
     {
+      "number": 318,
+      "title": "docs(ops): run #127（計画役）記録更新、新規起票なし",
+      "url": "https://github.com/hikuohiku/homelab/pull/318",
+      "mergedAt": "2026-08-06T07:44:48Z",
+      "headRefName": "autopilot/run127-plan-no-new-findings"
+    },
+    {
+      "number": 317,
+      "title": "docs: CLAUDE.md に ops-dashboard を追記 (T-0134)",
+      "url": "https://github.com/hikuohiku/homelab/pull/317",
+      "mergedAt": "2026-08-06T07:35:59Z",
+      "headRefName": "autopilot/T-0134-claude-md-ops-dashboard"
+    },
+    {
       "number": 316,
       "title": "docs(ops): run #124/#125 記録更新、T-0134 起票（ops-dashboard の CLAUDE.md 未記載）",
       "url": "https://github.com/hikuohiku/homelab/pull/316",
@@ -406,20 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/258",
       "mergedAt": "2026-08-05T23:34:16Z",
       "headRefName": "autopilot/T-0029-rollback-crashloop"
-    },
-    {
-      "number": 257,
-      "title": "feat(immich): postgres を16.14-1.1.1に上げinitdbブートストラップを組み込む (T-0029)",
-      "url": "https://github.com/hikuohiku/homelab/pull/257",
-      "mergedAt": "2026-08-05T23:22:16Z",
-      "headRefName": "autopilot/T-0029-postgres-bootstrap-integration"
-    },
-    {
-      "number": 256,
-      "title": "chore(ops): run #73-75 の journal/state/CHARTER を記録する",
-      "url": "https://github.com/hikuohiku/homelab/pull/256",
-      "mergedAt": "2026-08-05T23:11:57Z",
-      "headRefName": "autopilot/T-0111-run75-wrapup"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3708,3 +3708,34 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py` を実行し 0 error であることを確認
 - 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能になる。それまでの計画回は同様に
   手薄になりうるが、健全性確認と backlog 棚卸しは毎回続けること
+
+## 2026-08-06 16:47 JST — run #128（計画役）
+
+- 前回の中断を拾う: オープン PR 無し。`autopilot/*` 残りブランチも無し。ローカル `main` は
+  `origin/main`（`41f2ede`）と一致
+- `ops/inbox.md` を読んだ: 見出し以下は空。変換すべき引き継ぎ無し
+- 読んだフィードバック: issue #56 のコメントを `per_page=100` で2ページ（100件+6件）機械的に
+  確認。最新コメントは 2026-08-06T06:10:37Z で `last_read`（2026-08-06T06:49:21Z）より古く、
+  新規コメント無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T07:30:04Z`、17分前で新鮮）で
+  新規異常なし。`coder`/`immich`/`vaultwarden` の Degraded は引き続き T-0106 由来の
+  `SecretSyncedError` のみ、`pod_issues` の restarts:19 常連も変化なし。autopilot 自身の
+  heartbeat も `readyReplicas: 1`・`last_end.exit_code: 0` で異常なし
+- backlog 棚卸し: run #125/#127（15〜30分前）で `blocked`/`needs-human` 10件を個別に再確認
+  済みのため、今回は前提変化の兆候（フィードバック・健全性いずれも無変化）が無いことのみ確認し
+  重複した棚卸しは省略。`todo` は T-0117 のみで `not_before: 2026-08-06T18:30:00Z` により
+  引き続き着手不可（actionable な todo は 0 件）
+- 新規調査（run #125/#127 が inventory/apps дир/TODO grep 済みのため別角度を選択）:
+  (1) GitHub Actions の直近失敗 run を `branch=main&status=failure` で確認 →
+  該当は 2025-12-14 の `Release NixOS Image`（`workflow_dispatch` 専用、§5.4 により CI 検証
+  対象外）1件のみで、8ヶ月前の古い記録であり現在の変更とは無関係のため起票を見送った。
+  (2) `docs/backup.md` の T-0106/T-0120 append-only credential 関連記述が実際の backlog
+  状態（T-0106 needs-human・T-0120 blocked、いずれも未登録のまま）と一致しているか再確認 →
+  ドリフト無し
+- 新規起票: なし
+- やったこと: 上記の確認と journal 記録のみ（CHARTER §2「やることが無い起動でも journal に
+  書いた PR を出す」に従う）
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能。それまでの計画回は健全性確認と
+  フィードバック確認を続けつつ、backlog 棚卸しの重複実施は避けてよい（直近回で前提変化が
+  無いことが分かっている間は再確認のみで足りる）


### PR DESCRIPTION
## 変更点

run #128（計画役）の journal 記録と、それに伴うダッシュボード再生成時の `ops/dashboard/prs.json` キャッシュ更新のみ。コードやマニフェストの変更は無し。

## 検証したこと

- issue #56 のコメントを `per_page=100` で2ページ機械的に確認 → `last_read` 以降の新規コメント無し
- `ops-health-report`（`generated_at: 2026-08-06T07:30:04Z`）を確認 → 既知の異常（T-0106 由来の Degraded 3件、restarts:19 常連）のみで新規異常無し
- backlog の `blocked`/`needs-human` は直近2回（run #125/#127）で棚卸し済みのため、今回は前提変化の兆候が無いことのみ確認
- 新しい切り口として GitHub Actions の直近失敗 run（`branch=main&status=failure`）を確認 → 2025-12-14 の `Release NixOS Image`（`workflow_dispatch` 専用、CI 検証対象外）1件のみで、現在の変更とは無関係
- `docs/backup.md` の T-0106/T-0120 append-only credential 関連記述が実際の backlog 状態と一致しているか確認 → ドリフト無し
- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 正常終了、`ops-dashboard` ブランチへ publish 済み

## ロールバック手順

この PR は journal 追記と PR キャッシュ更新のみで、インフラ・アプリケーションへの影響は無い。revert すれば journal の記録が消えるだけ。

## backlog task id

該当なし（新規起票なし、既存タスクの状態変更もなし）
