### PR TITLE
docs(ops): run #145（計画役）記録更新、PR #336 の中断回収を記録

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 336,
+      "title": "docs(ops): run #144（計画役）記録更新、T-0146起票",
+      "url": "https://github.com/hikuohiku/homelab/pull/336",
+      "mergedAt": "2026-08-06T10:31:29Z",
+      "headRefName": "autopilot/run144-planning-record"
+    },
+    {
       "number": 335,
       "title": "T-0145: state.json runs 配列の journal 追随を CI で検証する",
       "url": "https://github.com/hikuohiku/homelab/pull/335",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/276",
       "mergedAt": "2026-08-06T02:17:58Z",
       "headRefName": "autopilot/T-0123-validate-pr-notes-warning-noise"
-    },
-    {
-      "number": 275,
-      "title": "docs(ops): T-0106 由来の ArgoCD Degraded health を既知事象として記録 (T-0122)",
-      "url": "https://github.com/hikuohiku/homelab/pull/275",
-      "mergedAt": "2026-08-06T02:06:56Z",
-      "headRefName": "autopilot/T-0122-degraded-health-from-t0106"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4217,3 +4217,32 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py` を実行し 0 error であることを確認
 - 次の起動へ: backlog の todo は T-0117（`not_before` 2026-08-06T18:30:00Z 未到来）・T-0146
   （cachix pull 実効性の調査）の2件。T-0146 は `not_before` 制約が無いため実行役は直ちに着手可能
+
+## 2026-08-06 19:32 JST — run #145（計画役）
+
+- 前回の中断確認: `main` に反映されないまま残っていたブランチ `autopilot/run144-planning-record`
+  を発見。中身は自分がこれから行うはずだった計画役の作業（inbox 反映・feedback 確認・health 確認・
+  backlog 棚卸し・T-0146 起票）を既に完了済みの journal/state/backlog 更新だった。着手時点で
+  PR は無かったため作成しようとしたところ、ほぼ同時刻に別セッション（同じ in-cluster loop の
+  並行イテレーションと思われる）が先に PR #336 を作成済みと判明（`already exists` エラーで発覚）。
+  内容の妥当性を独自に再検証: (1) issue #56 を `per_page=100` で2ページ確認し、ブランチの
+  `last_read`（10:24:03Z）以降に新規コメントが無いことを確認、(2) `ops-health-report`
+  （`generated_at: 10:30:04Z`、2分以内で新鮮）で ArgoCD の Degraded が T-0106 由来の既知3件のみ
+  なこと・autopilot 自身の heartbeat が正常なことを再確認、(3) backlog の `blocked`/`needs-human`
+  の中でも優先度が高い T-0107・T-0112 の理由が今も有効なことを個別に確認。CI 6件（GitGuardian /
+  terraform validate / ops state validate / nix flake check / kustomize build / manifest
+  deletion guard）が green だったため PR #336 を merge した。ブランチは merge 後に GitHub 側で
+  自動削除済み（削除 API 呼び出しは 422、既に存在しなかった）
+- 読んだフィードバック: 上記の再確認により、last_read 以降の新規人間フィードバックは無いことを
+  重複確認済み（last_read は PR #336 の内容で既に更新済み）
+- 健全性確認: 上記の通り異常なし
+- やったこと: PR #336 の merge のみ。PR #336 自身が計画役の1イテレーション分の作業（inbox 反映・
+  backlog 棚卸し・T-0146 起票）を完了済みだったため、同じ内容を重複して行うことはしなかった
+- 見つけたこと: 同一 in-cluster loop から複数セッションが同時に「計画役」として起動し、同じ
+  journal run 番号（#144）を独立に採番して同時に作業する事例を初めて観測した（実行役側では
+  run #32/#33、run #45/#46 で既知の現象だったが、計画役でも起きうると確認）。実害は無かった
+  （後発側が先発側の完成済み PR を発見し取り込んだだけ）が、次に計画役が同時起動を踏んだときの
+  参考として記録する
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: backlog の todo は T-0117（`not_before` 2026-08-06T18:30:00Z 未到来）・T-0146
+  （cachix pull 実効性の調査）の2件。変化なし

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T10:24:03Z",
+  "updated": "2026-08-06T10:32:14Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T10:24:03Z"
+    "last_read": "2026-08-06T10:32:14Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
@@ -1314,6 +1314,16 @@
       "by": "autopilot (in-cluster)",
       "summary": "計画役（journal run #144）。inbox の引き継ぎ（run #142 の journal 記述誤り訂正）を反映し空にした。issue #56 に新規の人間フィードバック無し（last_read 以降の1件は run #143 自身の反映報告への言及で自己返信と判断）。health 正常（T-0106 既知の Degraded のみ）。blocked/needs-human 13件の前提変化なし（T-0141 は .envrc がこの環境にも無いことを確認し needs-human 継続）。backlog の todo が T-0117（not_before 未到来）のみで actionable 不足だったため、inventory.json auto 対象13件の上流バージョン確認（差分無し）と未トリアージの open issue 洗い出しを実施し、issue #26（nix build cache がActions で効いていない疑い）を T-0146 として起票",
       "prs": []
+    },
+    {
+      "n": 128,
+      "at": "2026-08-06T10:32:14Z",
+      "kind": "in-cluster-loop",
+      "by": "autopilot (in-cluster)",
+      "summary": "計画役（journal run #145）。前回の中断（PR 化されずに残っていた run #144 のブランチ）を拾おうとしたところ、ほぼ同時刻に並行イテレーションが先に PR #336 を作成済みと判明。内容（issue #56 の未読無し確認、health 正常、blocked/needs-human 13件の前提変化なし、T-0146 起票）を独自に再検証し、CI green を確認して merge した。同一内容の重複作業はせず、計画役でも同一 loop からの並行起動が起きうると journal に記録。新規起票なし、todo は T-0117/T-0146 のまま変化なし",
+      "prs": [
+        336
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

計画役（journal run #145）の記録更新のみ。コード・マニフェストの変更は無い。

- 着手時に、main へ反映されないまま残っていたブランチ `autopilot/run144-planning-record`（計画役の1イテレーション分の作業が完了済み）を発見。PR を作ろうとしたところ、ほぼ同時刻に並行イテレーションが先に PR #336 を作成済みと判明した
- PR #336 の内容（issue #56 未読フィードバック無しの確認、`ops-health-report` による健全性確認、`blocked`/`needs-human` 13件の前提再確認、T-0146 起票）を独自に再検証し、CI green（6チェック success）を確認したうえで merge 済み
- 同一内容の重複作業はせず、その経緯を journal・`ops/state.json` に記録した

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 生成・`ops-dashboard` ブランチへの publish 成功
- issue #56 を `per_page=100` で2ページ確認し、last_read 以降の新規人間フィードバックが無いことを確認

## ロールバック手順

`ops/` 配下の記録ファイル（journal / state.json / dashboard の PR キャッシュ）のみの変更。DB・実インフラへの影響は無い。revert すれば直ちに元に戻る

## backlog task id

なし（新規起票は無し。前回起票済みの T-0146 のみ）

---
🤖 Generated with autopilot（計画役）