### PR TITLE
docs(ops): run #142（計画役）記録更新、着手可能タスク変化なしを確認

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 333,
+      "title": "docs(ops): run #141（計画役）記録更新、T-0143/T-0144/T-0145 起票",
+      "url": "https://github.com/hikuohiku/homelab/pull/333",
+      "mergedAt": "2026-08-06T09:56:27Z",
+      "headRefName": "autopilot/run141-planning-record"
+    },
+    {
       "number": 332,
       "title": "docs(ops): run #140 記録（着手可能タスク無し）",
       "url": "https://github.com/hikuohiku/homelab/pull/332",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/273",
       "mergedAt": "2026-08-06T01:43:51Z",
       "headRefName": "autopilot/T-0121-run89-wrapup"
-    },
-    {
-      "number": 272,
-      "title": "fix(ops-health-reporter): autopilot heartbeat 検出窓を tailLines から sinceSeconds に変更 (T-0121)",
-      "url": "https://github.com/hikuohiku/homelab/pull/272",
-      "mergedAt": "2026-08-06T01:39:43Z",
-      "headRefName": "autopilot/T-0121-heartbeat-tail-window"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4136,3 +4136,21 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py` を実行し 0 error であることを確認
 - 次の起動へ: backlog の todo は T-0117（`not_before` 到来済みのはず）のみ。実行役は
   優先度順にこれから着手すること。T-0143/T-0144 は人間・構築セッションの回答待ち
+
+## 2026-08-06 19:00 JST — run #142（計画役）
+
+- `ops/inbox.md` を読んだ: 空（run #141 が空にした後、新規の追記なし）
+- 読んだフィードバック: issue #56 のコメントを `per_page=100` で2ページ（100件+7件、計107件）
+  機械的に確認。`last_read`（2026-08-06T09:51:55Z、run #141 が更新）以降の新規コメント無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T09:30:04Z`、30分以内で新鮮）で
+  ArgoCD 13 アプリ中 `coder`/`immich`/`vaultwarden` の Degraded を確認。`kubectl get
+  externalsecret -A` で直接裏取りし、`SecretSyncedError` は `<app>-restic-backup-credentials`
+  の3件のみ（T-0106、既知）で他の ExternalSecret・Pod への波及は無いことを確認。autopilot 自身の
+  heartbeat も正常（iteration #14 exit_code 0、readyReplicas 1）
+- backlog 棚卸し: `blocked`/`needs-human` 13件を再確認。run #141 から日が浅く（issue #56/#35
+  への新規回答無し）前提に変化なし。todo は T-0117（`not_before` 到来済み）・T-0145 の2件で
+  実行役への引き継ぎ分は足りている。backlog が空/全blocked ではないため新規調査タスクの起票は
+  見送り
+- やったこと: 上記の確認のみ。新規起票・記録変更は無し
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: backlog の todo は T-0117・T-0145 の2件。実行役は優先度順に着手すること

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T09:58:00Z",
+  "updated": "2026-08-06T10:00:52Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
@@ -1287,6 +1287,14 @@
       "kind": "in-cluster",
       "by": "autopilot loop (計画役)",
       "summary": "計画役（journal run #141）。ops/inbox.md の2件を backlog に変換: T-0143（syncthing tailnet 到達性の構築セッション確認依頼、issue #56 に投稿済み）、T-0144（T-0142/issue #35 の人間回答待ち追跡）。issue #56 に新規フィードバック無し（last_read を投稿時刻に更新）。ops-health-report で新規異常無しを確認。blocked/needs-human 13件を棚卸し、前提の変化無しを確認（azure/setup-helm v5.0.1 の README も実読）。副次的に ops/state.json の runs 配列が journal run #138〜#140 分（さらに遡り #126〜#132 分）追随していなかったのを発見し、直近3件をバックフィル、再発防止を T-0145 として起票",
+      "prs": []
+    },
+    {
+      "n": 125,
+      "at": "2026-08-06T19:00:00+09:00",
+      "kind": "scheduled",
+      "by": "autopilot loop (計画役)",
+      "summary": "計画役（journal run #142）。inbox 空・フィードバック未読無し・health 正常（T-0106 既知のみ）・backlog 前提変化なしを確認。新規起票無し、todo は T-0117/T-0145 の2件を維持",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

autopilot 計画役 run #142 の記録（journal 追記 + `ops/state.json` の `runs` 配列追記）。コード・マニフェストの変更なし。

## やったこと（この回の計画作業）

- `ops/inbox.md`: 空（run #141 が空にした後、新規の追記なし）
- フィードバック issue #56: `per_page=100` で2ページ（計107件）を機械的に確認。`last_read`（2026-08-06T09:51:55Z）以降の新規コメント無し
- `ops-health-report`（`generated_at: 2026-08-06T09:30:04Z`、30分以内）で ArgoCD 全13アプリの状態を確認。`coder`/`immich`/`vaultwarden` の Degraded は `kubectl get externalsecret -A` で直接裏取りし、`SecretSyncedError` が `<app>-restic-backup-credentials`（T-0106、既知）の3件のみであることを確認。他の異常なし
- `ops/backlog.json` の `blocked`/`needs-human` 13件を再確認。直前の run #141 から日が浅く、前提に変化なし
- todo は T-0117（`not_before` 到来済み）・T-0145 の2件で、実行役への引き継ぎ分としては十分と判断し、新規タスクの起票は見送った

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 正常終了、`ops-dashboard` ブランチへ公開成功

## ロールバック手順

このコミットを revert すれば元に戻る。`ops/` の記録のみでスキーマ変更・実インフラへの影響なし。

## backlog task id

なし（新規タスクの起票は無し。記録更新のみ）
