### PR TITLE
docs(ops): T-0130 ops-dashboard 配信 URL を state.json/CHARTER に反映

### DIFF
--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -712,10 +712,19 @@ commit していたが、全タスク PR がこのファイルに触るため相
 
 Artifact ツールが使えるときは、`ops/state.json` の `dashboard.artifact_url` を `url` に渡して
 同じ URL へ再公開する（新しい URL を発行しないこと。人間はブックマークしている）。これは
-`ops-dashboard` ブランチへの push とは独立した経路で、当面どちらも並行して更新する
-（T-0128 で `ops-dashboard` ブランチを配信する経路が整うまでは、人間が実際に見られるのは
-Artifact 版だけ）。Artifact が使えない・失敗した場合は journal に「publish できなかった」と
+`ops-dashboard` ブランチへの push とは独立した経路で、当面どちらも並行して更新する。
+Artifact が使えない・失敗した場合は journal に「publish できなかった」と
 一行だけ書けばよい。**ここで止まらないこと。**
+
+**T-0128 の `ops-dashboard`（`apps/ops-dashboard/`）は稼働している。** `ops/state.json` の
+`dashboard.ops_dashboard_url`（`https://ops-dashboard.tailae6c2.ts.net/`）がその配信先。
+構築セッションが issue #56（2026-08-06T10:03:40Z）で L7 Ingress の稼働と Service の HTTP 200 を
+報告している（T-0130, run #148/#149）。**ただし構築セッションは tailnet のピアではないため、
+この URL 自体への外部到達（MagicDNS 経由）は未実測**（同じ issue コメントで syncthing の GUI L7
+Ingress について「このワークスペースは tailnet のノードではないため判定不能」と明記されており、
+同じ制約が `ops-dashboard.tailae6c2.ts.net` にも及ぶ可能性がある。§5.5 参照）。tailnet に居る
+人間が実際にブラウザで開いて確認するまでは「Service 自体は動いている」までしか裏付けが無いと
+扱うこと。
 
 HTML を repo に置かなくなった代わりに、CI (`ops` job) が `python3 ops/dashboard/build.py` を実行して
 例外なく終わることだけを毎回検証する。壊れたまま気づかない事態を防ぐのはこれで十分で、

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2467,7 +2467,7 @@
         "ops/CHARTER.md"
       ],
       "created": "2026-08-06",
-      "pr": null,
+      "pr": 341,
       "notes": "run #109 (計画役): ops/inbox.md の引き継ぎ（run #104 が残した）を起票。恒久対応として autopilot-reader ClusterRole に ingresses read を足す案もあるが、単発の確認で足りるため、まずは構築セッションへの確認依頼で解決を図る。権限追加が必要になったら別タスクにする | run #148（計画役）: 構築セッションが issue #56（2026-08-06T10:03:40Z）で https://ops-dashboard.tailae6c2.ts.net/ の L7 Ingress 到達（HTTP 200）を実測・報告済み。 DoD の確認待ち部分が解消したため needs-human → todo に変更。 次の実行役は ops/state.json の dashboard フィールドにこの URL を反映し、 CHARTER §7.1 の記述もあわせて更新すること | run #149（実行役）: ops/state.json に dashboard.ops_dashboard_url を追加、CHARTER §7.1 を更新し done に。ただし issue #56 の同コメントは同じ制約下で syncthing の GUI L7 Ingress を『tailnet ピアでないため判定不能』と明記しており、ops-dashboard の確認も内部 Service 止まりで外部到達は未実測の疑いがあるため、その旨を state.json に注記し ops/inbox.md へ引き継いだ"
     },
     {

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2456,7 +2456,7 @@
       "title": "T-0128 の dashboard 配信 URL (ops-dashboard) の実際の MagicDNS ホスト名を確認し ops/state.json に反映する",
       "kind": "investigate",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 45,
       "why": "T-0128（run #100-104, #290/#293/#295）で apps/ops-dashboard/ を実装し kubectl で 2/2 Running を実機確認したが、DoD が求める『ops/state.json の dashboard.artifact_url もしくは新しいフィールドを URL に更新』だけ未達のまま run #104 が ops/inbox.md に引き継ぎを残した（計画役の run #109 がこれを拾った）。autopilot-reader ClusterRole に networking.k8s.io/ingresses の read 権限が無く `kubectl get ingress -n ops-dashboard` が Forbidden、この Pod には tailscale credential も無いため、実際の MagicDNS ホスト名を実測できない。apps/{immich,vaultwarden,dex,argocd,coder}/ingress.yaml の tls.hosts 短縮名パターンから類推すると https://ops-dashboard.tailae6c2.ts.net/ の可能性が高いが未検証",
       "dod": "構築セッション（Coder ワークスペース、tailscale 到達可能）に issue #56 経由で ops-dashboard の実際の URL（推定: https://ops-dashboard.tailae6c2.ts.net/）への到達性を確かめてもらう。確かめられたら ops/state.json の dashboard フィールド（artifact_url をこの URL に置き換えるか、新フィールドを追加して両方残すかは実装時に判断）に反映し、CHARTER §7.1 の記述もあわせて更新する",
@@ -2468,7 +2468,7 @@
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "run #109 (計画役): ops/inbox.md の引き継ぎ（run #104 が残した）を起票。恒久対応として autopilot-reader ClusterRole に ingresses read を足す案もあるが、単発の確認で足りるため、まずは構築セッションへの確認依頼で解決を図る。権限追加が必要になったら別タスクにする | run #148（計画役）: 構築セッションが issue #56（2026-08-06T10:03:40Z）で https://ops-dashboard.tailae6c2.ts.net/ の L7 Ingress 到達（HTTP 200）を実測・報告済み。 DoD の確認待ち部分が解消したため needs-human → todo に変更。 次の実行役は ops/state.json の dashboard フィールドにこの URL を反映し、 CHARTER §7.1 の記述もあわせて更新すること"
+      "notes": "run #109 (計画役): ops/inbox.md の引き継ぎ（run #104 が残した）を起票。恒久対応として autopilot-reader ClusterRole に ingresses read を足す案もあるが、単発の確認で足りるため、まずは構築セッションへの確認依頼で解決を図る。権限追加が必要になったら別タスクにする | run #148（計画役）: 構築セッションが issue #56（2026-08-06T10:03:40Z）で https://ops-dashboard.tailae6c2.ts.net/ の L7 Ingress 到達（HTTP 200）を実測・報告済み。 DoD の確認待ち部分が解消したため needs-human → todo に変更。 次の実行役は ops/state.json の dashboard フィールドにこの URL を反映し、 CHARTER §7.1 の記述もあわせて更新すること | run #149（実行役）: ops/state.json に dashboard.ops_dashboard_url を追加、CHARTER §7.1 を更新し done に。ただし issue #56 の同コメントは同じ制約下で syncthing の GUI L7 Ingress を『tailnet ピアでないため判定不能』と明記しており、ops-dashboard の確認も内部 Service 止まりで外部到達は未実測の疑いがあるため、その旨を state.json に注記し ops/inbox.md へ引き継いだ"
     },
     {
       "id": "T-0131",

--- a/ops/inbox.md
+++ b/ops/inbox.md
@@ -7,3 +7,10 @@
 [`ops/CHARTER.md`](CHARTER.md) の §3「書く権利」。
 
 ---
+
+- T-0130 で `ops/state.json` に `dashboard.ops_dashboard_url` を反映したが、issue #56
+  (2026-08-06T10:03:40Z) の報告は構築セッション（tailnet 非ピア）による確認で、同じコメント内で
+  syncthing の GUI L7 Ingress は「tailnet ピアでないため判定不能」と明記されている。ops-dashboard の
+  「L7 Ingress が立ち、Service は HTTP 200」も内部 Service 確認どまりの可能性があり、
+  `https://ops-dashboard.tailae6c2.ts.net/` への実際の外部到達（tailnet ピアからのブラウザ確認）は
+  まだ実測されていない。人間がブラウザで一度開いて確認する needs-human タスクとして起票する価値がありそう。

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4325,3 +4325,19 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py` を実行し 0 error であることを確認
 - 次の起動へ: backlog の todo は T-0130（着手可能）と T-0117（`not_before` 2026-08-06T18:30:00Z、
   あと30分強で到来）の2件。次の実行役は T-0130 から着手できる
+
+## 2026-08-06 20:01 JST — run #149（実行役）
+
+- 前回の中断確認: オープン PR 0 件、`autopilot/*` ブランチ残存なし。ローカル main は origin/main と一致
+- 読んだフィードバック: issue #56 の `last_read`（2026-08-06T10:32:14Z）以降、新規コメント無し
+- やったこと: backlog の todo（T-0130）に着手。`ops/state.json` の `dashboard` に
+  `ops_dashboard_url`（`https://ops-dashboard.tailae6c2.ts.net/`）を追加し、CHARTER §7.1 の
+  T-0128 に関する記述を更新。T-0130 を done に
+- 見つけたこと: issue #56（2026-08-06T10:03:40Z）の構築セッションの報告は、同じコメント内で
+  syncthing の GUI L7 Ingress について「このワークスペースは tailnet ピアでないため判定不能」と
+  明記しているのに、直後の ops-dashboard の確認（「L7 Ingress が立ち、Service は HTTP 200」）が
+  同じ制約の対象かどうか本文からは判別できない。内部 Service 確認どまりで実際の外部到達は
+  未実測の疑いが残るため、その旨を `ops/state.json` に注記し `ops/inbox.md` に引き継いだ
+  （計画役が needs-human として起票するか判断する）
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: T-0117 の `not_before`（2026-08-06T18:30:00Z）は到来済み。次の実行役はそこから着手できる

--- a/ops/state.json
+++ b/ops/state.json
@@ -1361,7 +1361,9 @@
       "kind": "in-cluster-loop",
       "by": "autopilot (in-cluster)",
       "summary": "実行役（journal run #149）。前回の中断なし（オープン PR 0件、autopilot/* ブランチ残存なし）。issue #56 に新規フィードバック無し。T-0130 に着手し ops/state.json の dashboard.ops_dashboard_url を追加、CHARTER §7.1 を更新し done に。issue #56 のコメントが ops-dashboard の外部到達を実際には確認していない疑いを見つけ inbox.md へ引き継いだ",
-      "prs": []
+      "prs": [
+        341
+      ]
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -9,7 +9,9 @@
     "last_read": "2026-08-06T10:32:14Z"
   },
   "dashboard": {
-    "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc"
+    "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc",
+    "ops_dashboard_url": "https://ops-dashboard.tailae6c2.ts.net/",
+    "ops_dashboard_url_note": "T-0130: 構築セッションが issue #56 (2026-08-06T10:03:40Z) で L7 Ingress 稼働・Service HTTP 200 を報告。ただし構築セッションは tailnet ピアではないため、この URL 自体への外部到達（MagicDNS 経由）は未実測。tailnet に居る人間による確認が望ましい"
   },
   "routines": [
     {
@@ -1351,6 +1353,14 @@
       "kind": "in-cluster-loop",
       "by": "autopilot (in-cluster)",
       "summary": "計画役（journal run #148）。inbox の T-0146 フォローアップを T-0147 として起票し空にした。issue #56 に新規フィードバック無し。health 正常（T-0106 既知の Degraded のみ）。blocked/needs-human 14件を棚卸しし、T-0130（ops-dashboard URL 確認）がissue #56 の既存コメント（構築セッションが 2026-08-06T10:03:40Z に HTTP 200 を実測済み）で既に解消していたのに反映されていなかったのを発見し needs-human → todo に変更。他13件は前提変化なし。todo は T-0130（着手可能）・T-0117（not_before 未到来）の2件",
+      "prs": []
+    },
+    {
+      "n": 132,
+      "at": "2026-08-06T11:01:00Z",
+      "kind": "in-cluster-loop",
+      "by": "autopilot (in-cluster)",
+      "summary": "実行役（journal run #149）。前回の中断なし（オープン PR 0件、autopilot/* ブランチ残存なし）。issue #56 に新規フィードバック無し。T-0130 に着手し ops/state.json の dashboard.ops_dashboard_url を追加、CHARTER §7.1 を更新し done に。issue #56 のコメントが ops-dashboard の外部到達を実際には確認していない疑いを見つけ inbox.md へ引き継いだ",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

T-0130（`ops-dashboard` の実際の配信 URL を確認し反映する）を実施した。

- `ops/state.json` の `dashboard` に `ops_dashboard_url`
  (`https://ops-dashboard.tailae6c2.ts.net/`) を追加
- `ops/CHARTER.md` §7.1 の「T-0128 で ops-dashboard ブランチを配信する経路が整うまでは
  Artifact 版だけ」という記述を、稼働確認済みの記述に更新
- backlog の T-0130 を `done` に、journal・`ops/state.json` の `runs` に run 記録を追記

## 検証したこと

- 根拠は issue #56（2026-08-06T10:03:40Z）の構築セッションによる報告
  （`ops-dashboard.tailae6c2.ts.net` で L7 Ingress 稼働、Service HTTP 200）
- `python3 ops/validate.py` で 0 error を確認
- **残った不確実性**: 同じコメント内で構築セッションは syncthing の GUI L7 Ingress について
  「このワークスペースは tailnet ピアでないため判定不能」と明記している。ops-dashboard の確認
  （「L7 Ingress が立ち、Service は HTTP 200」）が同じ制約の対象か本文からは判別できず、内部
  Service 確認どまりで実際の外部到達（MagicDNS 経由）は未実測の疑いが残る。`ops/state.json` に
  注記を残し、`ops/inbox.md` に引き継いだ（tailnet に居る人間が一度ブラウザで開いて確認する
  needs-human タスクとして計画役が起票するかを判断する）

## ロールバック手順

`ops/`（state.json/backlog.json/CHARTER.md/journal/inbox.md）のドキュメント更新のみで、
インフラ・DB への変更は無い。revert すれば完全に元に戻る。

## backlog task id

T-0130
