### PR TITLE
docs(ops): run #135 の journal 記録（PR #325 merge、他は blocked/needs-human）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,36 +1,13 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 325,
       "title": "T-0137: syncthing の k8s 移行可否検討（実現可能と結論）",
       "url": "https://github.com/hikuohiku/homelab/pull/325",
-      "isDraft": false,
-      "createdAt": "2026-08-06T08:41:22Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "IN_PROGRESS"
-        },
-        {
-          "conclusion": "IN_PROGRESS"
-        },
-        {
-          "conclusion": "IN_PROGRESS"
-        },
-        {
-          "conclusion": "QUEUED"
-        },
-        {
-          "conclusion": "IN_PROGRESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        }
-      ],
-      "headRefName": "autopilot/T-0137-syncthing-k8s-feasibility",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-06T08:45:11Z",
+      "headRefName": "autopilot/T-0137-syncthing-k8s-feasibility"
+    },
     {
       "number": 324,
       "title": "T-0136: Tailscale Services/ProxyGroup 調査 — 導入見送り",
@@ -443,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/265",
       "mergedAt": "2026-08-06T00:36:29Z",
       "headRefName": "autopilot/T-0078-run83-records"
-    },
-    {
-      "number": 264,
-      "title": "feat(coder): workspace home PVC 用の restic backup CronJob を追加 (T-0078)",
-      "url": "https://github.com/hikuohiku/homelab/pull/264",
-      "mergedAt": "2026-08-06T00:36:24Z",
-      "headRefName": "autopilot/T-0078-coder-workspace-home-backup"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3917,3 +3917,20 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py` を実行し 0 error であることを確認
 - 次の起動へ: backlog の todo は無し（T-0117 は 2026-08-06T18:30Z 以降に着手可能）。次の計画回は
   `ops/inbox.md` の syncthing 実装タスク分割を拾うこと
+
+## 2026-08-06 17:46 JST — run #135（実行役）
+
+- 前回の中断を拾う: オープン PR #325（T-0137 syncthing 移行可否検討）を発見。CI 6件全て
+  green・`mergeable_state: clean`・repo 内で閉じる調査記録のみ（`Plans.md`/`ops/*`）で risk low
+  のため merge した（`7e42c6f`）。マージ済みブランチは GitHub 側で自動削除済みを確認
+  （`git fetch --prune` 後に `git branch -r` から消えていることを確認）
+- 読んだフィードバック: issue #56 のコメントを `per_page=100` で2ページ（100件+6件、計106件）
+  機械的に確認。最新コメントは `last_read`（2026-08-06T06:49:21Z）より古く、新規コメント無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T08:30:04Z`、直近30分以内）で
+  新規異常なし。`coder`/`immich`/`vaultwarden` の Degraded は引き続き T-0106 由来
+  （`<app>-restic-backup-credentials` の `SecretSyncedError` のみ）。autopilot 自身の
+  heartbeat（iteration #8, `last_end.exit_code: 0`）も異常なし
+- backlog の todo は T-0117 のみで `not_before: 2026-08-06T18:30:00Z`（現在時刻 08:46Z 時点は
+  未到来）のため対象外。他は全て `blocked`/`needs-human`（T-0084 も `next_review: 2026-08-08`
+  未到来）で、実行役が進められる部分は無かった
+- 次の起動へ: backlog の todo は無し（T-0117 は 2026-08-06T18:30Z 以降に着手可能）


### PR DESCRIPTION
## 変更点

前回の中断だった PR #325（T-0137: syncthing の k8s 移行可否検討）を merge しました。
機能・マニフェストの変更はなく、`ops/journal/2026-08.md` に run #135 の記録を追記しています。

backlog の `todo` は T-0117（`not_before: 2026-08-06T18:30:00Z`）のみで、実行時点（08:46Z）では
まだ着手可能時刻に到達していませんでした。他の全タスクは `blocked`/`needs-human` で、実行役として
進められる部分はありませんでした（T-0084 も `next_review: 2026-08-08` 未到来）。

`ops-health-report` で新規異常が無いことも確認済みです。

## 検証したこと

- `python3 ops/validate.py` で 0 error を確認
- `python3 ops/dashboard/build.py` を実行し、`ops-dashboard` ブランチへの publish が成功することを確認
- ops-health-report（`generated_at: 2026-08-06T08:30:04Z`）で `coder`/`immich`/`vaultwarden` の
  Degraded は既知の T-0106 由来（`SecretSyncedError`）のみであることを確認、他に異常なし

## ロールバック手順

このコミットを revert すれば journal の記録・dashboard キャッシュ（`ops/dashboard/prs.json`）が
元に戻ります。コード・マニフェストの変更は無いため実インフラへの影響はありません。

## backlog task id

なし（記録のみ。§4 の運用記録の相乗り例外に該当）
