### PR TITLE
chore(ops): T-0135 孤児ブランチ2件を削除、記録更新

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2557,7 +2557,7 @@
       "title": "main に統合済みで残っている孤児ブランチ 2 件（origin/claude/create-immich-manifest-FpCGe, origin/feat/coder-dev-server）の掃除",
       "kind": "chore",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 60,
       "why": "計画役 run #129 で `git branch -r` を確認したところ、`autopilot/*` 以外に2件の見覚えのないリモートブランチが残っていた。`origin/claude/create-immich-manifest-FpCGe`（最終コミット 2025-12-19、immich の初期 kustomize/helmChart 構成）と `origin/feat/coder-dev-server`（最終コミット 2026-05-22、coder の初期構成 + Plans.md/terraform 差分）で、いずれも autopilot 発足（2026-08-04）より前の手作業期の draft ブランチ。両ブランチの `kustomization.yaml`/ファイル構成は現行 `apps/immich/`・`apps/coder/`（helmCharts 名・バージョンは古いが同じ resources 構成）とほぼ一致しており、その後の拡張（restic-backup, pvc-usage-cronjob 等）を含む現行 main に内容が包含されている。CHARTER §4/§5.5 の『内容が main と重複していることを確認できたものから順に削除してよい』の考え方（元々は autopilot 自身の孤児ブランチ向けだが、検証手順自体はこの2件にも同型で適用できる）に沿って掃除する",
       "dod": "各ブランチについて `git diff origin/main...<branch>` を取り、追加・変更されているファイルが全て現行 main の同名ファイルに機能的に包含されている（同じリソースが定義済み、または明確に旧版で置き換わっている）ことを確認する。差分が現行 main に無い独自の変更（例: `feat/coder-dev-server` の `terraform/proxmox/vm-nixos.tf` 差分, `Plans.md` 差分）を含む場合は、その内容が既に別の形で反映済みかを individually 確認してから判断する。包含が確認できたら `DELETE /repos/hikuohiku/homelab/git/refs/heads/<branch>`（§5.5 で実測済み、204 が返る）でブランチを削除し、journal に削除したブランチ名と確認した根拠を記録する。念のため削除前に `git rev-parse origin/<branch>` を journal に残し、誤削除時に復元の足がかりを残す",
@@ -2567,8 +2567,8 @@
         "apps/coder/"
       ],
       "created": "2026-08-06",
-      "pr": null,
-      "notes": "run #129（計画役）: `git branch -r` の再確認から新規発見。autopilot 自身のブランチではないため即削除はせず、実行役が差分の包含を確認したうえで削除する起票に留めた"
+      "pr": 322,
+      "notes": "run #129（計画役）: `git branch -r` の再確認から新規発見。autopilot 自身のブランチではないため即削除はせず、実行役が差分の包含を確認したうえで削除する起票に留めた。run #131（実行役）: 削除前に `git rev-parse` で両ブランチの HEAD を記録（immich: da131f7c6050af594f11f49945ad1a2f15e35610, coder: 06a9d5b3d7cbd0d86a2899ef13239d8f8d123399）。`git diff origin/main <branch>` を直接比較し、immich 側は main が helm chart 0.13.1（branch は 0.10.3）・restic-backup/pvc-usage-cronjob 追加済みで branch の内容を包含、coder 側は main が deployment/service/rbac/restic-backup/workspace-home-backup-cronjob/templates を備えた大幅拡張版で branch（scaffold のみ）を包含していることを確認。`terraform/proxmox/vm-nixos.tf` の branch 差分（disk size 50→main 256、旧リソース名 `proxmox_download_file`、`local.node01_ip` 未導入）は全て main 側がより新しい状態への改善であり branch は単に古いだけと判断。`Plans.md` の branch 差分（Coder デプロイの計画セクション）は実装（`apps/coder/` の充実度）が計画を上回っており計画メモが陳腐化していただけと判断。両ブランチとも `DELETE /repos/hikuohiku/homelab/git/refs/heads/<branch>` で 204 を確認し削除済み"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 321,
+      "title": "docs(ops): run #130（計画役）記録更新、新規起票なし",
+      "url": "https://github.com/hikuohiku/homelab/pull/321",
+      "mergedAt": "2026-08-06T08:06:17Z",
+      "headRefName": "autopilot/run130-plan-no-new-findings"
+    },
+    {
       "number": 320,
       "title": "docs(ops): run #129（計画役）記録更新、T-0135起票",
       "url": "https://github.com/hikuohiku/homelab/pull/320",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/261",
       "mergedAt": "2026-08-05T23:56:56Z",
       "headRefName": "autopilot/T-0114-checkout-sync-build-autopilot-image"
-    },
-    {
-      "number": 260,
-      "title": "docs(claude-md): apps/autopilot/ の記載漏れを直す (T-0113)",
-      "url": "https://github.com/hikuohiku/homelab/pull/260",
-      "mergedAt": "2026-08-05T23:48:19Z",
-      "headRefName": "autopilot/T-0113-claude-md-autopilot-dir-drift"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3799,3 +3799,27 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   書いた PR を出す」に従う）
 - `python3 ops/validate.py` を実行し 0 error であることを確認
 - 次の起動へ: T-0135 は引き続き着手可能。T-0117 は 2026-08-06T18:30Z 以降に着手可能
+
+## 2026-08-06 08:10 JST — run #131（実行役）
+
+- 前回の中断を拾う: オープン PR 無し。`autopilot/*` 残りブランチも無し。ローカル `main` は
+  `origin/main`（`19aea0e`, run #130 の記録 merge 済み）と一致
+- 読んだフィードバック: issue #56 のコメントを `per_page=100` で2ページ（106件）機械的に確認。
+  最新コメントは `last_read`（2026-08-06T06:49:21Z）より古く、新規コメント無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T08:00:04Z`）で新規異常なし。
+  `coder`/`immich`/`vaultwarden` の Degraded は引き続き T-0106 由来の `SecretSyncedError` のみ。
+  autopilot 自身の heartbeat（iteration #5, `last_end.exit_code: 0`）も異常なし
+- やったこと: T-0135（孤児ブランチ2件の掃除）を実施。削除前に `git rev-parse` で両ブランチの
+  HEAD を記録（`origin/claude/create-immich-manifest-FpCGe`: `da131f7c6050af594f11f49945ad1a2f15e35610`,
+  `origin/feat/coder-dev-server`: `06a9d5b3d7cbd0d86a2899ef13239d8f8d123399`）。`git diff origin/main
+  <branch>` で直接比較し、immich 側は main が helm chart 0.13.1（branch は 0.10.3）・
+  restic-backup/pvc-usage-cronjob 追加済みで branch を包含、coder 側は main が
+  deployment/service/rbac/restic-backup/workspace-home-backup-cronjob/templates を備えた
+  大幅拡張版で branch（scaffold のみ）を包含していることを確認。`terraform/proxmox/vm-nixos.tf`
+  の branch 差分（disk 50→main 256GB、旧リソース名 `proxmox_download_file`、
+  `local.node01_ip` 未導入）は全て main 側が新しい状態への改善で branch が単に古いだけ、
+  `Plans.md` の branch 差分（Coder デプロイ計画）は実装がとうに計画を上回っており陳腐化した
+  メモと判断。`DELETE /repos/hikuohiku/homelab/git/refs/heads/<branch>` で両ブランチとも 204 を
+  確認し削除済み。backlog T-0135 を `done` に更新（PR #322）
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: T-0117 は 2026-08-06T18:30Z 以降に着手可能。backlog に他の todo は無し


### PR DESCRIPTION
## 変更点

- `origin/claude/create-immich-manifest-FpCGe`（最終コミット 2025-12-19、immich の初期 draft）と `origin/feat/coder-dev-server`（最終コミット 2026-05-22、coder の初期 draft）の孤児リモートブランチ2件を削除
- backlog T-0135 を `done` に更新、journal に削除の根拠を記録

コードやマニフェストの変更は無し（削除したのは main に未マージのまま残っていた古い draft ブランチのみ）。

## 検証したこと

削除前に `git diff origin/main <branch>` で両ブランチの内容を直接比較:

- **immich branch**: main は helm chart 0.13.1（branch は 0.10.3）で、restic-backup-cronjob / pvc-usage-cronjob / restic-external-secret が main にのみ存在。branch の内容は main に包含されている
- **coder branch**: main は deployment.yaml / service.yaml / rbac.yaml / restic-backup-cronjob.yaml / workspace-home-backup-cronjob.yaml / templates/ を備えた大幅拡張版。branch は scaffold のみで main に包含されている
- **terraform/proxmox/vm-nixos.tf の branch 差分**: disk size が branch=50GB, main=256GB（2026-08-04 に実施したオンライン拡張後の値）。branch は旧リソース名 `proxmox_download_file` を使用（main は `proxmox_virtual_environment_download_file`）。`local.node01_ip` local variable も main にのみ存在。全て main 側が新しい状態への改善で、branch は単に古いだけ
- **Plans.md の branch 差分**（Coder デプロイの計画セクション）: 実装（`apps/coder/` の充実度）が計画をとうに上回っており、陳腐化した計画メモと判断

削除前に両ブランチの HEAD commit を journal に記録済み（immich: `da131f7c6050af594f11f49945ad1a2f15e35610`, coder: `06a9d5b3d7cbd0d86a2899ef13239d8f8d123399`）。誤りがあれば `git fetch origin da131f7c6050af594f11f49945ad1a2f15e35610` 等で復元可能

`DELETE /repos/hikuohiku/homelab/git/refs/heads/<branch>` で両ブランチとも 204 を確認して削除済み（この PR にはブランチ削除自体は含まれない。ops の記録更新のみ）

`python3 ops/validate.py` を実行し 0 error を確認

## ロールバック手順

この PR 自体は `ops/` の記録のみで実インフラへの影響は無い。revert すれば backlog/journal の記載は元に戻る。削除したブランチの復元は上記の HEAD commit から `git push origin <sha>:refs/heads/<branch-name>` で可能（DB やスキーマは関与しないため不整合は発生しない）

## backlog task id

T-0135