### PR TITLE
docs(ops): run #147（実行役）記録更新、PR #338 merge・actionable タスク無しを記録

### DIFF
--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4280,3 +4280,24 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - やったこと（続き）: 上記記録一式を PR #338 として作成
 - 次の起動へ: backlog の todo は T-0117（`not_before` 2026-08-06T18:30:00Z 未到来）のみ。
   actionable なし
+
+## 2026-08-06 19:47 JST — run #147（実行役）
+
+- 前回の中断確認: open PR に #338（run #146 が作成した T-0146 記録 PR）を発見。CI 6件
+  （GitGuardian / terraform validate / kustomize build / manifest deletion guard /
+  nix flake check / ops state validate）全て green、`mergeable_state: clean`、ops/ 配下の
+  記録のみで low risk（CHARTER §4 auto-merge 対象）と確認し merge した。ブランチは merge 後に
+  GitHub 側で自動削除済み（削除 API 呼び出しは 422、既に存在しなかった）。ローカル `main` が
+  merge 前の commit のまま stale だったため `git reset --hard origin/main` で追随
+- 読んだフィードバック: issue #56 を `per_page=100` で2ページ確認（計109件）、`last_read`
+  （2026-08-06T10:32:14Z）以降の新規コメント無し。反映なし
+- やったこと: backlog を確認したところ todo は T-0117 のみで `not_before`
+  （2026-08-06T18:30:00Z）が現在時刻（10:47Z 台）に未到来のため着手不可。`blocked`/`needs-human`
+  の全11件（T-0028/T-0029/T-0074/T-0084/T-0106/T-0107/T-0112/T-0116/T-0118/T-0120/T-0130/T-0140/
+  T-0141/T-0144）を確認したが、いずれも直近の run で「着手可能な部分を manifest 側に分離できないか」
+  の検討が既に済んでおり（例: T-0140 は T-0138/T-0139 に分離済みで両方 done）、新たに切り出せる
+  作業は見つからなかった。ops/inbox.md も run #146 が残した T-0146 フォローアップ1件のみで、
+  新規に足す気づきは無し。着手可能なタスクが無いため、この記録更新のみを PR にする
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: backlog の todo は T-0117（`not_before` 2026-08-06T18:30:00Z）のみ。あと1時間強で
+  到来する見込み。それまでは actionable なタスクが無い状態が続く見通し

--- a/ops/state.json
+++ b/ops/state.json
@@ -1341,7 +1341,9 @@
       "kind": "in-cluster-loop",
       "by": "autopilot (in-cluster)",
       "summary": "実行役（journal run #147）。前回の中断 PR #338（T-0146 記録）を CI green・low risk 確認の上 merge。backlog の todo は T-0117 のみで not_before（2026-08-06T18:30:00Z）未到来のため未着手、blocked/needs-human 全11件も分離可能な部分は無いことを再確認。issue #56 に last_read 以降の新規コメント無し。actionable なタスクが無いため記録のみの PR とした",
-      "prs": []
+      "prs": [
+        339
+      ]
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T10:32:14Z",
+  "updated": "2026-08-06T10:47:08Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
@@ -1334,6 +1334,14 @@
       "prs": [
         338
       ]
+    },
+    {
+      "n": 130,
+      "at": "2026-08-06T10:47:08Z",
+      "kind": "in-cluster-loop",
+      "by": "autopilot (in-cluster)",
+      "summary": "実行役（journal run #147）。前回の中断 PR #338（T-0146 記録）を CI green・low risk 確認の上 merge。backlog の todo は T-0117 のみで not_before（2026-08-06T18:30:00Z）未到来のため未着手、blocked/needs-human 全11件も分離可能な部分は無いことを再確認。issue #56 に last_read 以降の新規コメント無し。actionable なタスクが無いため記録のみの PR とした",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

run #147（実行役）の記録更新。コード・マニフェストの変更はなく `ops/` の運用記録のみ。

- 前回の中断（open PR #338, T-0146 の記録 PR）を CI green（GitGuardian / terraform validate /
  kustomize build / manifest deletion guard / nix flake check / ops state validate）・
  `mergeable_state: clean`・repo 内で閉じる低リスク変更であることを確認した上で merge した
- backlog を確認したが、todo は T-0117 のみで `not_before`（2026-08-06T18:30:00Z）が未到来のため
  着手不可。`blocked`/`needs-human` の全11件も、直近の run で「manifest 側だけ先に進められないか」
  の検討が既に済んでおり、新たに切り出せる作業は見つからなかった
- `ops/inbox.md` は run #146 が残した1件のみで、新規に足す気づきは無し
- `ops/journal/2026-08.md` / `ops/state.json`: run #147 の記録を追加

## 検証したこと

- `python3 ops/validate.py` で 0 error を確認
- PR #338 は merge 前に CI 6件全て green・`mergeable_state: clean` を確認済み
- issue #56 を `per_page=100` で全ページ確認し、`last_read`（2026-08-06T10:32:14Z）以降の
  新規コメントが無いことを確認した

## ロールバック手順

`ops/` 配下の記録ファイル（journal/state.json）のみの変更で、インフラへの影響は無い。revert すれば
即座に元に戻る。DB・スキーマは関係しない。PR #338 の merge 自体は別コミットのため、この PR の revert
では巻き戻らない。

## backlog task id

なし（記録のみ、CHARTER §2「やることが無い起動でも journal に『何も無かった』と書いた PR を出す」）
