### PR TITLE
docs(ops): T-0142 調査記録（issue #35 コメント、backlog done）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2702,7 +2702,7 @@
         "terraform/proxmox/"
       ],
       "created": "2026-08-06",
-      "pr": null,
+      "pr": 331,
       "notes": "run #136（計画役）: run #132 が拾った「#56 以外の open issue」棚卸しの引き継ぎで起票 run #139（実行役）: bpg/proxmox（user/acl/user_token）、tailscale/tailscale（oauth_client、実ソース tailscale/resource_oauth_client.go まで確認）、DopplerHQ/doppler（secret）の各 provider ドキュメント・実装を確認し、4手順とも技術的には自動化可能と判断。bpg/proxmox の推奨ロール例に Realm.AllocateUser/User.Modify/Permissions.Modify が含まれる点から、既存 terraform Proxmox token がそのまま bootstrap credential として使える可能性が高いことを発見。ただし (1) その既存トークンのロール、(2) 既存 TAILSCALE_CLIENT_ID のスコープの2点は autopilot・構築セッションどちらからも確認不能なため issue #35 に結論とあわせて確認依頼を投稿（issuecomment-5202903809）。自動化不能の結論には至らなかったため CLAUDE.md への反映は見送り。実装タスクへの分割起票は計画役の仕事のため ops/inbox.md に引き継いだ。"
     }
   ]

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2692,7 +2692,7 @@
       "title": "手動 credential 作成手順（Proxmox/Doppler/Tailscale の UI 操作）の IaC 化可否を調査する（issue #35）",
       "kind": "investigate",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 76,
       "why": "issue #35（2026-05-19、autopilot 発足前）。エージェント用 read-only credential 分離（CLAUDE.md Agent Operations）で必要な手動手順が4つ（Proxmox agent@pve ユーザー/トークン作成 他）あり、再現性のため IaC 化したいという要望。着手されないまま残っている",
       "dod": "issue #35 に列挙された4手順それぞれについて、Terraform 等での自動化が技術的に可能か（例: Proxmox provider の pve_user/pve_acl リソースは、それ自体を作るのに十分な権限を持つ既存 credential が要るという鶏卵問題がありうる）を調査する。自動化可能な部分があれば実装タスクとして分割起票する。ブートストラップ性質上どうしても人間の初回手作業が要る部分は、その理由を issue #35 と CLAUDE.md に明記した上で、再現性を上げる次善策（手順をスクリプト化してコピペミスを防ぐ等）を検討する。全て自動化不能と判断した場合はその根拠を issue #35 に返信し、CHARTER の『人間に渡してよいもの』の実例として記録する",
@@ -2703,7 +2703,7 @@
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "run #136（計画役）: run #132 が拾った「#56 以外の open issue」棚卸しの引き継ぎで起票"
+      "notes": "run #136（計画役）: run #132 が拾った「#56 以外の open issue」棚卸しの引き継ぎで起票 run #139（実行役）: bpg/proxmox（user/acl/user_token）、tailscale/tailscale（oauth_client、実ソース tailscale/resource_oauth_client.go まで確認）、DopplerHQ/doppler（secret）の各 provider ドキュメント・実装を確認し、4手順とも技術的には自動化可能と判断。bpg/proxmox の推奨ロール例に Realm.AllocateUser/User.Modify/Permissions.Modify が含まれる点から、既存 terraform Proxmox token がそのまま bootstrap credential として使える可能性が高いことを発見。ただし (1) その既存トークンのロール、(2) 既存 TAILSCALE_CLIENT_ID のスコープの2点は autopilot・構築セッションどちらからも確認不能なため issue #35 に結論とあわせて確認依頼を投稿（issuecomment-5202903809）。自動化不能の結論には至らなかったため CLAUDE.md への反映は見送り。実装タスクへの分割起票は計画役の仕事のため ops/inbox.md に引き継いだ。"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 330,
+      "title": "docs(ops): run #138 の merge確認記録",
+      "url": "https://github.com/hikuohiku/homelab/pull/330",
+      "mergedAt": "2026-08-06T09:30:05Z",
+      "headRefName": "autopilot/run138-record-merge-confirmed"
+    },
+    {
       "number": 329,
       "title": "feat(syncthing): sync/GUI ポートを tailnet に公開する",
       "url": "https://github.com/hikuohiku/homelab/pull/329",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/270",
       "mergedAt": "2026-08-06T01:16:58Z",
       "headRefName": "autopilot/T-0119-run87-wrapup"
-    },
-    {
-      "number": 269,
-      "title": "docs(apps): apps/README.md のアプリ一覧を kustomization.yaml と同期 (T-0119)",
-      "url": "https://github.com/hikuohiku/homelab/pull/269",
-      "mergedAt": "2026-08-06T01:14:31Z",
-      "headRefName": "autopilot/T-0119-apps-readme-sync"
     }
   ]
 }

--- a/ops/inbox.md
+++ b/ops/inbox.md
@@ -14,3 +14,12 @@
   存在は見えても実際の tailnet 到達性は見えない）。構築セッションか人間に `tailscale status`
   で `syncthing`/`syncthing-sync` デバイスが見えるか、GUI(https://syncthing.<tailnet>.ts.net)
   にブラウザから到達できるかを確認してもらう投資対効果のある確認待ちタスクとして起票を検討してほしい
+
+- T-0142（issue #35 調査、issuecomment-5202903809）: 手動 credential 作成4手順は技術的には
+  全て自動化可能と判明（Proxmox: `proxmox_virtual_environment_user`/`_acl`/`user_token`、
+  Tailscale: `tailscale_oauth_client`、Doppler: `doppler_secret` の各 provider リソースが実在）。
+  ただし着手前に人間の確認が2件要る: (1) Proxmox の既存 terraform トークンのロールに
+  `Realm.AllocateUser`/`User.Modify`/`Permissions.Modify` が含まれるか、(2) 既存の
+  `TAILSCALE_CLIENT_ID` のスコープが他の OAuth client を作成できるものか。この2点が
+  確認できたら、Proxmox 自動化・Tailscale 自動化・Doppler provider 導入（新規 service token
+  発行込み）をそれぞれ1タスクずつ（1 PR 1 コンポーネントの粒度、§3）に分割起票することを検討してほしい

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4049,3 +4049,38 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - 次の起動へ: backlog の todo は T-0142（IaC 化調査）のみ（T-0117 は 18:30 JST 以降）。
   syncthing の実機 tailnet 到達性（`syncthing`/`syncthing-sync` デバイス、GUI アクセス）は
   未確認のまま。`ops/inbox.md` に確認依頼を書いたので、計画役が次回読んで起票判断する
+
+## 2026-08-06 18:30 JST — run #139（実行役）
+
+- 前回の中断を拾う: open PR は #330（run #138 の journal 訂正・dashboard キャッシュ更新のみの
+  記録専用 PR）のみ。CI 6 チェック全て success、`mergeable_state: clean` を確認し merge
+  （merge commit `d0547b6`）。ブランチは既に GitHub 側で自動削除済み
+- 読んだフィードバック: issue #56 のコメントを `last_read`（2026-08-06T06:49:21Z）以降で
+  機械的に確認（`per_page=100` で2ページ、計106件）。新規コメント無し
+- backlog の todo は T-0117・T-0142 の2件。T-0117 は `not_before: 2026-08-06T18:30:00Z` が
+  まだ到来していない（現在 09:30 UTC = 18:30 JST ちょうど、境界のため見送り）ため T-0142 に着手
+- やったこと: T-0142（issue #35「手動 credential 作成手順の IaC 化可否」調査）を実施
+  - bpg/proxmox provider の `docs/resources/{virtual_environment_user,virtual_environment_acl,
+    user_token}.md` を実読し、Proxmox 側の3手順（ユーザー・ACL・トークン）に対応する
+    Terraform リソースが揃っていることを確認
+  - tailscale/tailscale provider は `docs/resources/oauth_client.md` だけでなく実ソース
+    `tailscale/resource_oauth_client.go`（GitHub Git Trees API で存在を裏取り）まで確認し、
+    ドキュメントの記述を鵜呑みにせず実装が実在の Tailscale API を呼んでいることを確かめた
+  - DopplerHQ/doppler provider の `docs/resources/secret.md` を確認。`doppler_secret` で
+    生成値を書き込めるが、provider 自身の認証に新規の Doppler service token が要ることが分かった
+  - 副次的な発見: bpg/proxmox の `docs/index.md` が示す推奨ロール例に
+    `Realm.AllocateUser`/`User.Modify`/`Permissions.Modify` が含まれており、既存の terraform
+    Proxmox token が同種のロールなら Proxmox 側は新規ブートストラップ credential 無しで
+    実装できる可能性が高いと判明
+  - 4手順とも技術的には自動化可能と結論。ただし (1) 既存 Proxmox terraform token のロール、
+    (2) 既存 `TAILSCALE_CLIENT_ID` のスコープの2点は autopilot（PVEAuditor/devices:core:read
+    のみ）・構築セッション（kubectl agent-reader のみ、Proxmox/Tailscale の書き込み権限無し）
+    どちらからも確認できないため、issue #35 に調査結果とあわせて確認依頼を投稿した
+    （issuecomment-5202903809）
+  - 実装タスクへの分割起票（DoD に書かれている）は 実行役の権限外（CHARTER §3）のため行わず、
+    `ops/inbox.md` に引き継いだ
+  - backlog（T-0142 を `done`）の更新をこの PR に相乗りさせた
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: backlog の todo は T-0117 のみ（引き続き `not_before` 待ち、次回到来済みのはず）。
+  T-0142 の続きは issue #35 への人間の回答待ち（2点の確認）。回答が来たら計画役が
+  `ops/inbox.md` の引き継ぎを読んで実装タスクに分割起票する想定


### PR DESCRIPTION
## 変更点

T-0142（issue #35「手動 credential 作成手順の IaC 化可否」）の調査記録。コード・manifest の変更は無く、`ops/` の運用記録のみ。

- issue #35 に調査結果を投稿（Proxmox/Tailscale/Doppler の各 Terraform provider リソースを一次ソース（公式ドキュメント・実ソースコード）で確認し、4手順とも技術的には自動化可能と判断。ただし bootstrap credential の権限確認が2点、人間にしか実行できないため確認を依頼した）: https://github.com/hikuohiku/homelab/issues/35#issuecomment-5202903809
- `ops/backlog.json`: T-0142 を `done` に更新
- `ops/inbox.md`: 実装タスクへの分割起票（人間の確認後）を計画役に引き継ぐ1行を追記
- `ops/journal/2026-08.md`: run #139 の記録を追記（あわせて run #138 の記録専用 PR #330 のこの起動内での merge も記載）
- `ops/dashboard/prs.json`: `python3 ops/dashboard/build.py` 実行に伴うキャッシュ更新

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 正常終了、`ops-dashboard` ブランチへ publish 成功
- 記録のみの変更（`ops/`）で `apps/`/`terraform/` には触れていない

## ロールバック手順

revert すれば journal・backlog の記載が調査前の状態（T-0142 `todo`）に戻るだけで、実インフラには影響しない。issue #35 に投稿したコメントは revert では消えない（GitHub 側の記録として残る）。

## backlog task id

T-0142
