### PR TITLE
feat(syncthing): sync/GUI ポートを tailnet に公開する

### DIFF
--- a/Plans.md
+++ b/Plans.md
@@ -54,7 +54,7 @@ Proxmox LXC で手動運用中のサービスを k8s (ArgoCD) へ移行する。
 |------|------|-----|---------|--------|
 | M0 | docker VM(106) 削除（未使用） | qemu/106 削除 / Tailscale `hikuo-homedocker` 削除 | - | 完了（qemu/106 削除済み・検証済み。Tailscale デバイス削除はユーザー手動） |
 | M1 | vaultwarden を k8s 移行（手書き manifest） | apps/vaultwarden/ 作成・登録 / Doppler `VAULTWARDEN_ADMIN_TOKEN` 登録 / 旧 LXC tailscale 退避 / /data 移行 / 検証 | - | 完了 [PR #47]（ciphers 781 件移行・ログイン確認済み・旧 LXC 100 破棄済み） |
-| M2 | syncthing を k8s 移行 | 移行可否検討完了（T-0137, 2026-08-06）。技術的には実現可能と判断。実装タスクへの分割は未着手 | - | 検討完了・実装待ち |
+| M2 | syncthing を k8s 移行 | manifest 作成（T-0138, PR #328）・tailnet 公開（T-0139）完了。旧 LXC 101 からの実データ移行（T-0140）待ち | - | 実装進行中 |
 
 > 補足: k8s への書き込み操作（移行時の scale/cp/exec 等）は kubectl CLI で行う方針（CLAUDE.md 反映済み）。
 > 当初は `.claude/settings.json` の `permissions.ask` で毎回人間の承認を求めていたが、autopilot の
@@ -74,7 +74,13 @@ Proxmox LXC で手動運用中のサービスを k8s (ArgoCD) へ移行する。
 > L7 Ingress のみで、L3 Service 公開は前例が無い。global discovery/relay はいずれも outbound 接続のみで
 > 動作するため、この cluster の既存 egress で足りる。local discovery（UDP 21027, マルチキャスト）は
 > Pod のネットワーク namespace 内では機能しないが、既存の LXC 版もピア側は Tailscale 経由で到達している
-> 前提のため実質的な後退ではない（ここは実機の現行構成確認までは至っていない）。実装で詰めるべき残課題:
-> PVC サイジング、GUI(8384) を公開するか（公開するなら既存の L7 Ingress パターンを流用可）、
-> LXC 101 の `/var/lib/syncthing`（想定パス、要確認）から新 PVC への config/データ移行手順
-> （cert.pem/key.pem を含めて移すことで既存ピアとの再認証を避ける）。issue #31/#38 に結論を返信済み。
+> 前提のため実質的な後退ではない（ここは実機の現行構成確認までは至っていない）。issue #31/#38 に結論を返信済み。
+>
+> T-0139（2026-08-06）で実装: sync/discovery ポート（TCP/UDP 22000, UDP 21027）は
+> `apps/syncthing/service-tailnet.yaml`（`type: LoadBalancer` + `loadBalancerClass: tailscale`、
+> `tailscale.com/hostname: syncthing-sync`）で公開。GUI(8384) は他アプリ（immich/vaultwarden）と
+> 同じ L7 Ingress パターン（`apps/syncthing/ingress.yaml`）で `syncthing` として公開する判断とした
+> （人間が sync フォルダ・デバイス承認を GUI から操作する必要があるため）。実機での到達性確認は
+> このクラウド/クラスタ内サンドボックスからは検証できず未確認（`kustomize build` による構文検証のみ）。
+> 残課題: LXC 101 の `/var/lib/syncthing`（想定パス、要確認）から新 PVC への config/データ移行手順
+> （cert.pem/key.pem を含めて移すことで既存ピアとの再認証を避ける、T-0140 で対応）。

--- a/apps/syncthing/ingress.yaml
+++ b/apps/syncthing/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: syncthing
+  namespace: syncthing
+  annotations:
+    # immich/vaultwarden パターン流用: クラスタ内トラフィックを Ingress 経由で転送
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: syncthing
+      port:
+        number: 8384
+  tls:
+    # tailscale Ingress は tls.hosts の短縮名から MagicDNS 名 syncthing.<tailnet>.ts.net を発行する
+    # (immich/vaultwarden と同様)。sync ポート用の syncthing-sync とは別デバイス
+    - hosts:
+        - syncthing

--- a/apps/syncthing/kustomization.yaml
+++ b/apps/syncthing/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - pvc.yaml
   - deployment.yaml
   - service.yaml
+  - service-tailnet.yaml
+  - ingress.yaml

--- a/apps/syncthing/service-tailnet.yaml
+++ b/apps/syncthing/service-tailnet.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: syncthing-sync
+  namespace: syncthing
+  labels:
+    app: syncthing
+  annotations:
+    # sync プロトコルは HTTP ではないため L7 Ingress では転送できない。Tailscale operator の
+    # L3 ingress（type: LoadBalancer + loadBalancerClass: tailscale）は iptables/nftables の DNAT で
+    # Service の全ポート・全プロトコル（TCP/UDP）を転送する（Plans.md M2, T-0137/T-0139 調査）。
+    # この Service は独自の tailnet デバイスとして登録されるため、GUI 用 Ingress（syncthing）とは
+    # 別のホスト名にする
+    tailscale.com/hostname: syncthing-sync
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app: syncthing
+  ports:
+    - name: sync-tcp
+      port: 22000
+      targetPort: sync-tcp
+      protocol: TCP
+    - name: sync-udp
+      port: 22000
+      targetPort: sync-udp
+      protocol: UDP
+    - name: discovery
+      port: 21027
+      targetPort: discovery
+      protocol: UDP

--- a/apps/syncthing/service.yaml
+++ b/apps/syncthing/service.yaml
@@ -6,7 +6,8 @@ metadata:
   labels:
     app: syncthing
 spec:
-  # ClusterIP のみ。tailnet 経由の公開方式（sync ポート用の L3 ingress、GUI 公開要否）は T-0139 で決める
+  # GUI のみ。ingress.yaml (L7 Ingress) の backend として使う。
+  # sync/discovery ポートは L7 Ingress で転送できないため service-tailnet.yaml (L3) に分離した（T-0139）
   type: ClusterIP
   selector:
     app: syncthing
@@ -14,15 +15,3 @@ spec:
     - name: gui
       port: 8384
       targetPort: gui
-    - name: sync-tcp
-      port: 22000
-      targetPort: sync-tcp
-      protocol: TCP
-    - name: sync-udp
-      port: 22000
-      targetPort: sync-udp
-      protocol: UDP
-    - name: discovery
-      port: 21027
-      targetPort: discovery
-      protocol: UDP

--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -593,8 +593,13 @@ upstream リポジトリのファイル（例: `deploy/crds/bundle.yaml` のよ�
 - **`restic` CLI はイメージに入っているが、この Pod に B2/restic の credential は無い**
   （`apps/autopilot/external-secret.yaml` は `CLAUDE_CODE_OAUTH_TOKEN`/`AUTOPILOT_GITHUB_TOKEN`
   の 2 つのみ）。バックアップの実 push を自分で検証することはできない。これも構築セッションに頼む
-- 旧 §5.2 のうち引き続き成り立つ（イメージに無い）もの: `terraform` / `kustomize` / `nix` / `just` /
-  `direnv` / `sops` / `docker` / `jq`。`node` は入っている
+- 旧 §5.2 のうち引き続き成り立つ（イメージに無い）もの: `terraform` / `kustomize`（単体バイナリ）/
+  `nix` / `just` / `direnv` / `sops` / `docker` / `jq`。`node` は入っている
+- **ただし `kubectl kustomize <dir>` は使える**（kubectl に組み込みの kustomize 機能。単体
+  `kustomize` バイナリが無いことと矛盾しない、2026-08-06 run #138 で実測）。`helm` チャートを
+  含む場合（`--enable-helm` 相当）はレンダリングできない可能性が高い（未検証）が、helm chart を
+  使わないアプリ（例: `apps/syncthing/`）の manifest は push 前にこれで実際に render 結果を
+  目視確認できる。CI (`kustomize build --enable-helm`) に完全に委ねる前に、まずこれを試す
 - **`/tmp` は Pod の生存期間を通じて持続する。旧・クラウド定期実行サンドボックス（起動毎に使い捨て）
   と違い、この Pod は `INTERVAL_SECONDS` 毎に同じファイルシステムでイテレーションを繰り返す。**
   固定パス（例: `/tmp/pr_body.txt`）に一度書いたファイルは、明示的に消さない限り次のイテレーション

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2632,8 +2632,8 @@
       "domain": "homelab",
       "title": "syncthing を Tailscale 経由で公開する（sync ポート/GUI の公開方式を決めて実装）",
       "kind": "feature",
-      "risk": "low",
-      "status": "todo",
+      "risk": "medium",
+      "status": "done",
       "priority": 69,
       "why": "T-0137 の技術的検討で、sync プロトコル（TCP 22000、discovery UDP 21027 等）は既存アプリが使う Tailscale operator の L7 Ingress（ingressClassName: tailscale）では転送できず、L3 ingress（Service に tailscale.com/expose: \"true\" または loadBalancerClass: tailscale）が必要と判明した。この repo では L3 Service 公開の前例が無い。GUI(8384) を公開するかどうかも Plans.md M2 で未決定のまま残っている",
       "dod": "T-0138 で作成した Service（または追加の Service）に L3 ingress を設定し、sync ポートを tailnet 上で到達可能にする。GUI(8384) は人間が使う想定があるかで公開要否を判断し、公開する場合は既存の L7 Ingress パターンを別 Service で流用する（sync 用の L3 と GUI 用の L7 は別 Service に分けるのが自然）。前例が無い変更のため、kustomize build（CI）で構文の妥当性は確認できても実際の到達性は確認できない前提を PR 本文に明記する（実機到達性確認は次タスクの範囲か、構築セッション/人間に委ねる）",
@@ -2644,8 +2644,8 @@
         "apps/tailscale-operator/"
       ],
       "created": "2026-08-06",
-      "pr": null,
-      "notes": "run #136（計画役）: T-0137 完了を受け ops/inbox.md の引き継ぎ（実装タスクへの分割）をここで起票。"
+      "pr": 329,
+      "notes": "run #136（計画役）: T-0137 完了を受け ops/inbox.md の引き継ぎ（実装タスクへの分割）をここで起票。run #138（実行役）: service-tailnet.yaml（L3, loadBalancerClass: tailscale）と ingress.yaml（GUI, L7）を実装、PR #329。起票時 risk=low だったが実インフラ（Tailscale）への到達性を新設する変更のため medium に修正（可逆・ロールバック手順は PR 本文に明記）。実機到達性は未確認のため ops/inbox.md に確認依頼を追記。"
     },
     {
       "id": "T-0140",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,11 +1,11 @@
 {
   "open": [
     {
-      "number": 328,
-      "title": "feat(syncthing): apps/syncthing/ manifest 新規作成（T-0138）",
-      "url": "https://github.com/hikuohiku/homelab/pull/328",
+      "number": 329,
+      "title": "feat(syncthing): sync/GUI ポートを tailnet に公開する",
+      "url": "https://github.com/hikuohiku/homelab/pull/329",
       "isDraft": false,
-      "createdAt": "2026-08-06T09:11:31Z",
+      "createdAt": "2026-08-06T09:21:41Z",
       "statusCheckRollup": [
         {
           "conclusion": "SUCCESS"
@@ -26,11 +26,18 @@
           "conclusion": "SUCCESS"
         }
       ],
-      "headRefName": "autopilot/T-0138-syncthing-manifests",
+      "headRefName": "autopilot/T-0139-syncthing-tailnet-expose",
       "autoMergeRequest": null
     }
   ],
   "merged": [
+    {
+      "number": 328,
+      "title": "feat(syncthing): apps/syncthing/ manifest 新規作成（T-0138）",
+      "url": "https://github.com/hikuohiku/homelab/pull/328",
+      "mergedAt": "2026-08-06T09:14:25Z",
+      "headRefName": "autopilot/T-0138-syncthing-manifests"
+    },
     {
       "number": 327,
       "title": "docs(ops): run #136 の計画記録（T-0138〜T-0142 起票、PR #326 merge、issue #30 close）",
@@ -443,13 +450,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/268",
       "mergedAt": "2026-08-06T01:05:55Z",
       "headRefName": "autopilot/T-0118-helm-v4-investigate"
-    },
-    {
-      "number": 267,
-      "title": "chore(ops): run #85 の記録更新（inventory 定点調査・T-0118 起票）",
-      "url": "https://github.com/hikuohiku/homelab/pull/267",
-      "mergedAt": "2026-08-06T00:53:42Z",
-      "headRefName": "autopilot/T-0118-inventory-sweep-records"
     }
   ]
 }

--- a/ops/inbox.md
+++ b/ops/inbox.md
@@ -7,3 +7,10 @@
 [`ops/CHARTER.md`](CHARTER.md) の §3「書く権利」。
 
 ---
+
+- T-0139（PR #329）で syncthing の sync ポート(L3, `syncthing-sync`)・GUI(L7, `syncthing`) を
+  tailnet に公開したが、この substrate から実機の tailnet 到達性を検証できない（`tailscale`
+  MCP は devices:core:read のみで疎通確認はできず、read-only kubectl も Service/Ingress の
+  存在は見えても実際の tailnet 到達性は見えない）。構築セッションか人間に `tailscale status`
+  で `syncthing`/`syncthing-sync` デバイスが見えるか、GUI(https://syncthing.<tailnet>.ts.net)
+  にブラウザから到達できるかを確認してもらう投資対効果のある確認待ちタスクとして起票を検討してほしい

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4012,3 +4012,37 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - 次の起動へ: backlog の todo は T-0139・T-0142 の2件。T-0139 は T-0138（PR #328）が
   実際に merge されてから着手すること（Service の変更が前提）。PR #328 は CI green を確認して
   merge まで見届ける
+
+## 2026-08-06 18:22 JST — run #138
+
+- 前回の中断を拾う: オープン PR 無し。`autopilot/*` の全ブランチ（30+件）で
+  `git diff origin/main..origin/<branch>` が空であることを確認（すべて main に統合済み）。
+  ローカル `main` は `origin/main`（`43a797c`）と一致
+- 読んだフィードバック: issue #56 のコメントを `per_page=100` で2ページ（100件+6件、計106件）
+  機械的に確認。最新コメントは `last_read`（2026-08-06T06:49:21Z）より古く、新規コメント無し
+- backlog の todo は T-0117・T-0139・T-0142 の3件。T-0117 は `not_before: 2026-08-06T18:30:00Z`
+  未到来のため対象外。T-0139 は blocker だった T-0138（PR #328）が main に merge 済みのため
+  priority 昇順どおり着手
+- やったこと: T-0139（syncthing の sync/GUI ポートを tailnet に公開）を実装（PR #329）
+  - sync プロトコル（TCP/UDP 22000, discovery UDP 21027）は L7 Ingress で転送できないため、
+    新規 `apps/syncthing/service-tailnet.yaml`（`type: LoadBalancer` +
+    `loadBalancerClass: tailscale`、`tailscale.com/hostname: syncthing-sync`）で L3 公開に分離。
+    Tailscale 公式ドキュメント（`kb/1439`）と WebSearch で `loadBalancerClass: tailscale` の
+    構文・`tailscale.com/hostname` アノテーションの存在を裏取りしてから実装した
+  - GUI(8384) は他アプリ（immich/vaultwarden）と同じ L7 Ingress パターンで新規
+    `apps/syncthing/ingress.yaml` を作成し `syncthing` として公開（人間が sync フォルダ・
+    デバイス承認を GUI から操作できるようにする判断）
+  - 既存 `service.yaml` は GUI 用 ClusterIP のみに縮小
+  - `Plans.md` M2 を更新（実装進行中、GUI 公開判断の根拠を追記）
+  - この substrate に `kustomize`/`helm` は無いが、**`kubectl kustomize apps/syncthing` が
+    実際にレンダリングできる**と分かった（read-only kubectl には kustomize 組み込み機能が
+    含まれる。前回 run #137 の journal に記載があったのに §5.2 のツール表には未反映だった）。
+    これで Service/Ingress の render 結果を実際に目視確認できた。CI 前に手元で
+    render 確認できる範囲が増えたので、次回以降 `kubectl kustomize <dir>` を使う
+  - backlog 起票時点の risk=low を medium に修正（実インフラ=Tailscale への到達性を新設する
+    変更のため）。ロールバック手順は PR 本文に明記。実機の tailnet 到達性はこの substrate から
+    検証不能なため未確認のまま。`ops/inbox.md` に確認依頼を追記
+  - 同じ PR に backlog（T-0139 を `done`、`pr: 329`）の更新も相乗りさせた
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: PR #329 の CI green・merge を見届けること。merge 済みなら backlog の残りは
+  T-0142（IaC 化調査）のみ（T-0117 は 18:30 JST 以降）


### PR DESCRIPTION
## 変更点

T-0138 で作成した syncthing (`apps/syncthing/`) を tailnet に公開する。

- sync プロトコル（TCP/UDP 22000, discovery UDP 21027）は HTTP ではないため、既存アプリが使う
  Tailscale operator の L7 Ingress (`ingressClassName: tailscale`) では転送できない。新規
  `service-tailnet.yaml` で `type: LoadBalancer` + `loadBalancerClass: tailscale`（L3、
  iptables/nftables DNAT で全ポート・TCP/UDP を転送）を使い、`syncthing-sync` という別 tailnet
  デバイスとして公開する。この repo で L3 Service 公開を使うのは初めて
- GUI(8384) は他アプリ（immich/vaultwarden）と同じ L7 Ingress パターンで `syncthing` として公開
  する（新規 `ingress.yaml`）。人間が sync フォルダ・デバイス承認を GUI から操作できるようにする
  判断
- 既存 `service.yaml` は GUI 用の ClusterIP のみに縮小（sync/discovery ポートは
  `service-tailnet.yaml` に移動）
- `Plans.md` M2 を更新（実装進行中、GUI 公開の判断根拠を追記）

## 検証したこと

- `python3 -c "import yaml; yaml.safe_load_all(...)"` で追加・変更した YAML の構文を個別に確認
- `python3 ops/validate.py` → 0 error, 0 warning
- `kustomize`/`helm` はこのクラスタ内サンドボックス（§5.2）に無いため、実際の render 結果は
  CI (`kustomize build --enable-helm`) に委ねる
- **実機の tailnet 到達性（`syncthing-sync`/`syncthing` デバイスが実際に見え、sync/GUI ポートに
  到達できるか）はこのサンドボックスから検証不能。** kubectl は read-only（Service/Ingress の
  作成有無は見えるが、実際の tailnet 上の疎通は確認できない）。次回以降、構築セッション（Coder
  ワークスペース）か人間に `tailscale status` / ブラウザでの GUI アクセスでの確認を委ねる
  （`ops/inbox.md` に追記済み）

## ロールバック手順

この PR の変更（`apps/syncthing/service.yaml`, `service-tailnet.yaml`, `ingress.yaml`,
`kustomization.yaml`, `Plans.md`）を revert すれば、GUI/sync ポートの tailnet 公開は止まり
Service/Ingress は ArgoCD prune で削除される（`syncthing-sync`/`syncthing` の tailnet デバイスも
消える想定）。PVC (`syncthing-data`) やコンテナイメージには触れていないため、データ整合性・
スキーマの問題は無い。

## backlog task id

T-0139
