### PR TITLE
docs(ops): run #140 記録（着手可能タスク無し）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 331,
+      "title": "docs(ops): T-0142 調査記録（issue #35 コメント、backlog done）",
+      "url": "https://github.com/hikuohiku/homelab/pull/331",
+      "mergedAt": "2026-08-06T09:40:56Z",
+      "headRefName": "autopilot/T-0142-credential-iac-investigation"
+    },
+    {
       "number": 330,
       "title": "docs(ops): run #138 の merge確認記録",
       "url": "https://github.com/hikuohiku/homelab/pull/330",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/271",
       "mergedAt": "2026-08-06T01:30:35Z",
       "headRefName": "autopilot/T-0106-restic-backup-append-only-credential"
-    },
-    {
-      "number": 270,
-      "title": "chore(ops): run #87 の記録更新",
-      "url": "https://github.com/hikuohiku/homelab/pull/270",
-      "mergedAt": "2026-08-06T01:16:58Z",
-      "headRefName": "autopilot/T-0119-run87-wrapup"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4084,3 +4084,23 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - 次の起動へ: backlog の todo は T-0117 のみ（引き続き `not_before` 待ち、次回到来済みのはず）。
   T-0142 の続きは issue #35 への人間の回答待ち（2点の確認）。回答が来たら計画役が
   `ops/inbox.md` の引き継ぎを読んで実装タスクに分割起票する想定
+
+## 2026-08-06 18:41 JST — run #140（実行役）
+
+- 前回の中断を拾う: open PR は #331（T-0142 調査記録の PR、run #139 が作成）のみ。CI 6 チェック
+  全て success、`mergeable_state: clean`、base が現在の main と一致していることを確認し merge
+  （merge commit `a563f51`）。ブランチは GitHub 側で自動削除済み
+- 読んだフィードバック: issue #56 のコメントを `last_read`（2026-08-06T06:49:21Z）以降で
+  機械的に確認（`per_page=100` で2ページ、計106件）。新規コメント無し
+- backlog の todo は T-0117 のみで、`not_before: 2026-08-06T18:30:00Z`（UTC）が未到来
+  （現在 09:41 UTC）のため着手不可。他の todo は無く、blocked/needs-human は 13 件
+  （いずれも人間の回答・credential 待ちで、実行役の手が届く範囲に無い）
+- `ops-health-report`（`generated_at: 2026-08-06T09:30:04Z`、11分前で新鮮）を確認:
+  autopilot 自身の heartbeat は iteration #14 exit_code 0、readyReplicas 1 で正常。
+  `coder`/`immich`/`vaultwarden` の Degraded は T-0106（Doppler 未登録の
+  `SecretSyncedError`、既知）のみで新規異常なし。`pod_issues` の restarts:19 常連も変化なし
+- やったこと: 着手可能なタスクが無いため実装は無し。中断の後始末（PR #331 merge）とフィードバック・
+  健全性の確認のみ
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: backlog の todo は T-0117 のみ（`not_before` は 2026-08-06T18:30:00Z UTC、
+  次回到来しているはず）。それ以外は blocked/needs-human の棚卸し（計画役の仕事）待ち


### PR DESCRIPTION
## 変更点

今回の起動（run #140）で着手可能なタスクが無かったための記録のみの PR。コード・manifest の変更は無い。

- 前回の中断だった PR #331（T-0142 調査記録）を CI green・`mergeable_state: clean` を確認し merge（merge commit `a563f51`）
- issue #56 のフィードバックを機械的に確認（新規コメント無し）
- `ops/backlog.json` の `todo` は T-0117 のみで、`not_before: 2026-08-06T18:30:00Z`（UTC）が未到来のため着手不可。他は全て `blocked`/`needs-human`
- `ops-health-report`（生成 11 分前）で異常が無いことを確認（`coder`/`immich`/`vaultwarden` の Degraded は T-0106 の既知事象のみ、autopilot 自身の heartbeat も正常）
- `ops/journal/2026-08.md` に run #140 の記録を追記
- `ops/dashboard/prs.json`: `python3 ops/dashboard/build.py` 実行に伴うキャッシュ更新

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 正常終了、`ops-dashboard` ブランチへ publish 成功
- 記録のみの変更（`ops/`）で `apps/`/`terraform/` には触れていない

## ロールバック手順

revert すれば journal の追記が無くなるだけで、実インフラには影響しない。

## backlog task id

なし（記録専用 PR）
