### PR TITLE
docs(ops): run #129（計画役）記録更新、T-0135起票

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 135,
-  "updated": "2026-08-06T07:30:00Z",
+  "next_id": 136,
+  "updated": "2026-08-06T08:00:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2550,6 +2550,25 @@
       "created": "2026-08-06",
       "pr": 317,
       "notes": "run #126: CLAUDE.md の Apps 一覧・ディレクトリ構造図に ops-dashboard を追加して done"
+    },
+    {
+      "id": "T-0135",
+      "domain": "homelab",
+      "title": "main に統合済みで残っている孤児ブランチ 2 件（origin/claude/create-immich-manifest-FpCGe, origin/feat/coder-dev-server）の掃除",
+      "kind": "chore",
+      "risk": "low",
+      "status": "todo",
+      "priority": 60,
+      "why": "計画役 run #129 で `git branch -r` を確認したところ、`autopilot/*` 以外に2件の見覚えのないリモートブランチが残っていた。`origin/claude/create-immich-manifest-FpCGe`（最終コミット 2025-12-19、immich の初期 kustomize/helmChart 構成）と `origin/feat/coder-dev-server`（最終コミット 2026-05-22、coder の初期構成 + Plans.md/terraform 差分）で、いずれも autopilot 発足（2026-08-04）より前の手作業期の draft ブランチ。両ブランチの `kustomization.yaml`/ファイル構成は現行 `apps/immich/`・`apps/coder/`（helmCharts 名・バージョンは古いが同じ resources 構成）とほぼ一致しており、その後の拡張（restic-backup, pvc-usage-cronjob 等）を含む現行 main に内容が包含されている。CHARTER §4/§5.5 の『内容が main と重複していることを確認できたものから順に削除してよい』の考え方（元々は autopilot 自身の孤児ブランチ向けだが、検証手順自体はこの2件にも同型で適用できる）に沿って掃除する",
+      "dod": "各ブランチについて `git diff origin/main...<branch>` を取り、追加・変更されているファイルが全て現行 main の同名ファイルに機能的に包含されている（同じリソースが定義済み、または明確に旧版で置き換わっている）ことを確認する。差分が現行 main に無い独自の変更（例: `feat/coder-dev-server` の `terraform/proxmox/vm-nixos.tf` 差分, `Plans.md` 差分）を含む場合は、その内容が既に別の形で反映済みかを individually 確認してから判断する。包含が確認できたら `DELETE /repos/hikuohiku/homelab/git/refs/heads/<branch>`（§5.5 で実測済み、204 が返る）でブランチを削除し、journal に削除したブランチ名と確認した根拠を記録する。念のため削除前に `git rev-parse origin/<branch>` を journal に残し、誤削除時に復元の足がかりを残す",
+      "blocked_by": null,
+      "refs": [
+        "apps/immich/",
+        "apps/coder/"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #129（計画役）: `git branch -r` の再確認から新規発見。autopilot 自身のブランチではないため即削除はせず、実行役が差分の包含を確認したうえで削除する起票に留めた"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 319,
+      "title": "docs(ops): run #128（計画役）記録更新、新規起票なし",
+      "url": "https://github.com/hikuohiku/homelab/pull/319",
+      "mergedAt": "2026-08-06T07:51:49Z",
+      "headRefName": "autopilot/run128-plan-no-new-findings"
+    },
+    {
       "number": 318,
       "title": "docs(ops): run #127（計画役）記録更新、新規起票なし",
       "url": "https://github.com/hikuohiku/homelab/pull/318",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/259",
       "mergedAt": "2026-08-05T23:41:46Z",
       "headRefName": "autopilot/T-0029-confirm-rollback-recovery"
-    },
-    {
-      "number": 258,
-      "title": "revert(immich): postgres 16.14-1.1.1 化を revert する (T-0029, CrashLoopBackOff)",
-      "url": "https://github.com/hikuohiku/homelab/pull/258",
-      "mergedAt": "2026-08-05T23:34:16Z",
-      "headRefName": "autopilot/T-0029-rollback-crashloop"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3739,3 +3739,33 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能。それまでの計画回は健全性確認と
   フィードバック確認を続けつつ、backlog 棚卸しの重複実施は避けてよい（直近回で前提変化が
   無いことが分かっている間は再確認のみで足りる）
+
+## 2026-08-06 16:57 JST — run #129（計画役）
+
+- 前回の中断を拾う: オープン PR 無し。`autopilot/*` 残りブランチも無し。ローカル `main` は
+  `origin/main`（`776f115`）と一致
+- `ops/inbox.md` を読んだ: 見出し以下は空。変換すべき引き継ぎ無し
+- 読んだフィードバック: issue #56 のコメントを `per_page=100` で2ページ（100件+6件、計106件）
+  機械的に確認。最新コメントは 2026-08-06T06:10:37Z で `last_read`（2026-08-06T06:49:21Z）より
+  古く、新規コメント無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T07:30:04Z`、27分前で新鮮）で
+  新規異常なし。`coder`/`immich`/`vaultwarden` の Degraded は引き続き T-0106 由来の
+  `SecretSyncedError` のみ、`pod_issues` の restarts:19 常連も変化なし。autopilot 自身の
+  heartbeat も `readyReplicas: 1`・`last_end.exit_code: 0` で異常なし
+- backlog 棚卸し: run #125/#127/#128（直近30〜60分）で `blocked`/`needs-human` 10件を個別に
+  再確認済みで前提変化の兆候も無いため、今回は重複した個別再確認を省略（run #128 の判断を踏襲）。
+  `todo` は T-0117 のみで `not_before: 2026-08-06T18:30:00Z` により引き続き着手不可
+- 新規調査（run #125/#127/#128 が inventory/apps dir/TODO grep/Actions失敗/docs drift を
+  既に確認済みのため別角度を選択）: (1) GitHub Dependabot alerts / code scanning alerts を
+  API で確認 → 両方とも無効化 or トークン権限不足で 403、この経路からは何も得られず。
+  (2) `git branch -r` を再確認したところ、`autopilot/*` 以外に見覚えのないリモートブランチ
+  2件（`origin/claude/create-immich-manifest-FpCGe` 最終コミット2025-12-19、
+  `origin/feat/coder-dev-server` 最終コミット2026-05-22）が残っていると判明。いずれも
+  autopilot 発足（2026-08-04）より前の手作業期の draft ブランチで、`git diff origin/main...`
+  で確認したところファイル構成が現行 `apps/immich/`・`apps/coder/`（拡張済みの上位互換）に
+  ほぼ一致し、main に内容が包含されていると判断した。ただし削除は autopilot 自身のブランチでは
+  ないため実行役の確認・削除タスクとして T-0135（priority 60, chore, low risk）を起票した
+- 新規起票: T-0135（孤児ブランチ2件の掃除）
+- やったこと: T-0135 の起票（backlog.json のみ、コード変更なし）
+- `python3 ops/validate.py`（0 error）を実行
+- 次の起動へ: T-0135 は着手可能。T-0117 は 2026-08-06T18:30Z 以降に着手可能


### PR DESCRIPTION
## 変更点

計画役 run #129 の記録更新（`ops/journal/2026-08.md`・`ops/backlog.json`・`ops/dashboard/prs.json`）のみ。コード・マニフェストの変更は無し。

- backlog に **T-0135**（priority 60, chore, low risk）を新規起票: `git branch -r` の再確認で見つかった、autopilot 発足（2026-08-04）より前の孤児ブランチ2件（`origin/claude/create-immich-manifest-FpCGe`, `origin/feat/coder-dev-server`）の掃除。内容は現行 `apps/immich/`・`apps/coder/` に包含されていると判断したが、autopilot 自身のブランチではないため即削除はせず、実行役が差分包含を再確認したうえで削除する起票に留めた
- フィードバック（issue #56）・ops-health-report・backlog の blocked/needs-human 10件は前回起動から変化なしを確認

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/dashboard/build.py` → 生成・`ops-dashboard` ブランチへの publish 成功

## ロールバック手順

この PR を revert すれば記録は元に戻る。DB・実インフラへの変更は無いためスキーマ等の考慮は不要。

## backlog task id

T-0135（新規起票、記録のみ）