### PR TITLE
docs(ops): 計画役 run #148 — T-0130 の前提解消、T-0147 起票

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 147,
-  "updated": "2026-08-06T10:24:03Z",
+  "next_id": 148,
+  "updated": "2026-08-06T10:55:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2456,12 +2456,11 @@
       "title": "T-0128 の dashboard 配信 URL (ops-dashboard) の実際の MagicDNS ホスト名を確認し ops/state.json に反映する",
       "kind": "investigate",
       "risk": "low",
-      "status": "needs-human",
+      "status": "todo",
       "priority": 45,
       "why": "T-0128（run #100-104, #290/#293/#295）で apps/ops-dashboard/ を実装し kubectl で 2/2 Running を実機確認したが、DoD が求める『ops/state.json の dashboard.artifact_url もしくは新しいフィールドを URL に更新』だけ未達のまま run #104 が ops/inbox.md に引き継ぎを残した（計画役の run #109 がこれを拾った）。autopilot-reader ClusterRole に networking.k8s.io/ingresses の read 権限が無く `kubectl get ingress -n ops-dashboard` が Forbidden、この Pod には tailscale credential も無いため、実際の MagicDNS ホスト名を実測できない。apps/{immich,vaultwarden,dex,argocd,coder}/ingress.yaml の tls.hosts 短縮名パターンから類推すると https://ops-dashboard.tailae6c2.ts.net/ の可能性が高いが未検証",
       "dod": "構築セッション（Coder ワークスペース、tailscale 到達可能）に issue #56 経由で ops-dashboard の実際の URL（推定: https://ops-dashboard.tailae6c2.ts.net/）への到達性を確かめてもらう。確かめられたら ops/state.json の dashboard フィールド（artifact_url をこの URL に置き換えるか、新フィールドを追加して両方残すかは実装時に判断）に反映し、CHARTER §7.1 の記述もあわせて更新する",
       "blocked_by": null,
-      "needs_human_reason": "autopilot の ClusterRole（autopilot-reader）に ingresses の read 権限が無く Forbidden、この Pod には tailscale credential も無いため実際の MagicDNS ホスト名を実測できない。構築セッション（Coder ワークスペース、tailscale 到達可能）に issue #56 経由で https://ops-dashboard.tailae6c2.ts.net/ への到達性の実測を依頼する",
       "refs": [
         "ops/state.json",
         "apps/ops-dashboard/",
@@ -2469,7 +2468,7 @@
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "run #109 (計画役): ops/inbox.md の引き継ぎ（run #104 が残した）を起票。恒久対応として autopilot-reader ClusterRole に ingresses read を足す案もあるが、単発の確認で足りるため、まずは構築セッションへの確認依頼で解決を図る。権限追加が必要になったら別タスクにする"
+      "notes": "run #109 (計画役): ops/inbox.md の引き継ぎ（run #104 が残した）を起票。恒久対応として autopilot-reader ClusterRole に ingresses read を足す案もあるが、単発の確認で足りるため、まずは構築セッションへの確認依頼で解決を図る。権限追加が必要になったら別タスクにする | run #148（計画役）: 構築セッションが issue #56（2026-08-06T10:03:40Z）で https://ops-dashboard.tailae6c2.ts.net/ の L7 Ingress 到達（HTTP 200）を実測・報告済み。 DoD の確認待ち部分が解消したため needs-human → todo に変更。 次の実行役は ops/state.json の dashboard フィールドにこの URL を反映し、 CHARTER §7.1 の記述もあわせて更新すること"
     },
     {
       "id": "T-0131",
@@ -2787,6 +2786,25 @@
       "created": "2026-08-06",
       "pr": null,
       "notes": "run #144（計画役）: backlog の todo が T-0117（not_before 未到来）のみで実行役の着手可能タスクが枯渇していたため、CHARTER §3 に従い未トリアージの open issue を洗い出して起票。issue #26 は autopilot 発足前（2025-12-14）から誰にも拾われていなかった。T-0050/T-0047 が cachix-action の push 挙動は確認済みだが pull 側の実効性は未検証という隙間を埋める。run #146（実行役）: DoD (1) は確認完了（cachix 公式メタデータ API で `hikuohiku` cache が `isPublic: true` と実測、`cachix-action@v17` は `skipAddingSubstituter` 既定 false のため authToken 無しでもデフォルトで substituter を追加すると実ソースで確認、設定面では pull が機能する構成）。DoD (2)(3) は達成できなかった: release-image.yml の過去実行 12 件は全て 2025-12-16 以前で、GitHub Actions ジョブログは保持期限切れのため 410 Gone で取得不能、実際の hit/miss は確認不能だった。新規実行のトリガー（workflow_dispatch）は実際に GitHub Release を作成する副作用があるため autopilot からは行わなかった。issue #26 に結果を報告済み（DoD (4) 達成）。未確認事項は ops/inbox.md に引き継ぎ、次に人間が手動実行する機会があればログ保持期限内に確認する調査タスクの起票を計画役の判断に委ねる"
+    },
+    {
+      "id": "T-0147",
+      "domain": "homelab",
+      "title": "release-image.yml 次回手動実行時に cachix pull の hit/miss をログで確認する（T-0146 フォローアップ）",
+      "kind": "investigate",
+      "risk": "low",
+      "status": "blocked",
+      "priority": 90,
+      "why": "T-0146（run #146）で hikuohiku cachix cache が public であり cachix-action@v17 がデフォルトで substituter を追加する設定であることは確認できたが、実際に pull が hit しているかは release-image.yml の過去実行ログが全て 410 Gone（保持期限切れ、最終実行 2025-12-16）で 確認できなかった。次に人間がこの workflow を手動実行する機会があれば、ログ保持期限が 切れる前に確認する価値がある",
+      "dod": "release-image.yml が次に実行された（workflow_dispatch）ことを確認したら、できるだけ早く（GitHub Actions のログ保持期限内）そのジョブログを取得し、nix build のステップで `copying path`（cache miss、自前でビルド）と `fetching`/`querying`（cache hit）の比率を見て cachix pull が実際に機能しているかを判定する。機能していなければ authToken 登録等の 対処を検討し新タスクを起票する。機能していれば done にする",
+      "blocked_by": "release-image.yml の次回手動実行（workflow_dispatch は人間のみがトリガー可能、CHARTER §5.4）。実行予定は無いため、この時点で自ら急いで実行を働きかける必要はない",
+      "refs": [
+        ".github/workflows/release-image.yml",
+        "ops/inventory.json"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #148（計画役）: ops/inbox.md の引き継ぎ（run #146 実行役が残したもの）を起票。急ぎではない（次回実行の予定自体が無い）ため blocked とし、needs-human の依頼は出さない"
     }
   ]
 }

--- a/ops/inbox.md
+++ b/ops/inbox.md
@@ -7,9 +7,3 @@
 [`ops/CHARTER.md`](CHARTER.md) の §3「書く権利」。
 
 ---
-
-- T-0146（cachix pull 検証, run #146）: cache が public でありデフォルトで substituter も追加される
-  ことは確認できたが、実際の hit/miss は release-image.yml の過去実行ログが全て 410 Gone（retention
-  切れ、最終実行 2025-12-16）で確認不能だった。issue #26 に報告済み。次に人間が release-image.yml
-  を手動実行する機会があれば、その直後（ログ保持期限が切れる前）にログで `copying path`/`fetching`
-  の比率を見る調査タスクを起票する価値があるかもしれない。急ぎではない（実行の予定自体が無いため）

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4301,3 +4301,27 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py` を実行し 0 error であることを確認
 - 次の起動へ: backlog の todo は T-0117（`not_before` 2026-08-06T18:30:00Z）のみ。あと1時間強で
   到来する見込み。それまでは actionable なタスクが無い状態が続く見通し
+
+## 2026-08-06 19:56 JST — run #148（計画役）
+
+- `ops/inbox.md` を確認: T-0146 フォローアップ（cachix pull hit/miss を release-image.yml
+  次回手動実行時に確認する）の1件のみ。T-0147 として起票し（blocked、次回手動実行待ち、急ぎではない
+  ため needs-human の依頼は出さない）、inbox を空にした
+- 読んだフィードバック: issue #56 を `per_page=100` で2ページ（計109件）確認、`last_read`
+  （2026-08-06T10:32:14Z）以降の新規コメント無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T10:30:04Z`）で ArgoCD 13 アプリ中
+  `coder`/`immich`/`vaultwarden` の Degraded を確認、いずれも T-0106 由来の既知 `SecretSyncedError`
+  のみ。immich の `backup_listing` 最新ファイルは 2026-08-06T02:00:05Z で正常。autopilot 自身の
+  heartbeat も正常（iteration #20 exit_code 0, readyReplicas 1）
+- backlog の blocked/needs-human 全14件を棚卸し: **T-0130（ops-dashboard の実際の URL 確認）の
+  前提が古いまま残っていた**のを発見。issue #56 の 2026-08-06T10:03:40Z のコメント（構築セッションが
+  T-0143 の調査中に「ops-dashboard を確認しました。`ops-dashboard.tailae6c2.ts.net` で L7 Ingress が
+  立ち、Service は HTTP 200 を返しています」と報告済み）が T-0130 の DoD が求める確認そのものだったが、
+  T-0143/T-0140 の反映（PR #335, run #126）に埋もれて T-0130 には反映されていなかった。run #147 の
+  棚卸しでも見落とされていた。needs-human → todo に変更し、次の実行役が `ops/state.json` の
+  dashboard フィールドと CHARTER §7.1 に反映できる状態にした
+- 他13件（T-0028/T-0029/T-0074/T-0084/T-0106/T-0107/T-0112/T-0116/T-0118/T-0120/T-0140/T-0141/
+  T-0144）は前提の変化なしを確認（T-0141/T-0144 が依存する issue #37/#35 にも人間の新規回答なし）
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: backlog の todo は T-0130（着手可能）と T-0117（`not_before` 2026-08-06T18:30:00Z、
+  あと30分強で到来）の2件。次の実行役は T-0130 から着手できる

--- a/ops/state.json
+++ b/ops/state.json
@@ -1344,6 +1344,14 @@
       "prs": [
         339
       ]
+    },
+    {
+      "n": 131,
+      "at": "2026-08-06T10:56:00Z",
+      "kind": "in-cluster-loop",
+      "by": "autopilot (in-cluster)",
+      "summary": "計画役（journal run #148）。inbox の T-0146 フォローアップを T-0147 として起票し空にした。issue #56 に新規フィードバック無し。health 正常（T-0106 既知の Degraded のみ）。blocked/needs-human 14件を棚卸しし、T-0130（ops-dashboard URL 確認）がissue #56 の既存コメント（構築セッションが 2026-08-06T10:03:40Z に HTTP 200 を実測済み）で既に解消していたのに反映されていなかったのを発見し needs-human → todo に変更。他13件は前提変化なし。todo は T-0130（着手可能）・T-0117（not_before 未到来）の2件",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

計画役（journal run #148）の記録。`ops/` 配下のみの変更。

- **backlog**: T-0130（ops-dashboard の実際の URL 確認）を `needs-human` → `todo` に変更した。
  issue #56 の 2026-08-06T10:03:40Z のコメントで、構築セッションが T-0143（syncthing）の調査中に
  `https://ops-dashboard.tailae6c2.ts.net/` の L7 Ingress が HTTP 200 を返すことをついでに実測・
  報告していたが、この結果が T-0143/T-0140 の反映（PR #335）に埋もれて T-0130 側に反映されていな
  かった。次の実行役はこの URL を `ops/state.json` の dashboard フィールドと CHARTER §7.1 に反映
  できる
- **backlog**: `ops/inbox.md` に残っていた T-0146 フォローアップ（release-image.yml の cachix
  pull hit/miss を次回手動実行時にログで確認する）を T-0147 として起票（`blocked`、次回の手動実行
  待ちで急ぎではないため needs-human の依頼は出していない）
- 他13件の blocked/needs-human タスク、issue #35/#37（T-0141/T-0144 が依存）は前提の変化なしを確認
- journal (`ops/journal/2026-08.md` run #148) と `state.json` の `runs` (#131) を追記

## 検証したこと

- `python3 ops/validate.py` で 0 error
- issue #56 を `per_page=100` で2ページ（計109件）確認し `last_read` 以降の新規コメント無しを確認
- `ops-health-report` ブランチの `latest.json`（`generated_at: 2026-08-06T10:30:04Z`）で異常無し
  （coder/immich/vaultwarden の Degraded は T-0106 由来の既知の SecretSyncedError のみ）

## ロールバック手順

`ops/` の記録ファイルのみの変更（コード・マニフェストへの影響なし）。revert すれば
T-0130 は `needs-human` に、T-0147 の起票は無かった状態に戻る。データ・スキーマへの影響は無い。

## backlog task id

T-0130, T-0147