### PR TITLE
docs(ops): run #138 の merge確認記録

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,36 +1,13 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 329,
       "title": "feat(syncthing): sync/GUI ポートを tailnet に公開する",
       "url": "https://github.com/hikuohiku/homelab/pull/329",
-      "isDraft": false,
-      "createdAt": "2026-08-06T09:21:41Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        }
-      ],
-      "headRefName": "autopilot/T-0139-syncthing-tailnet-expose",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-06T09:25:34Z",
+      "headRefName": "autopilot/T-0139-syncthing-tailnet-expose"
+    },
     {
       "number": 328,
       "title": "feat(syncthing): apps/syncthing/ manifest 新規作成（T-0138）",
@@ -443,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/269",
       "mergedAt": "2026-08-06T01:14:31Z",
       "headRefName": "autopilot/T-0119-apps-readme-sync"
-    },
-    {
-      "number": 268,
-      "title": "chore(ops): run #86 の記録更新（T-0118: helm v4 移行を blocked に）",
-      "url": "https://github.com/hikuohiku/homelab/pull/268",
-      "mergedAt": "2026-08-06T01:05:55Z",
-      "headRefName": "autopilot/T-0118-helm-v4-investigate"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4044,5 +4044,8 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
     検証不能なため未確認のまま。`ops/inbox.md` に確認依頼を追記
   - 同じ PR に backlog（T-0139 を `done`、`pr: 329`）の更新も相乗りさせた
 - `python3 ops/validate.py` を実行し 0 error であることを確認
-- 次の起動へ: PR #329 の CI green・merge を見届けること。merge 済みなら backlog の残りは
-  T-0142（IaC 化調査）のみ（T-0117 は 18:30 JST 以降）
+- PR #329 は同じ起動内で CI green（6 チェック全て success）を確認し merge 済み
+  （merge commit `91656b3`）。ブランチも GitHub 側で自動削除済み
+- 次の起動へ: backlog の todo は T-0142（IaC 化調査）のみ（T-0117 は 18:30 JST 以降）。
+  syncthing の実機 tailnet 到達性（`syncthing`/`syncthing-sync` デバイス、GUI アクセス）は
+  未確認のまま。`ops/inbox.md` に確認依頼を書いたので、計画役が次回読んで起票判断する


### PR DESCRIPTION
## 変更点

run #138（T-0139, PR #329）の journal を、同一起動内で実際に CI green・merge まで見届けた
事実を反映するよう更新（マージ前に書いた「見届けること」という未完了の書き方のまま main に
入っていたのを訂正）。あわせて `ops/dashboard/prs.json` キャッシュを最新化。

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- 記録のみの変更（`ops/journal/`, `ops/dashboard/prs.json`）で `apps/`/`terraform/` には触れていない

## ロールバック手順

revert すれば journal の記載が「見届けること」の未完了表記に戻るだけで、実インフラ・データには影響しない。

## backlog task id

なし（記録のみ、§4 の相乗り例外に該当する運用記録の単独 PR）
