### PR TITLE
docs(ops): run #141（計画役）記録更新、T-0143/T-0144/T-0145 起票

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 143,
-  "updated": "2026-08-06T09:05:00Z",
+  "next_id": 146,
+  "updated": "2026-08-06T09:58:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2704,6 +2704,68 @@
       "created": "2026-08-06",
       "pr": 331,
       "notes": "run #136（計画役）: run #132 が拾った「#56 以外の open issue」棚卸しの引き継ぎで起票 run #139（実行役）: bpg/proxmox（user/acl/user_token）、tailscale/tailscale（oauth_client、実ソース tailscale/resource_oauth_client.go まで確認）、DopplerHQ/doppler（secret）の各 provider ドキュメント・実装を確認し、4手順とも技術的には自動化可能と判断。bpg/proxmox の推奨ロール例に Realm.AllocateUser/User.Modify/Permissions.Modify が含まれる点から、既存 terraform Proxmox token がそのまま bootstrap credential として使える可能性が高いことを発見。ただし (1) その既存トークンのロール、(2) 既存 TAILSCALE_CLIENT_ID のスコープの2点は autopilot・構築セッションどちらからも確認不能なため issue #35 に結論とあわせて確認依頼を投稿（issuecomment-5202903809）。自動化不能の結論には至らなかったため CLAUDE.md への反映は見送り。実装タスクへの分割起票は計画役の仕事のため ops/inbox.md に引き継いだ。"
+    },
+    {
+      "id": "T-0143",
+      "domain": "homelab",
+      "title": "syncthing (T-0139) の tailnet 実到達性を構築セッションに確認してもらう",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "needs-human",
+      "priority": 77,
+      "why": "T-0139（PR #329）で syncthing の sync ポート（L3, Service tailscale.com/hostname: syncthing-sync）と GUI（L7 Ingress, syncthing）を tailnet に公開したが、この autopilot 実行環境（in-cluster、kubectl read-only + tailscale devices:core:read のみ）からは実際の到達性を検証できない。tailscale MCP は疎通確認ができず、kubectl でも Service/Ingress の存在は見えても実際に tailnet 上でデバイスとして解決できるかは見えない",
+      "dod": "構築セッション（Coder ワークスペース、tailnet 到達可能）または人間に (1) tailscale status で syncthing / syncthing-sync デバイスが見えるか、(2) GUI（https://syncthing.<tailnet>.ts.net/）にブラウザ/curl から到達できるかを確認してもらう。到達できていれば T-0139 の残った不確実性を解消して journal に記録、できていなければ原因調査タスクを新規起票する",
+      "needs_human_reason": "autopilot・構築セッションいずれの credential でも tailnet の実疎通確認ができない（tailscale MCP は devices:core:read のみで疎通確認不可、read-only kubectl は Service/Ingress の存在確認のみ）。構築セッションが実際に tailnet 上のマシンから tailscale status やブラウザアクセスを試せるなら、それは construction session の範囲内（人間専有ではない）だが、実行の可否自体は issue #56 経由で確認する必要がある",
+      "blocked_by": null,
+      "refs": [
+        "apps/syncthing/",
+        "ops/inbox.md"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #141（計画役）: ops/inbox.md の引き継ぎ（run #138 実行役が残したもの）を起票。issue #56 に確認依頼を投稿済み（https://github.com/hikuohiku/homelab/issues/56#issuecomment-5203057784）"
+    },
+    {
+      "id": "T-0144",
+      "domain": "homelab",
+      "title": "T-0142 (credential 作成手順の IaC 化, issue #35) の人間回答を待って実装タスクに分割する",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "needs-human",
+      "priority": 78,
+      "why": "T-0142 の調査で手動 credential 作成4手順（Proxmox ユーザー/ACL/トークン、Tailscale OAuth client、Doppler provider 導入）は技術的に全て自動化可能と判明したが、着手前に確認が必要な人間専有の情報が2点残っている: (1) 既存 Proxmox terraform トークンのロールに Realm.AllocateUser/User.Modify/Permissions.Modify が含まれるか、(2) 既存 TAILSCALE_CLIENT_ID のスコープが他の OAuth client を作成できるものか。いずれも Proxmox/Tailscale の管理コンソールでしか確認できず、autopilot・構築セッションのどちらの credential にも書き込み権限が無い",
+      "dod": "issue #35（issuecomment-5202903809 で確認依頼済み）への人間の回答を待つ。回答が揃ったら、Proxmox 自動化・Tailscale 自動化・Doppler provider 導入（新規 service token 発行込み）をそれぞれ1タスクずつ（1 PR 1 コンポーネントの粒度、CHARTER §3）に分割して起票し、このタスクは done にする",
+      "needs_human_reason": "既存 Proxmox terraform トークンのロールと既存 TAILSCALE_CLIENT_ID のスコープの確認は Proxmox/Tailscale の管理コンソールでのみ可能で、autopilot・構築セッションいずれの credential にも参照権限が無い。確認依頼は issue #35 に投稿済み（T-0142 で実施）",
+      "blocked_by": null,
+      "refs": [
+        "docs/",
+        "ops/inbox.md"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #141（計画役）: ops/inbox.md の引き継ぎ（run #139 実行役が残したもの）を起票。issue #35 への確認依頼は T-0142 で既に投稿済み（issuecomment-5202903809）のため追加の投稿はしない。2026-08-06T09:35 時点で issue #35 に人間の回答なし（自分の調査コメントのみ）"
+    },
+    {
+      "id": "T-0145",
+      "domain": "homelab",
+      "title": "ops/state.json の runs 配列が journal の run 番号に追随せず抜け続けている（CI での機械検出を追加）",
+      "kind": "chore",
+      "risk": "low",
+      "status": "todo",
+      "priority": 60,
+      "why": "ops/dashboard/build.py はダッシュボードの活動タイムライン・gantt・n_runs 統計を ops/state.json の runs 配列から生成するが、この配列は journal の run 番号に対して2回連続で大きく欠落していた（run #125→#133 の間の7回分、run #138〜#140 の3回分）。CHARTER §7 は journal への毎回追記を明記するが、state.json runs への追記は暗黙の前提のまま明文化されておらず、機械的な検出も無いため、抜けても誰も気づかない。VISION の『人間への報告はダッシュボードに集約する』『同じ事実が2箇所に書かれていない』に反する状態が放置され続けていた（run #141 計画役が run #138〜#140 の3件のみ手で埋め合わせたが、run #126〜#132 の7件は未回収のまま）",
+      "dod": "ops/validate.py に、直近の journal（ops/journal/YYYY-MM.md）から見出し `## ... — run #N` の最大 N を抽出し、ops/state.json の runs 配列がその run 番号まで（欠落なく）追随しているかを検証するチェックを追加する。厳密な1:1対応が前提と分かれば欠落を error、前提が崩れていれば（例: 同一 cron からの並行起動で run 番号が重複するケースがある、run #33 参照）warning に留める。あわせて CHARTER §7 に『journal と同じタイミングで state.json の runs 配列にも追記する』ことを明記する。run #126〜#132 の7件の内容復元は本タスクの範囲外とし、優先度が上がれば別タスクに分ける",
+      "needs_human_reason": null,
+      "blocked_by": null,
+      "refs": [
+        "ops/validate.py",
+        "ops/state.json",
+        "ops/journal/2026-08.md",
+        "ops/CHARTER.md"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #141（計画役）: state.json 棚卸し中に発見。runs 配列の最終更新コミットが T-0138（run #137 相当、8bb31ed）で止まっており、その後の run #138〜#140（PR #329/#331/#332）が追記していなかった。この3件は本 run で手動バックフィル済み（n=121〜123）。さらに遡ると n=118（journal run #125）→ n=119（journal run #133）の間も7回分（run #126〜#132）が欠落しており、これは今回バックフィルしていない（内容の正確な復元には該当run群の journal 全文精読が要るため、再発防止の仕組み化を先に済める判断）"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 332,
+      "title": "docs(ops): run #140 記録（着手可能タスク無し）",
+      "url": "https://github.com/hikuohiku/homelab/pull/332",
+      "mergedAt": "2026-08-06T09:43:51Z",
+      "headRefName": "autopilot/run140-no-actionable-task"
+    },
+    {
       "number": 331,
       "title": "docs(ops): T-0142 調査記録（issue #35 コメント、backlog done）",
       "url": "https://github.com/hikuohiku/homelab/pull/331",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/272",
       "mergedAt": "2026-08-06T01:39:43Z",
       "headRefName": "autopilot/T-0121-heartbeat-tail-window"
-    },
-    {
-      "number": 271,
-      "title": "security(backup): restic backup 専用の append-only credential を追加 (T-0106)",
-      "url": "https://github.com/hikuohiku/homelab/pull/271",
-      "mergedAt": "2026-08-06T01:30:35Z",
-      "headRefName": "autopilot/T-0106-restic-backup-append-only-credential"
     }
   ]
 }

--- a/ops/inbox.md
+++ b/ops/inbox.md
@@ -7,19 +7,3 @@
 [`ops/CHARTER.md`](CHARTER.md) の §3「書く権利」。
 
 ---
-
-- T-0139（PR #329）で syncthing の sync ポート(L3, `syncthing-sync`)・GUI(L7, `syncthing`) を
-  tailnet に公開したが、この substrate から実機の tailnet 到達性を検証できない（`tailscale`
-  MCP は devices:core:read のみで疎通確認はできず、read-only kubectl も Service/Ingress の
-  存在は見えても実際の tailnet 到達性は見えない）。構築セッションか人間に `tailscale status`
-  で `syncthing`/`syncthing-sync` デバイスが見えるか、GUI(https://syncthing.<tailnet>.ts.net)
-  にブラウザから到達できるかを確認してもらう投資対効果のある確認待ちタスクとして起票を検討してほしい
-
-- T-0142（issue #35 調査、issuecomment-5202903809）: 手動 credential 作成4手順は技術的には
-  全て自動化可能と判明（Proxmox: `proxmox_virtual_environment_user`/`_acl`/`user_token`、
-  Tailscale: `tailscale_oauth_client`、Doppler: `doppler_secret` の各 provider リソースが実在）。
-  ただし着手前に人間の確認が2件要る: (1) Proxmox の既存 terraform トークンのロールに
-  `Realm.AllocateUser`/`User.Modify`/`Permissions.Modify` が含まれるか、(2) 既存の
-  `TAILSCALE_CLIENT_ID` のスコープが他の OAuth client を作成できるものか。この2点が
-  確認できたら、Proxmox 自動化・Tailscale 自動化・Doppler provider 導入（新規 service token
-  発行込み）をそれぞれ1タスクずつ（1 PR 1 コンポーネントの粒度、§3）に分割起票することを検討してほしい

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4104,3 +4104,35 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py` を実行し 0 error であることを確認
 - 次の起動へ: backlog の todo は T-0117 のみ（`not_before` は 2026-08-06T18:30:00Z UTC、
   次回到来しているはず）。それ以外は blocked/needs-human の棚卸し（計画役の仕事）待ち
+
+## 2026-08-06 18:55 JST — run #141（計画役）
+
+- `ops/inbox.md` を読んだ: 2件を backlog に変換し inbox を空にした
+  - **T-0143**: T-0139（syncthing tailnet 公開）の実機到達性確認を構築セッションに依頼
+    （`needs-human`）。issue #56 に確認依頼を投稿済み
+    （https://github.com/hikuohiku/homelab/issues/56#issuecomment-5203057784）
+  - **T-0144**: T-0142（issue #35, credential 作成手順の IaC 化）の人間回答待ちを追跡する
+    軽量タスク（`needs-human`）。確認依頼は T-0142 で issue #35 に投稿済みのため追加投稿はしない
+- 読んだフィードバック: issue #56 のコメントを `per_page=100` で2ページ（100件+6件、計106件）
+  機械的に確認。`last_read`（2026-08-06T06:49:21Z）以降の新規コメント無し（自分が投稿した
+  T-0143 の確認依頼のみ）。`last_read` を投稿時刻（2026-08-06T09:51:55Z）に更新
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T09:30:04Z`）で ArgoCD 13 アプリ中
+  `coder`/`immich`/`vaultwarden` の Degraded は既知の T-0106（`SecretSyncedError`）のみ、新規異常
+  なし。`pod_issues` の `restarts:19` 常連も履歴（2026-08-05T22:30〜）を辿り値が変化していない
+  ことを確認し、新規異常ではないと判断。autopilot 自身の heartbeat も正常（iteration #14
+  exit_code 0）
+- backlog 棚卸し: `blocked`/`needs-human` 13件を再確認。issue #56/#35 に人間からの新規回答が
+  無いため、いずれも前提は変わっていない。`azure/setup-helm`（T-0118）の最新リリース (v5.0.1)
+  の README も実読したが「v2+ of this action only support Helm3」の記述は変わらず、blocked の
+  前提は継続して成立
+- 副次的に発見: `ops/state.json` の `runs` 配列が journal の run 番号に追随しておらず、
+  直近では run #138〜#140（PR #329/#331/#332）の3件が未反映だった（さらに遡ると run #126〜
+  #132 の7件も欠落）。ダッシュボードの活動タイムライン・gantt がこの配列を直接参照するため、
+  人間向けの窓が実態より古い状態のまま表示され続けていた。直近3件は本 run で内容を復元して
+  バックフィルし、再発防止（CI での機械検出、CHARTER §7 への明記）を **T-0145** として起票した。
+  古い7件（run #126〜#132）の復元は T-0145 の範囲外とし、必要になれば別タスクに分ける
+- やったこと: inbox 変換（T-0143/T-0144 起票 + issue #56 への投稿）、backlog 棚卸し、
+  state.json runs 配列のバックフィル（n=121〜123）+ 本 run 分の追記（n=124）、T-0145 起票
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: backlog の todo は T-0117（`not_before` 到来済みのはず）のみ。実行役は
+  優先度順にこれから着手すること。T-0143/T-0144 は人間・構築セッションの回答待ち

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T09:12:44Z",
+  "updated": "2026-08-06T09:58:00Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T06:49:21Z"
+    "last_read": "2026-08-06T09:51:55Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -1252,6 +1252,42 @@
       "prs": [
         328
       ]
+    },
+    {
+      "n": 121,
+      "at": "2026-08-06T18:22:00+09:00",
+      "kind": "in-cluster",
+      "by": "autopilot loop (実行役)",
+      "summary": "実行役（journal run #138）。前回中断（T-0138, PR #328）が main に merge 済みと確認。T-0139（syncthing の sync/GUI ポートを tailnet に公開）を実装: sync プロトコル用に L3 Service（loadBalancerClass: tailscale）を新設、GUI は既存パターンの L7 Ingress。risk を low→medium に修正（実インフラへの到達性新設）。PR #329 を同起動内で CI green 確認のうえ merge。実機の tailnet 到達性は未確認のため ops/inbox.md に確認依頼を追記。backlog T-0139 を done に更新",
+      "prs": [
+        329
+      ]
+    },
+    {
+      "n": 122,
+      "at": "2026-08-06T18:30:00+09:00",
+      "kind": "in-cluster",
+      "by": "autopilot loop (実行役)",
+      "summary": "実行役（journal run #139）。前回中断（run #138 の記録専用 PR #330）を merge。T-0142（issue #35 の credential 手動作成手順、IaC 化可否）を調査: Proxmox/Tailscale/Doppler 各 provider のドキュメント・実ソースを確認し技術的には全て自動化可能と判断。ただし既存 Proxmox terraform トークンのロールと既存 TAILSCALE_CLIENT_ID のスコープの2点は自動化された経路から確認できないため issue #35 に確認依頼を投稿（issuecomment-5202903809）。実装タスクへの分割は計画役の仕事のため ops/inbox.md に引き継いだ。backlog T-0142 を done に更新",
+      "prs": [
+        331
+      ]
+    },
+    {
+      "n": 123,
+      "at": "2026-08-06T18:41:00+09:00",
+      "kind": "in-cluster",
+      "by": "autopilot loop (実行役)",
+      "summary": "実行役（journal run #140）。前回中断（T-0142 記録 PR #331）を merge。backlog の todo は T-0117 のみで not_before 未到来のため着手可能なタスク無し。issue #56 に新規フィードバックなし、ops-health-report にも新規異常なし（既知の T-0106 由来 Degraded のみ）。実装は行わず中断の後始末とフィードバック・健全性確認のみ",
+      "prs": []
+    },
+    {
+      "n": 124,
+      "at": "2026-08-06T18:55:00+09:00",
+      "kind": "in-cluster",
+      "by": "autopilot loop (計画役)",
+      "summary": "計画役（journal run #141）。ops/inbox.md の2件を backlog に変換: T-0143（syncthing tailnet 到達性の構築セッション確認依頼、issue #56 に投稿済み）、T-0144（T-0142/issue #35 の人間回答待ち追跡）。issue #56 に新規フィードバック無し（last_read を投稿時刻に更新）。ops-health-report で新規異常無しを確認。blocked/needs-human 13件を棚卸し、前提の変化無しを確認（azure/setup-helm v5.0.1 の README も実読）。副次的に ops/state.json の runs 配列が journal run #138〜#140 分（さらに遡り #126〜#132 分）追随していなかったのを発見し、直近3件をバックフィル、再発防止を T-0145 として起票",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

計画役（run #141）による ops/ 記録の更新のみ。コード・マニフェストの変更は無い。

- `ops/inbox.md` の2件を backlog タスクに変換し、inbox を空にした
  - **T-0143**: T-0139（syncthing の tailnet 公開）の実機到達性を構築セッションに確認して
    もらう依頼。issue #56 に確認依頼を投稿済み
    ([issuecomment-5203057784](https://github.com/hikuohiku/homelab/issues/56#issuecomment-5203057784))
  - **T-0144**: T-0142（issue #35, credential 手動作成手順の IaC 化）の人間回答待ちを追跡する
    軽量タスク。確認依頼自体は T-0142 で issue #35 に投稿済み
- `ops/state.json` の `runs` 配列が journal の run 番号に追随しておらず、直近では run #138〜
  #140（PR #329/#331/#332）の3件が未反映だったのを発見。ダッシュボードの活動タイムライン・
  gantt はこの配列を直接参照するため、人間向けの窓が実態より古いまま表示され続けていた。
  内容を復元し3件をバックフィル（n=121〜123）。再発防止（CI での機械検出、CHARTER §7 への
  明記）を **T-0145** として起票。より古い run #126〜#132（7件）の欠落は本 PR の範囲外
- issue #56 の `feedback.last_read` を、新規に投稿した確認依頼コメントの時刻まで更新
- `ops/dashboard/index.html` を再生成し `ops-dashboard` ブランチへ publish

## 検証したこと

- `python3 ops/validate.py` で 0 error
- `python3 ops/dashboard/build.py` が例外なく完了（`ops-dashboard` ブランチへの publish 成功）

## ロールバック手順

この PR は `ops/` 配下の記録ファイルのみで、インフラ・アプリへの変更は無い。revert すれば
即座に元に戻る（スキーマ等の後方互換性の懸念も無い）。

## backlog task id

T-0143, T-0144, T-0145（起票のみ、実装は無し）
