### PR TITLE
feat(syncthing): apps/syncthing/ manifest 新規作成（T-0138）

### DIFF
--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -13,4 +13,5 @@ resources:
   - ops-health-reporter/application.yaml
   - autopilot/application.yaml
   - ops-dashboard/application.yaml
+  - syncthing/application.yaml
 

--- a/apps/syncthing/application.yaml
+++ b/apps/syncthing/application.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: syncthing
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/hikuohiku/homelab.git
+    targetRevision: HEAD
+    path: apps/syncthing
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: syncthing
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/syncthing/deployment.yaml
+++ b/apps/syncthing/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: syncthing
+  namespace: syncthing
+  labels:
+    app: syncthing
+spec:
+  replicas: 1
+  # 内部 DB (SQLite, v2 系) を単一 PVC 上に持つため、rolling 中の二重起動を避けて Recreate
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: syncthing
+  template:
+    metadata:
+      labels:
+        app: syncthing
+    spec:
+      containers:
+        - name: syncthing
+          # 公式イメージは latest ではなく具体的なバージョンに pin。2026-08-06 時点の最新安定版
+          # （GitHub Releases で breaking change の記載なしを確認済み、DB は SQLite で新規インストールは
+          # マイグレーション対象外）
+          image: syncthing/syncthing:2.1.3
+          # 公式イメージの entrypoint (script/docker-entrypoint.sh) は root で起動し、$HOME
+          # (=/var/syncthing) を PUID:PGID へ chown した上で su-exec により非 root (既定 1000:1000)
+          # へ権限を落として実行する（GitHub syncthing/syncthing 実測、2026-08-06）。vaultwarden と
+          # 異なり別途 initContainer での chown は不要。root 起動が前提のため runAsNonRoot 等の
+          # securityContext は設定しない
+          env:
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+          ports:
+            - name: gui
+              containerPort: 8384
+            - name: sync-tcp
+              containerPort: 22000
+              protocol: TCP
+            - name: sync-udp
+              containerPort: 22000
+              protocol: UDP
+            - name: discovery
+              containerPort: 21027
+              protocol: UDP
+          volumeMounts:
+            - name: data
+              mountPath: /var/syncthing
+          resources:
+            requests:
+              cpu: 20m
+              memory: 64Mi
+            # memory の limits は入れない（immich/coder と同型の方針、issue #56 2026-08-05）。
+            # 実データ同期を始める前の新規デプロイで実測が無いため、超過が回復不能な OOMKill に
+            # なる memory limits は設定しない。CPU limits は throttle で回復するため設定する
+            limits:
+              cpu: 1000m
+          # 公式 Dockerfile の HEALTHCHECK と同じエンドポイント。GUI 認証設定に関わらず疎通確認できる
+          livenessProbe:
+            httpGet:
+              path: /rest/noauth/health
+              port: gui
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /rest/noauth/health
+              port: gui
+            initialDelaySeconds: 15
+            periodSeconds: 10
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: syncthing-data

--- a/apps/syncthing/kustomization.yaml
+++ b/apps/syncthing/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# helm chart は使わず全リソースを手書き管理 (隠れリソースを作らない方針)
+resources:
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml

--- a/apps/syncthing/pvc.yaml
+++ b/apps/syncthing/pvc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: syncthing-data
+  namespace: syncthing
+  annotations:
+    # データ消失防止: ArgoCD prune / app 削除時も PVC を残す
+    argocd.argoproj.io/sync-options: Prune=false
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      # local-path は実ディスクを予約しない（docs/node01-storage.md）ので大きめに確保する。
+      # この時点では空 PVC（新規デバイスとして起動するだけ）。旧 LXC 101 からの実データ移行は
+      # T-0140 で行う
+      storage: 20Gi

--- a/apps/syncthing/service.yaml
+++ b/apps/syncthing/service.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: syncthing
+  namespace: syncthing
+  labels:
+    app: syncthing
+spec:
+  # ClusterIP のみ。tailnet 経由の公開方式（sync ポート用の L3 ingress、GUI 公開要否）は T-0139 で決める
+  type: ClusterIP
+  selector:
+    app: syncthing
+  ports:
+    - name: gui
+      port: 8384
+      targetPort: gui
+    - name: sync-tcp
+      port: 22000
+      targetPort: sync-tcp
+      protocol: TCP
+    - name: sync-udp
+      port: 22000
+      targetPort: sync-udp
+      protocol: UDP
+    - name: discovery
+      port: 21027
+      targetPort: discovery
+      protocol: UDP

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2613,7 +2613,7 @@
       "title": "syncthing の PVC + Deployment/Service manifest を新規作成する（apps/syncthing/）",
       "kind": "feature",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 68,
       "why": "T-0137（syncthing の k8s 移行可否検討, 2026-08-06 完了・PR #325）で技術的に実現可能と判断した。Plans.md M2 は「検討完了・実装待ち」。CHARTER §3 の起票の粒度（1タスク=1PR=1論点）に従い、まず manifest 作成のみを独立させる。実データ移行（旧 LXC 101 からの config/データ移行）は別タスク T-0140、Tailscale 公開は別タスク T-0139 に分けた",
       "dod": "apps/syncthing/ ディレクトリを新設し、kustomization.yaml・deployment.yaml（syncthing 公式イメージ）・service.yaml（この時点では ClusterIP のみ。外部公開の方式は T-0139 で決める）・pvc.yaml（local-path StorageClass。node01 は単一ノードのためノード固定制約は問題にならない、T-0137 の根拠を参照）を作成する。apps/apps.yaml の App of Apps に登録する。ops/inventory.json にバージョン監視対象として追加する（他アプリと同様、check_version_sync.py の対象にするかも検討）。kustomize build（CI）が green であることを確認する。この時点では空の PVC で新規デバイスとして起動するだけで、旧 LXC 101 の既存データ・ピア関係とは無関係（そちらは T-0140）",
@@ -2624,8 +2624,8 @@
         "ops/inventory.json"
       ],
       "created": "2026-08-06",
-      "pr": null,
-      "notes": "run #136（計画役）: T-0137 完了を受け ops/inbox.md の引き継ぎ（実装タスクへの分割）をここで起票。"
+      "pr": 328,
+      "notes": "run #136（計画役）: T-0137 完了を受け ops/inbox.md の引き継ぎ（実装タスクへの分割）をここで起票。 run #137（実行役）: manifest 実装完了、PR #328。"
     },
     {
       "id": "T-0139",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,43 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 328,
+      "title": "feat(syncthing): apps/syncthing/ manifest 新規作成（T-0138）",
+      "url": "https://github.com/hikuohiku/homelab/pull/328",
+      "isDraft": false,
+      "createdAt": "2026-08-06T09:11:31Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        }
+      ],
+      "headRefName": "autopilot/T-0138-syncthing-manifests",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 327,
+      "title": "docs(ops): run #136 の計画記録（T-0138〜T-0142 起票、PR #326 merge、issue #30 close）",
+      "url": "https://github.com/hikuohiku/homelab/pull/327",
+      "mergedAt": "2026-08-06T09:01:18Z",
+      "headRefName": "autopilot/run136-planning-record"
+    },
     {
       "number": 326,
       "title": "docs(ops): run #135 の journal 記録（PR #325 merge、他は blocked/needs-human）",
@@ -413,13 +450,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/267",
       "mergedAt": "2026-08-06T00:53:42Z",
       "headRefName": "autopilot/T-0118-inventory-sweep-records"
-    },
-    {
-      "number": 266,
-      "title": "chore(ops): T-0078 を done に、run #84 の記録を反映",
-      "url": "https://github.com/hikuohiku/homelab/pull/266",
-      "mergedAt": "2026-08-06T00:44:57Z",
-      "headRefName": "autopilot/T-0078-mark-done"
     }
   ]
 }

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -407,6 +407,17 @@
       "policy": "auto",
       "note": "T-0078 で新設。他3ファイルと同じタグ (0.19.1) を使う設計。ファイル内では coder-workspace-home-backup-retention CronJob の image 行の1箇所のみが check_version_sync.py の regex に検出される（オーケストレータ script 内の RESTIC_IMAGE 定数はリポジトリ名とタグを分けて保持し、regex の誤検出を避けている。詳細はファイル内コメント参照）。タグを上げるときは retention CronJob の image 行と RESTIC_IMAGE_TAG 定数の両方を揃えること。check_version_sync.py の GROUPS に4ファイル目として登録済み（vaultwarden-restic-image の note 参照）",
       "observability_impact": "coder workspace home (coder-<workspace-id>-home PVC) の restic バックアップ・retention CronJob が使用。壊れるとバックアップが取れなくなるが coder workspace 本体の可用性には影響しない"
+    },
+    {
+      "id": "syncthing",
+      "kind": "image",
+      "name": "syncthing/syncthing",
+      "current": "2.1.3",
+      "file": "apps/syncthing/deployment.yaml",
+      "match": "syncthing/syncthing:",
+      "upstream": "github:syncthing/syncthing",
+      "policy": "auto",
+      "note": "T-0138 で新設。タグに v プレフィックスは無い（Docker Hub 実測、2026-08-06）。2.x 系は v1 系から DB を LevelDB→SQLite に変更しているが新規インストールはマイグレーション対象外（GitHub Releases v2.0.0 実測）"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -3979,3 +3979,36 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   `apps/syncthing/` 未作成によるもの、想定通り）であることを確認
 - 次の起動へ: backlog の todo は T-0138・T-0139・T-0142 の3件が着手可能。T-0117 は
   2026-08-06T18:30Z（あと約30分弱）以降に着手可能。実行役は優先度順に T-0138 から着手すること
+
+## 2026-08-06 18:11 JST — run #137（実行役）
+
+- 前回の中断を拾う: オープン PR 無し。`autopilot/*` 残りブランチも無し。ローカル `main` は
+  `origin/main`（`1e90a84`）と一致
+- 読んだフィードバック: issue #56 のコメントを `per_page=100` で2ページ（100件+6件、計106件）
+  機械的に確認。最新コメントは `last_read`（2026-08-06T06:49:21Z）より古く、新規コメント無し
+- backlog の todo は T-0138・T-0139・T-0142 の3件（T-0117 は `not_before: 2026-08-06T18:30:00Z`
+  未到来のため対象外）。run #136 の引き継ぎどおり priority 昇順で T-0138 に着手
+- やったこと: T-0138（syncthing の PVC + Deployment/Service manifest 新規作成）を実装。
+  `apps/syncthing/`（pvc.yaml/deployment.yaml/service.yaml/kustomization.yaml/application.yaml）
+  を新規作成し、`apps/kustomization.yaml`（App of Apps）と `ops/inventory.json`
+  （バージョン監視対象）に登録した（PR #328）
+  - 実装前に GitHub 一次情報源（`syncthing/syncthing` の Dockerfile・
+    `script/docker-entrypoint.sh`）を確認: 公式イメージは root で起動し entrypoint 内で
+    `$HOME`（`/var/syncthing`）を `PUID`/`PGID` へ chown した上で `su-exec` により非 root
+    （既定 1000:1000）へ権限を落とす設計。vaultwarden と異なり別途 `initContainer` の chown が
+    不要と判明したため実装しなかった
+  - image は `syncthing/syncthing:2.1.3`（Docker Hub 実測でタグに `v` プレフィックス無しと確認）。
+    v2.0.0 の GitHub Releases を読み、LevelDB→SQLite のDB移行は「アップグレード時」限定で
+    新規インストールには無関係と確認済み
+  - memory の limits は設定していない（immich/coder と同型の方針。実データ同期前の新規デプロイで
+    実測が無く、CHARTER §4「縛る変更には実測か裏付けが要る」に抵触するため）
+  - `kubectl kustomize apps/syncthing` と `kubectl kustomize apps`（App of Apps 全体）で
+    レンダリングを確認、`python3 ops/validate.py` で 0 error を確認
+  - PR 本文に「未検証（実機）」として Pod ログを読む権限が無く entrypoint の権限降格を直接
+    確認できない旨を明記した。risk は medium（実インフラへの新規デプロイ、ただし新規 namespace
+    に閉じており既存アプリへの影響は無い）と判断し、ロールバック手順を本文に明記
+  - 同じ PR に backlog（T-0138 を `done`、`pr: 328`）の更新も相乗りさせた
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: backlog の todo は T-0139・T-0142 の2件。T-0139 は T-0138（PR #328）が
+  実際に merge されてから着手すること（Service の変更が前提）。PR #328 は CI green を確認して
+  merge まで見届ける

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T08:27:00Z",
+  "updated": "2026-08-06T09:12:44Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
@@ -1241,6 +1241,16 @@
       "summary": "実行役（journal run #133）。T-0136（Tailscale Services/ProxyGroup 調査）を完遂。node01 が単一ノードのため HA 目的での導入効果は無く、副次効果のリソース集約（ts-* proxy pod 6→少数、実測で合計約150Mi/22m）も独立性喪失（到達性リスク）と人間専有の ACL/grants 設定を天秤にかけると見送りが妥当と判断し、issue #204 に結論を返信した。新規実装タスクの起票なし",
       "prs": [
         324
+      ]
+    },
+    {
+      "n": 120,
+      "at": "2026-08-06T18:12:00+09:00",
+      "kind": "in-cluster",
+      "by": "autopilot loop (実行役)",
+      "summary": "実行役（journal run #137）。T-0138（syncthing の PVC + Deployment/Service manifest 新規作成）を実装し PR #328 を作成。公式イメージの entrypoint（root起動→PUID/PGID chown→su-exec で権限降格）を一次情報源で確認し initContainer 不要と判断。memory limits は実測が無いため未設定（immich/coder と同型の方針）。backlog T-0138 を done に更新",
+      "prs": [
+        328
       ]
     }
   ]


### PR DESCRIPTION
## 変更点

`apps/syncthing/` を新規作成し、syncthing (公式イメージ `syncthing/syncthing:2.1.3`) を稼働させる PVC・Deployment・Service の manifest を追加した。App of Apps (`apps/kustomization.yaml`) にも登録し、`ops/inventory.json` にバージョン監視対象として追加した。

- `pvc.yaml`: `local-path` StorageClass、20Gi（旧 LXC 101 との実データ移行は別タスク T-0140。この時点では空の PVC で新規デバイスとして起動するだけ）。`Prune=false` でデータ消失を防止
- `deployment.yaml`: 公式イメージの entrypoint (`script/docker-entrypoint.sh`) は root で起動し `$HOME` を `PUID`/`PGID`（既定 1000:1000）へ chown した上で `su-exec` により非 root へ権限を落として実行する設計（GitHub `syncthing/syncthing` の Dockerfile / entrypoint.sh を一次情報源で確認）。vaultwarden と異なり別途 `initContainer` での chown は不要で、root 起動が前提のため `runAsNonRoot` 等の securityContext は設定していない。memory の limits は設定していない（immich/coder と同型の方針。実データ同期前の新規デプロイで実測が無く、OOMKill は回復しないため）
- `service.yaml`: `ClusterIP` のみ（GUI:8384, sync:22000/tcp,udp, discovery:21027/udp）。Tailscale 経由の外部公開方式は T-0139 で決定・実装する

## 検証したこと

- `kubectl kustomize apps/syncthing` で単体レンダリングが成功することを確認（このクラスタ内 substrate では `kubectl` の read-only 操作が可能、CHARTER §5.5）
- `kubectl kustomize apps` で App of Apps 全体のレンダリングに `syncthing` Application が追加されていることを確認
- `python3 ops/validate.py` で `ops/inventory.json` の追加分を含め 0 error であることを確認
- syncthing v2.0.0 の GitHub Releases を一次情報源で確認し、LevelDB→SQLite のデータベース移行は「アップグレード時」の話で新規インストールには影響しないこと、破壊的な設定フォーマット変更が無いことを確認した

## 未検証（実機）

実際に ArgoCD が sync した後、Pod が Running/Ready になり entrypoint の root→非 root 権限降格が想定通り動くかは、このクラウド/クラスタ内サンドボックスからは Pod ログを読む権限が無く（CHARTER §5.5、`pods/log` サブリソース未許可）確認できない。`ops-health-report` の次回実行（30分毎）で `applications` の health / `pod_issues` を確認する。

## ロールバック手順

このコミットを revert すれば、ArgoCD の prune (`apps` Application, `prune: true`) により `apps/syncthing/` 配下の Deployment/Service/PVC-以外のリソースと App of Apps 登録が削除される。`pvc.yaml` は `Prune=false` のため PVC (`syncthing-data`, `syncthing` namespace) 自体は残る。ただしこの時点では実データを一切含まない空の PVC（旧 LXC 101 からのデータ移行は T-0140 で別途実施）なので、残存しても実害は無い。`syncthing` namespace 自体も ArgoCD の prune 対象外のため残るが空になる。

## backlog

T-0138
