### PR TITLE
docs(ops): run #136 の計画記録（T-0138〜T-0142 起票、PR #326 merge、issue #30 close）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 138,
-  "updated": "2026-08-06T08:19:48Z",
+  "next_id": 143,
+  "updated": "2026-08-06T09:05:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2606,6 +2606,104 @@
       "created": "2026-08-06",
       "pr": 325,
       "notes": "run #132（計画役）: Plans.md M2 の『移行可否検討が未了』が T-0006（run #7, docs のみ）以降も検討タスクとして起票されていなかったため、ここで実行可能な investigate タスクに変換した run #134（実行役）: 移行可否を調査し実現可能と判断。技術的根拠を Plans.md M2 に追記し、issue #31/#38 に結論を返信。実装タスクへの分割起票は計画役の仕事のため ops/inbox.md に引き継ぎ。"
+    },
+    {
+      "id": "T-0138",
+      "domain": "homelab",
+      "title": "syncthing の PVC + Deployment/Service manifest を新規作成する（apps/syncthing/）",
+      "kind": "feature",
+      "risk": "low",
+      "status": "todo",
+      "priority": 68,
+      "why": "T-0137（syncthing の k8s 移行可否検討, 2026-08-06 完了・PR #325）で技術的に実現可能と判断した。Plans.md M2 は「検討完了・実装待ち」。CHARTER §3 の起票の粒度（1タスク=1PR=1論点）に従い、まず manifest 作成のみを独立させる。実データ移行（旧 LXC 101 からの config/データ移行）は別タスク T-0140、Tailscale 公開は別タスク T-0139 に分けた",
+      "dod": "apps/syncthing/ ディレクトリを新設し、kustomization.yaml・deployment.yaml（syncthing 公式イメージ）・service.yaml（この時点では ClusterIP のみ。外部公開の方式は T-0139 で決める）・pvc.yaml（local-path StorageClass。node01 は単一ノードのためノード固定制約は問題にならない、T-0137 の根拠を参照）を作成する。apps/apps.yaml の App of Apps に登録する。ops/inventory.json にバージョン監視対象として追加する（他アプリと同様、check_version_sync.py の対象にするかも検討）。kustomize build（CI）が green であることを確認する。この時点では空の PVC で新規デバイスとして起動するだけで、旧 LXC 101 の既存データ・ピア関係とは無関係（そちらは T-0140）",
+      "blocked_by": null,
+      "refs": [
+        "Plans.md",
+        "apps/apps.yaml",
+        "ops/inventory.json"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #136（計画役）: T-0137 完了を受け ops/inbox.md の引き継ぎ（実装タスクへの分割）をここで起票。"
+    },
+    {
+      "id": "T-0139",
+      "domain": "homelab",
+      "title": "syncthing を Tailscale 経由で公開する（sync ポート/GUI の公開方式を決めて実装）",
+      "kind": "feature",
+      "risk": "low",
+      "status": "todo",
+      "priority": 69,
+      "why": "T-0137 の技術的検討で、sync プロトコル（TCP 22000、discovery UDP 21027 等）は既存アプリが使う Tailscale operator の L7 Ingress（ingressClassName: tailscale）では転送できず、L3 ingress（Service に tailscale.com/expose: \"true\" または loadBalancerClass: tailscale）が必要と判明した。この repo では L3 Service 公開の前例が無い。GUI(8384) を公開するかどうかも Plans.md M2 で未決定のまま残っている",
+      "dod": "T-0138 で作成した Service（または追加の Service）に L3 ingress を設定し、sync ポートを tailnet 上で到達可能にする。GUI(8384) は人間が使う想定があるかで公開要否を判断し、公開する場合は既存の L7 Ingress パターンを別 Service で流用する（sync 用の L3 と GUI 用の L7 は別 Service に分けるのが自然）。前例が無い変更のため、kustomize build（CI）で構文の妥当性は確認できても実際の到達性は確認できない前提を PR 本文に明記する（実機到達性確認は次タスクの範囲か、構築セッション/人間に委ねる）",
+      "blocked_by": "T-0138（apps/syncthing/ の Service manifest が存在すること）",
+      "refs": [
+        "Plans.md",
+        "apps/syncthing/",
+        "apps/tailscale-operator/"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #136（計画役）: T-0137 完了を受け ops/inbox.md の引き継ぎ（実装タスクへの分割）をここで起票。"
+    },
+    {
+      "id": "T-0140",
+      "domain": "homelab",
+      "title": "旧 LXC 101 (syncthing) の config/データを新 PVC へ移行する",
+      "kind": "migrate",
+      "risk": "high",
+      "status": "needs-human",
+      "priority": 70,
+      "why": "T-0137 の検討で、device ID/証明書（cert.pem/key.pem、syncthing の config ディレクトリに保存）を移さないと既存ピアから別デバイスとして再認識されると判明した。CHARTER §4「データを失いうる変更」に該当するため、戻せることを確かめてから着手する必要がある。LXC 101 のファイルシステムへの直接アクセス（pct exec や Proxmox コンソール等）は、autopilot（Proxmox は PVEAuditor=監査専用、kubectl は k8s 内 read-only）にも構築セッション（kubectl read-only のみ、Proxmox/LXC への到達経路なし）にも無い",
+      "dod": "(1) LXC 101 の実際の config パス（`/var/lib/syncthing` 想定、要確認）の中身一式（cert.pem/key.pem/config.xml/index データ）を人間が取得し、構築セッションまたは autopilot が使える経路（例: 一時的な到達手段、Doppler 等）で引き渡す。(2) T-0138 で作成した PVC へそのデータを配置する（kubectl cp 等の書き込み操作は構築セッションか人間が実施。autopilot 自身の ClusterRole は書き込み動詞を持たない、CHARTER §5.5）。(3) 新しい syncthing Pod が既存ピアと再認証なしに同期を再開できることを確認する。(4) 確認できたら旧 LXC 101 を停止し、一定期間の観察後に破棄する（M1 vaultwarden 移行と同じ順序、Plans.md 参照）",
+      "needs_human_reason": "LXC 101 (`/var/lib/syncthing` 想定パス、要確認) の config ディレクトリ一式（cert.pem/key.pem 含む）を取得し、新 PVC へ配置できる形で提供してほしい。自動化された経路（autopilot・構築セッションいずれの credential）でもこのファイルシステムには到達できない",
+      "blocked_by": "T-0138/T-0139 が完了し、移行先の PVC/Service が用意されていること",
+      "refs": [
+        "Plans.md",
+        "apps/syncthing/"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #136（計画役）: T-0137 完了を受け ops/inbox.md の引き継ぎ（実装タスクへの分割）をここで起票。データ移行部分は human 専有（物理的にLXC上のファイルへアクセスする経路が無い）と判断し needs-human で起票。manifest 側（T-0138/T-0139）は着手可能な todo として分離した（CHARTER §3「blocked/needs-human はタスク全体ではなくどの部分かで見る」）"
+    },
+    {
+      "id": "T-0141",
+      "domain": "homelab",
+      "title": "Doppler の Tailscale OAuth credential 3種類の重複・上書き問題を調査する（issue #37）",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "needs-human",
+      "priority": 75,
+      "why": "issue #37（2026-05-19、autopilot 発足前）。Doppler に TAILSCALE_OAUTH_CLIENT_ID/SECRET（旧, auth_keys スコープ）・TAILSCALE_AGENT_CLIENT_ID/SECRET（エージェント専用, devices:core:read）・TAILSCALE_CLIENT_ID/SECRET（不明）の3種類が存在し、.envrc の読み込み順序により対話セッションの Tailscale MCP が意図せず旧 credential（auth_keys スコープ）を使ってしまう、という報告。CLAUDE.md の Agent Operations 節は現在 TAILSCALE_AGENT_CLIENT_ID/SECRET → .envrc → TAILSCALE_OAUTH_CLIENT_ID/SECRET というマッピングを明記しており、これが既に修正済みの状態を指しているのか、報告時点のままなのか、この in-cluster 実行環境からは判別できない",
+      "dod": ".envrc（gitignore 対象で this repo checkout には無い）の実際の内容と、対話セッションで Tailscale MCP が実際にどの credential を使っているかを確認する。既に解消済みなら issue #37 をその根拠とともに close する。未解消なら .envrc の読み込み順序を修正し、TAILSCALE_CLIENT_ID/SECRET（用途不明）が本当に不要なら Doppler から削除する（削除は人間の Doppler 操作）",
+      "needs_human_reason": ".envrc は gitignore 対象でこの in-cluster 実行環境（autopilot pod）からは読めない。また対話セッションの MCP 起動時の環境変数読み込み順序という、autopilot 自身の運用経路（REST API 直叩き、MCP 不使用、CHARTER §5.5）とは別物のため、人間または対話セッションでの再現確認が必要",
+      "blocked_by": null,
+      "refs": [
+        "CLAUDE.md"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #136（計画役）: run #132 が拾った「#56 以外の open issue」棚卸しの引き継ぎで確認。autopilot からは検証不能なため needs-human で起票"
+    },
+    {
+      "id": "T-0142",
+      "domain": "homelab",
+      "title": "手動 credential 作成手順（Proxmox/Doppler/Tailscale の UI 操作）の IaC 化可否を調査する（issue #35）",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "todo",
+      "priority": 76,
+      "why": "issue #35（2026-05-19、autopilot 発足前）。エージェント用 read-only credential 分離（CLAUDE.md Agent Operations）で必要な手動手順が4つ（Proxmox agent@pve ユーザー/トークン作成 他）あり、再現性のため IaC 化したいという要望。着手されないまま残っている",
+      "dod": "issue #35 に列挙された4手順それぞれについて、Terraform 等での自動化が技術的に可能か（例: Proxmox provider の pve_user/pve_acl リソースは、それ自体を作るのに十分な権限を持つ既存 credential が要るという鶏卵問題がありうる）を調査する。自動化可能な部分があれば実装タスクとして分割起票する。ブートストラップ性質上どうしても人間の初回手作業が要る部分は、その理由を issue #35 と CLAUDE.md に明記した上で、再現性を上げる次善策（手順をスクリプト化してコピペミスを防ぐ等）を検討する。全て自動化不能と判断した場合はその根拠を issue #35 に返信し、CHARTER の『人間に渡してよいもの』の実例として記録する",
+      "blocked_by": null,
+      "refs": [
+        "CLAUDE.md",
+        "terraform/proxmox/"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #136（計画役）: run #132 が拾った「#56 以外の open issue」棚卸しの引き継ぎで起票"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 326,
+      "title": "docs(ops): run #135 の journal 記録（PR #325 merge、他は blocked/needs-human）",
+      "url": "https://github.com/hikuohiku/homelab/pull/326",
+      "mergedAt": "2026-08-06T08:51:32Z",
+      "headRefName": "autopilot/run135-record-only"
+    },
+    {
       "number": 325,
       "title": "T-0137: syncthing の k8s 移行可否検討（実現可能と結論）",
       "url": "https://github.com/hikuohiku/homelab/pull/325",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/266",
       "mergedAt": "2026-08-06T00:44:57Z",
       "headRefName": "autopilot/T-0078-mark-done"
-    },
-    {
-      "number": 265,
-      "title": "chore(ops): run #83 の記録更新",
-      "url": "https://github.com/hikuohiku/homelab/pull/265",
-      "mergedAt": "2026-08-06T00:36:29Z",
-      "headRefName": "autopilot/T-0078-run83-records"
     }
   ]
 }

--- a/ops/inbox.md
+++ b/ops/inbox.md
@@ -7,9 +7,3 @@
 [`ops/CHARTER.md`](CHARTER.md) の §3「書く権利」。
 
 ---
-
-- T-0137（syncthing の k8s 移行可否検討）の結論: 技術的に実現可能と判断（詳細は Plans.md M2
-  補足、issue #31/#38 への返信）。実装は「1 タスク = 1 PR = 1 論点」に沿って複数タスクへ分割が
-  必要（例: PVC + Deployment/Service manifest 作成、Tailscale L3 ingress 公開設定、旧 LXC 101
-  からの config/データ移行）。移行対象の LXC 101 の実際の config パス（`/var/lib/syncthing` 想定、
-  未確認）と GUI(8384) を公開するかどうかは実装タスク起票時に決める必要あり。

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3934,3 +3934,48 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   未到来）のため対象外。他は全て `blocked`/`needs-human`（T-0084 も `next_review: 2026-08-08`
   未到来）で、実行役が進められる部分は無かった
 - 次の起動へ: backlog の todo は無し（T-0117 は 2026-08-06T18:30Z 以降に着手可能）
+
+## 2026-08-06 18:05 JST — run #136（計画役）
+
+- 前回の中断を拾う: オープン PR #326（run #135 の journal 記録のみ、`autopilot/run135-record-only`）
+  が残っていた。CI 全 green・`mergeable_state: clean` を確認し merge（低リスクの記録用 PR、
+  §4 の即マージ対象）。ブランチは GitHub 側で自動削除、`git fetch --prune` でローカルの
+  追跡ブランチも整理。以降オープン PR 無し・`autopilot/*` 残りブランチ無しを確認
+- 読んだフィードバック: issue #56 のコメントを `per_page=100` で2ページ（100件+6件、計106件）
+  機械的に確認。最新コメントは `last_read`（2026-08-06T06:49:21Z）より古く、新規コメント無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T08:30:04Z`、取得時点で約20分前、
+  新鮮）で新規異常なし。`coder`/`immich`/`vaultwarden` の Degraded は引き続き T-0106 由来の
+  `SecretSyncedError` のみ、`pod_issues` の restarts:19 常連も変化なし。immich の
+  `backup_listing` 最新ファイルは `2026-08-06T02:00:05Z`（24時間以内）で正常。ファイル名が
+  `v3.1.0` になっていたため一瞬 unpinned floating tag による意図しないメジャー更新かと疑ったが、
+  `apps/immich/values.yaml` が既に `tag: v3.1.0` を pin していることを確認し、想定通りと判断
+  （異常ではない）。autopilot 自身の heartbeat（iteration #9 start, iteration #8 end
+  exit_code: 0）も異常なし
+- `ops/inbox.md` を読んだ: T-0137（syncthing 移行可否検討）完了に伴う実装タスク分割の引き継ぎ
+  （run #134 実行役が残したもの）。「1タスク=1PR=1論点」に沿って3タスクへ分割して起票し、
+  inbox を空にした:
+  - **T-0138**: syncthing の PVC + Deployment/Service manifest 新規作成（`todo`, リスク low、
+    着手可能）
+  - **T-0139**: syncthing を Tailscale 経由で公開（L3 ingress、sync ポート用。GUI 公開要否も
+    判断）（`todo`, T-0138 に続けて着手）
+  - **T-0140**: 旧 LXC 101 からの config/データ移行（device ID/証明書を含む）（`needs-human`、
+    LXC のファイルシステムへ autopilot・構築セッションいずれも到達できないため）
+- backlog 棚卸し: `blocked`/`needs-human` の既存10件は run #132（1.5時間前）が直近で全件
+  再確認済みで、前提を変える新しい情報（フィードバック・健全性の変化）も今回無かったため
+  再確認は省略し据え置き
+- 新規調査: run #132 が引き継いだ「issue #56 以外の open issue（#30/#37/#35）の要否判断」に
+  対応した
+  - **#30**（vaultwarden の追加）: Plans.md M1 で実装済み（`apps/vaultwarden/`, PR #47）と
+    確認し、コメントの上 close した
+  - **#37**（Doppler の Tailscale OAuth credential 3種の上書き問題）: `.envrc` は gitignore
+    対象でこの in-cluster 実行環境からは読めず、対話セッションの MCP 起動順序という autopilot
+    自身の運用経路（REST API 直叩き）とは別物のため検証不能と判断。**T-0141** として
+    `needs-human` で起票
+  - **#35**（手動 credential 作成手順の IaC 化）: Proxmox provider での自動化可否など調査の
+    余地があるため **T-0142** として `todo`（investigate）で起票
+- やったこと: PR #326 の merge、inbox → backlog 変換（T-0138/T-0139/T-0140）、issue 棚卸し
+  （#30 close、T-0141/T-0142 起票）
+- `python3 ops/validate.py` を実行し 0 error（warning 2件は T-0139/T-0140 の refs が
+  `apps/syncthing/` 未作成によるもの、想定通り）であることを確認
+- 次の起動へ: backlog の todo は T-0138・T-0139・T-0142 の3件が着手可能。T-0117 は
+  2026-08-06T18:30Z（あと約30分弱）以降に着手可能。実行役は優先度順に T-0138 から着手すること


### PR DESCRIPTION
## 変更点

計画役として1イテレーション分の作業を実施。**コード・マニフェストの変更はなし**（`ops/` 配下の記録のみ）。

1. **前回の中断を拾う**: オープン PR #326（run #135 の journal 記録のみ）を CI green 確認の上 merge
2. **`ops/inbox.md` の変換**: T-0137（syncthing 移行可否検討）完了に伴う実装タスク分割を、1タスク=1PR=1論点に沿って3件へ起票し inbox を空にした
   - T-0138: syncthing の PVC + Deployment/Service manifest 新規作成（`todo`）
   - T-0139: syncthing を Tailscale 経由で公開（`todo`）
   - T-0140: 旧 LXC 101 からの config/データ移行（`needs-human`、LXC ファイルシステムへの到達手段が無いため）
3. **backlog 棚卸し**: 既存の `blocked`/`needs-human` 10件は直近（run #132, 約1.5時間前）に全件再確認済みで新しい変化が無かったため据え置き
4. **issue 棚卸し**（前回の計画回からの引き継ぎ）: issue #56 以外の open issue（#30/#37/#35）を確認
   - #30（vaultwarden の追加）: 実装済み（Plans.md M1）と確認しコメントの上 close
   - #37（Doppler の Tailscale credential 上書き問題）: この実行環境から検証不能と判断し T-0141 として起票
   - #35（手動 credential 作成手順の IaC 化）: T-0142 として調査タスクを起票

## 検証したこと

- `python3 ops/validate.py` で 0 error（warning 2件は T-0139/T-0140 の refs が `apps/syncthing/` 未作成によるもの。T-0138 で作成されるまでの想定内の警告）
- `python3 ops/dashboard/build.py` を実行し `ops-dashboard` ブランチへの publish が成功することを確認
- `ops-health-report`（`generated_at: 2026-08-06T08:30:04Z`）で新規異常が無いことを確認

## ロールバック手順

このコミットを revert すれば journal の記録・backlog の新規タスク・dashboard キャッシュが元に戻ります。コード・マニフェストの変更が無いため実インフラへの影響はありません。issue #30 の close・issue コメントは GitHub 側の操作のため revert では戻らず、必要なら手動で reopen してください。

## backlog task id

なし（起票そのものが今回の作業内容。§4 の運用記録の相乗り例外に該当）
