### PR TITLE
T-0136: Tailscale Services/ProxyGroup 調査 — 導入見送り

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2585,7 +2585,7 @@
         "apps/tailscale-operator/"
       ],
       "created": "2026-08-06",
-      "pr": null,
+      "pr": 324,
       "notes": "run #132（計画役）: issue #204 が起票から約1日、backlog・journal のどこにも変換されていなかったため起票。#56 以外の open issue も『まだ観測していないもの』の一つとして毎回確認する価値がある。run #133（実行役）: Tailscale Docs（kubernetes-operator/concepts/proxygroup, manage-and-configure/high-availability）を一次情報源で確認。Services(VIP)/ProxyGroup は主目的が複数ノード間でのプロキシ HA だが、node01 のみの単一ノード構成（`kubectl get nodes` で `nixos` 1台のみ実測）では複数レプリカを立てても同一ノード上に載るためフェイルオーバーの実利益が無い。副次効果のリソース集約（1 Ingress = 1 専用 proxy pod → ProxyGroup で共有 pod に集約）は実在し、`kubectl get pods -n tailscale`/`kubectl top pods -n tailscale` で現在 6 個の ts-* pod が稼働（各 26〜44Mi・2〜7m、合計約 150Mi/22m）と実測したが、集約すると「1 アプリの ingress 障害が他アプリに波及しない」という現状の独立性を失い、CHARTER §4 の到達性を失いうる変更に該当する。ACL/grants の許可設定は Tailscale 管理コンソール（人間専有の外部サービス操作）が要る点も踏まえ、約150Mi（node容量の1.3%程度）の節約のために波及リスクと人間の手作業を払う価値は薄いと判断し、追加実装タスクは起票せず結論を issue #204 に返信した（見送りの再検討条件: ノード追加でHA需要が生じる、またはメモリ逼迫が実際に問題化する場合）"
     },
     {

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2576,7 +2576,7 @@
       "title": "Tailscale の Services 機能を調査し、homelab で使える箇所があるか判断する",
       "kind": "investigate",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 65,
       "why": "issue #204（2026-08-05 15:51:31、人間）「最近出た機能で使ったらよさそうな気がする」。#56 経由のフィードバックではないが、人間からの直接のやってほしいこと。backlog・journal のどこにも未反映だった",
       "dod": "Tailscale の Services（VIP Service）機能のドキュメントを一次情報源で読み、このリポジトリの構成（tailscale-operator によるアプリ毎の ingress 公開、`apps/tailscale-operator/`）に対して何が改善できるか（例: 複数レプリカ/フェイルオーバー、DNS 名の簡素化等）を具体的に洗い出す。使える箇所があれば新しい実装タスクを起票する。無ければ『調査したが現状の構成で追加のメリットが薄い』と結論を issue #204 に返信し、この調査タスクを done にする",
@@ -2586,7 +2586,7 @@
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "run #132（計画役）: issue #204 が起票から約1日、backlog・journal のどこにも変換されていなかったため起票。#56 以外の open issue も『まだ観測していないもの』の一つとして毎回確認する価値がある"
+      "notes": "run #132（計画役）: issue #204 が起票から約1日、backlog・journal のどこにも変換されていなかったため起票。#56 以外の open issue も『まだ観測していないもの』の一つとして毎回確認する価値がある。run #133（実行役）: Tailscale Docs（kubernetes-operator/concepts/proxygroup, manage-and-configure/high-availability）を一次情報源で確認。Services(VIP)/ProxyGroup は主目的が複数ノード間でのプロキシ HA だが、node01 のみの単一ノード構成（`kubectl get nodes` で `nixos` 1台のみ実測）では複数レプリカを立てても同一ノード上に載るためフェイルオーバーの実利益が無い。副次効果のリソース集約（1 Ingress = 1 専用 proxy pod → ProxyGroup で共有 pod に集約）は実在し、`kubectl get pods -n tailscale`/`kubectl top pods -n tailscale` で現在 6 個の ts-* pod が稼働（各 26〜44Mi・2〜7m、合計約 150Mi/22m）と実測したが、集約すると「1 アプリの ingress 障害が他アプリに波及しない」という現状の独立性を失い、CHARTER §4 の到達性を失いうる変更に該当する。ACL/grants の許可設定は Tailscale 管理コンソール（人間専有の外部サービス操作）が要る点も踏まえ、約150Mi（node容量の1.3%程度）の節約のために波及リスクと人間の手作業を払う価値は薄いと判断し、追加実装タスクは起票せず結論を issue #204 に返信した（見送りの再検討条件: ノード追加でHA需要が生じる、またはメモリ逼迫が実際に問題化する場合）"
     },
     {
       "id": "T-0137",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3869,3 +3869,27 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   への書き込みより前に実行され、数イテレーション前の別タスクが残した同名ファイルの残骸を
   読んでしまっていた（旧サンドボックスと違いこの Pod は `/tmp` が使い捨てにならない）。
   `PATCH` で本文を訂正し、再発防止のため CHARTER §5.5 に一時ファイルの扱いを追記した
+
+## 2026-08-06 17:27 JST — run #133（実行役）
+
+- 前回の中断を拾う: オープン PR 無し。`autopilot/*` 残りブランチも無し。ローカル `main` は
+  `origin/main`（`cb10bf1`, run #132 の T-0136/T-0137 起票記録 merge 済み）と一致
+- 読んだフィードバック: issue #56 のコメントを `per_page=100` で確認（全100件）。
+  最新コメントは `last_read`（2026-08-06T06:49:21Z）より古く、新規コメント無し
+- backlog の todo は T-0117（`not_before: 2026-08-06T18:30:00Z` で現在時刻 08:26Z 時点は
+  未到来のため対象外）、T-0136、T-0137 の3件。priority 昇順で T-0136 に着手
+- やったこと: T-0136（Tailscale Services 機能の調査）を実施。Tailscale 公式ドキュメント
+  （`kubernetes-operator/concepts/proxygroup`、`manage-and-configure/high-availability`）を
+  一次情報源で確認し、Services(VIP)/ProxyGroup の主目的が複数ノード間の proxy HA だと判明。
+  `kubectl get nodes` で node01（`nixos`）が単一ノードであることを実測し、複数レプリカにしても
+  フェイルオーバーの実利益が無いと確認。副次効果のリソース集約（現状 `kubectl get pods -n
+  tailscale` で ts-argocd/ts-coder/ts-dex/ts-immich/ts-ops-dashboard/ts-vaultwarden の
+  6 pod が稼働、`kubectl top pods` で合計約150Mi/22m と実測）は実在するが、集約すると
+  「1アプリの ingress 障害が他アプリに波及しない」という現状の独立性を失う（CHARTER §4 の
+  到達性を失いうる変更に該当）うえ、tailnet ACL/grants の変更（Tailscale 管理コンソール、
+  人間専有の外部サービス操作）も要る。150Mi（node容量の1.3%程度）の節約のためにこの
+  トレードオフを払う価値は薄いと判断し、新規実装タスクは起票せず issue #204 に結論を返信した
+  （再検討条件: ノード追加で本来の HA 需要が生じる、またはメモリ逼迫が実際に問題化する場合）
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: backlog の todo は T-0137（syncthing 移行可否検討）のみ。T-0117 は
+  2026-08-06T18:30Z 以降に着手可能

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T07:42:40Z",
+  "updated": "2026-08-06T08:27:00Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
@@ -1231,6 +1231,14 @@
       "kind": "in-cluster",
       "by": "autopilot loop (計画役)",
       "summary": "計画役（journal run #125）。T-0133 の reexec_if_updated 反映と role=plan への切り替えが実際に機能していることを確認（run #124 の疑問に回答）。issue #56 に新規フィードバックなし、ops-health-report・autopilot heartbeat とも正常（T-0106 の SecretSyncedError は kubectl で直接再確認、既知のまま）。blocked/needs-human 10件を棚卸ししたが前提の変化なし。新規調査: inventory.json auto対象27件の upstream 突き合わせは新規発見なし、apps/ops-dashboard/ が CLAUDE.md の Apps 一覧・ディレクトリ構造に未記載と判明し T-0134 を起票。",
+      "prs": []
+    },
+    {
+      "n": 119,
+      "at": "2026-08-06T17:27:00+09:00",
+      "kind": "in-cluster",
+      "by": "autopilot loop (実行役)",
+      "summary": "実行役（journal run #133）。T-0136（Tailscale Services/ProxyGroup 調査）を完遂。node01 が単一ノードのため HA 目的での導入効果は無く、副次効果のリソース集約（ts-* proxy pod 6→少数、実測で合計約150Mi/22m）も独立性喪失（到達性リスク）と人間専有の ACL/grants 設定を天秤にかけると見送りが妥当と判断し、issue #204 に結論を返信した。新規実装タスクの起票なし",
       "prs": []
     }
   ]

--- a/ops/state.json
+++ b/ops/state.json
@@ -1239,7 +1239,9 @@
       "kind": "in-cluster",
       "by": "autopilot loop (実行役)",
       "summary": "実行役（journal run #133）。T-0136（Tailscale Services/ProxyGroup 調査）を完遂。node01 が単一ノードのため HA 目的での導入効果は無く、副次効果のリソース集約（ts-* proxy pod 6→少数、実測で合計約150Mi/22m）も独立性喪失（到達性リスク）と人間専有の ACL/grants 設定を天秤にかけると見送りが妥当と判断し、issue #204 に結論を返信した。新規実装タスクの起票なし",
-      "prs": []
+      "prs": [
+        324
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

T-0136（Tailscale の Services / ProxyGroup 機能の調査、issue #204 由来）を完遂し、**現状の homelab 構成では導入を見送る**と結論しました。コード・マニフェストの変更はなく、backlog/journal/state の記録更新のみです。

- Tailscale 公式ドキュメント（`kubernetes-operator/concepts/proxygroup`、`manage-and-configure/high-availability`）を一次情報源で確認。Services(VIP)/ProxyGroup の主目的は複数ノード間での proxy HA
- node01 が単一ノード（実測: `kubectl get nodes` で `nixos` 1台のみ）のため、複数レプリカにしても同一ノード上に載りフェイルオーバーの実利益が無い
- 副次効果のリソース集約（現状 `apps/tailscale-operator/` 配下、アプリ毎に専用 proxy pod が1個ずつ、実測で `ts-argocd`/`ts-coder`/`ts-dex`/`ts-immich`/`ts-ops-dashboard`/`ts-vaultwarden` の6 pod・合計約150Mi/22m）は実在するが、集約すると「1アプリの ingress 障害が他アプリに波及しない」という現状の独立性を失う（CHARTER §4 の到達性を失いうる変更に該当）うえ、tailnet ACL/grants の変更（Tailscale 管理コンソール、人間専有の操作）も要る
- 150Mi（node容量の1.3%程度）の節約のためにこのトレードオフを払う価値は薄いと判断し、新規実装タスクは起票せず issue #204 に結論を返信した

## 検証したこと

- `kubectl get nodes` / `kubectl get pods -n tailscale` / `kubectl top pods -n tailscale` で単一ノード構成と現在の proxy pod 構成・実使用量を実測
- `python3 ops/validate.py` で 0 error を確認

## ロールバック手順

マニフェスト変更なし。backlog.json / journal / state.json の記録のみのため、必要であれば `git revert` で戻せる。データ・スキーマへの影響なし。

## backlog task id

T-0136（done）