### PR TITLE
docs(ops): 計画役 run #150 — T-0148/T-0149/T-0150 起票、T-0140 の前提是正

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 148,
-  "updated": "2026-08-06T10:55:00Z",
+  "next_id": 151,
+  "updated": "2026-08-06T11:30:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2234,7 +2234,7 @@
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "run #85: 定期の inventory 調査（対象8件、他7件は current が最新のまま）で発見。緊急性は無い（v3.21.3 で CI は動いている）が EOL 接近の一次情報あり。run #86: 調査完遂。技術的な互換性のハードルは無い——kustomize v5.8.1（本リポジトリが既に使用中）は helm v4 対応の既知バグ修正（kubernetes-sigs/kustomize#6013, PR #6016）を取り込み済みで、本リポジトリが使う helmCharts の基本フィールド（repo/name/version/releaseName/namespace/valuesFile）は helm v4 の breaking changes に抵触しない（一次情報: https://helm.sh/blog/helm-4-released/ 、 https://helm.sh/docs/changelog/ ）。唯一の障害は CI が使う `azure/setup-helm` アクション自身が README で『v2+ of this action only support Helm3』と明言しており、v4 系のバージョン指定を公式サポートしていないこと（動く可能性はあるが未検証・未保証）。auto-merge のゲートである CI に根拠の薄い変更を入れないため blocked とした。再開条件: azure/setup-helm が v4 対応を明言するリリースを出す、または検証用ブランチで実機テストして動作を確認できたとき"
+      "notes": "run #85: 定期の inventory 調査（対象8件、他7件は current が最新のまま）で発見。緊急性は無い（v3.21.3 で CI は動いている）が EOL 接近の一次情報あり。run #86: 調査完遂。技術的な互換性のハードルは無い——kustomize v5.8.1（本リポジトリが既に使用中）は helm v4 対応の既知バグ修正（kubernetes-sigs/kustomize#6013, PR #6016）を取り込み済みで、本リポジトリが使う helmCharts の基本フィールド（repo/name/version/releaseName/namespace/valuesFile）は helm v4 の breaking changes に抵触しない（一次情報: https://helm.sh/blog/helm-4-released/ 、 https://helm.sh/docs/changelog/ ）。唯一の障害は CI が使う `azure/setup-helm` アクション自身が README で『v2+ of this action only support Helm3』と明言しており、v4 系のバージョン指定を公式サポートしていないこと（動く可能性はあるが未検証・未保証）。auto-merge のゲートである CI に根拠の薄い変更を入れないため blocked とした。再開条件: azure/setup-helm が v4 対応を明言するリリースを出す、または検証用ブランチで実機テストして動作を確認できたとき | run #150（計画役）: 上流に helm v4.2.3 GA が実在することを inventory 定期調査で確認したが、azure/setup-helm@v5 の README（raw.githubusercontent.com で実読）は依然「v2+ of this action only support Helm3」のまま。blocked_by の条件は変わっておらず、ステータス変更なし。"
     },
     {
       "id": "T-0119",
@@ -2657,14 +2657,14 @@
       "why": "T-0137 の検討で、device ID/証明書（cert.pem/key.pem、syncthing の config ディレクトリに保存）を移さないと既存ピアから別デバイスとして再認識されると判明した。CHARTER §4「データを失いうる変更」に該当するため、戻せることを確かめてから着手する必要がある。LXC 101 のファイルシステムへの直接アクセス（pct exec や Proxmox コンソール等）は、autopilot（Proxmox は PVEAuditor=監査専用、kubectl は k8s 内 read-only）にも構築セッション（kubectl read-only のみ、Proxmox/LXC への到達経路なし）にも無い",
       "dod": "(1) LXC 101 の実際の config パス（`/var/lib/syncthing` 想定、要確認）の中身一式（cert.pem/key.pem/config.xml/index データ）を人間が取得し、構築セッションまたは autopilot が使える経路（例: 一時的な到達手段、Doppler 等）で引き渡す。(2) T-0138 で作成した PVC へそのデータを配置する（kubectl cp 等の書き込み操作は構築セッションか人間が実施。autopilot 自身の ClusterRole は書き込み動詞を持たない、CHARTER §5.5）。(3) 新しい syncthing Pod が既存ピアと再認証なしに同期を再開できることを確認する。(4) 確認できたら旧 LXC 101 を停止し、一定期間の観察後に破棄する（M1 vaultwarden 移行と同じ順序、Plans.md 参照）",
       "needs_human_reason": "LXC 101 (`/var/lib/syncthing` 想定パス、要確認) の config ディレクトリ一式（cert.pem/key.pem 含む）を取得し、新 PVC へ配置できる形で提供してほしい。自動化された経路（autopilot・構築セッションいずれの credential）でもこのファイルシステムには到達できない",
-      "blocked_by": "T-0138/T-0139 が完了し、移行先の PVC/Service が用意されていること",
+      "blocked_by": null,
       "refs": [
         "Plans.md",
         "apps/syncthing/"
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "run #136（計画役）: T-0137 完了を受け ops/inbox.md の引き継ぎ（実装タスクへの分割）をここで起票。データ移行部分は human 専有（物理的にLXC上のファイルへアクセスする経路が無い）と判断し needs-human で起票。manifest 側（T-0138/T-0139）は着手可能な todo として分離した（CHARTER §3「blocked/needs-human はタスク全体ではなくどの部分かで見る」）。run #143（実行役）: issue #56（2026-08-06T10:03:40Z, hikuohiku）で、現在稼働中の syncthing は新規デバイス ID（旧 LXC 101 とは別デバイス）であり、cert.pem/key.pem 移行なしに既存ピアと接続すると同期方向次第で削除が伝播しうるため、needs-human のまま止めておく現状の判断が正しいと確認された。ステータス変更なし"
+      "notes": "run #136（計画役）: T-0137 完了を受け ops/inbox.md の引き継ぎ（実装タスクへの分割）をここで起票。データ移行部分は human 専有（物理的にLXC上のファイルへアクセスする経路が無い）と判断し needs-human で起票。manifest 側（T-0138/T-0139）は着手可能な todo として分離した（CHARTER §3「blocked/needs-human はタスク全体ではなくどの部分かで見る」）。run #143（実行役）: issue #56（2026-08-06T10:03:40Z, hikuohiku）で、現在稼働中の syncthing は新規デバイス ID（旧 LXC 101 とは別デバイス）であり、cert.pem/key.pem 移行なしに既存ピアと接続すると同期方向次第で削除が伝播しうるため、needs-human のまま止めておく現状の判断が正しいと確認された。ステータス変更なし | run #149（計画役）: blocked_by の前提（T-0138/T-0139 未完了）が古いままだったのを是正。両タスクとも done・merge 済みで移行先 PVC/Service は既に用意されている。実際に残っている唯一の障壁は needs_human_reason（LXC 101 のファイルシステムへの到達経路が無い）であり、これは変わっていない。ステータスは needs-human のまま。"
     },
     {
       "id": "T-0141",
@@ -2805,6 +2805,69 @@
       "created": "2026-08-06",
       "pr": null,
       "notes": "run #148（計画役）: ops/inbox.md の引き継ぎ（run #146 実行役が残したもの）を起票。急ぎではない（次回実行の予定自体が無い）ため blocked とし、needs-human の依頼は出さない"
+    },
+    {
+      "id": "T-0148",
+      "domain": "homelab",
+      "title": "ops-dashboard 配信 URL の外部到達性を tailnet ピアの人間が実際にブラウザで確認する",
+      "kind": "verify",
+      "risk": "low",
+      "status": "needs-human",
+      "priority": 60,
+      "why": "T-0130 で ops-dashboard.tailae6c2.ts.net への配信が稼働している旨を state.json に反映したが、報告は構築セッション（tailnet 非ピア）による内部 Service 到達（HTTP 200）の確認どまりで、tailnet 経由の実際の外部到達（MagicDNS 名前解決 + L7 Ingress 経由）は未実測。同じ制約が syncthing の GUI L7 Ingress でも指摘されており、ops-dashboard にも及ぶ可能性がある（ops/inbox.md 経由、実行役の気づき）。",
+      "dod": "tailnet に参加している人間が、実際に自分の端末のブラウザで https://ops-dashboard.tailae6c2.ts.net/ を開き、ダッシュボードが表示されることを確認して issue #56 に結果を書く。表示できなければ、その旨と症状（DNS 解決失敗 / 接続拒否 / 証明書エラー等）を書いてもらう。",
+      "blocked_by": null,
+      "refs": [
+        "apps/ops-dashboard/",
+        "ops/state.json"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "needs_human_reason": "ops-dashboard.tailae6c2.ts.net への実際の外部到達確認は tailnet に参加しているブラウザからのアクセスが要る。autopilot（in-cluster、tailnet 到達性なし）にも構築セッション（tailnet 非ピア、既に内部確認済み）にも実行できない。",
+      "notes": "run #149（計画役）: ops/inbox.md の引き継ぎ（実行役の気づき）を起票。T-0130 の内部確認と今回求める外部到達確認は別物であるため、T-0130 を re-open せず新規タスクとして分離した。"
+    },
+    {
+      "id": "T-0149",
+      "domain": "homelab",
+      "title": "ghcr.io/coder/coder を v2.35.3 → v2.36.0 に上げる",
+      "kind": "update",
+      "risk": "medium",
+      "status": "todo",
+      "priority": 40,
+      "why": "計画役の run #150 の inventory 定期調査（policy: auto 全対象の上流最新版チェック）で発見。ghcr.io の実タグ・GitHub Releases API で v2.36.0 (2026-08-04 公開) が存在し、v2.35.3 より新しいことを確認済み。",
+      "dod": "CHARTER §4「バージョン更新の作法」に従い v2.35.3 → v2.36.0 のリリースノートを原文で確認し、破壊的変更が無いことを確かめたうえで apps/coder/ の image タグと ops/inventory.json を更新する。",
+      "blocked_by": null,
+      "refs": [
+        "apps/coder/",
+        "ops/inventory.json"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #150（計画役）: GitHub の `/repos/coder/coder/releases/latest` は make_latest フラグの都合で v2.35.3 を指したままだが、v2.36.0 のリリース自体は実在し ghcr.io に イメージも存在する（agent 調査で確認）。実装時は `/releases/latest` を鵜呑みにせず、tag 指定（`/repos/coder/coder/releases/tags/v2.36.0`）でリリースノートを取得すること。"
+    },
+    {
+      "id": "T-0150",
+      "domain": "homelab",
+      "title": "ops/ 監視系 CronJob の python ベースイメージを 3.12-alpine → 3.14-alpine に上げる",
+      "kind": "update",
+      "risk": "low",
+      "status": "todo",
+      "priority": 40,
+      "why": "計画役の run #150 の inventory 定期調査で、python:3.12-alpine より新しい 3.14-alpine（3.13-alpine も存在）が出ていると判明。対象は ops/inventory.json の ops-health-reporter-image と pvc-usage-reporter-image の2エントリで、後者は mirrors 4ファイルを含む。どちらも標準ライブラリのみで動く読み取り専用スクリプトで homelab 本体の到達性には影響しない（各エントリの observability_impact 参照）。",
+      "dod": "対象5ファイル（apps/ops-health-reporter/cronjob.yaml、apps/immich/pvc-usage-cronjob.yaml、apps/coder/pvc-usage-cronjob.yaml、apps/vaultwarden/pvc-usage-cronjob.yaml、apps/vaultwarden/restic-backup-cronjob.yaml）の python:3.12-alpine を 3.14-alpine に揃えて更新し、ops/inventory.json の該当2エントリも更新する。3.13 を飛ばして 3.14 に上げる場合は CPython 3.13→3.14 の changelog（3.12→3.13 分も含め）に、これらのスクリプトが使う標準ライブラリ（json/urllib/subprocess/pathlib 等）の破壊的変更が無いか目を通す。",
+      "blocked_by": null,
+      "refs": [
+        "apps/ops-health-reporter/cronjob.yaml",
+        "apps/immich/pvc-usage-cronjob.yaml",
+        "apps/coder/pvc-usage-cronjob.yaml",
+        "apps/vaultwarden/pvc-usage-cronjob.yaml",
+        "apps/vaultwarden/restic-backup-cronjob.yaml",
+        "ops/inventory.json",
+        "ops/check_version_sync.py"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #150（計画役）: 2つの inventory エントリ（ops-health-reporter-image は単独ファイル、pvc-usage-reporter-image は mirrors 4ファイル）にまたがるが、全て同一の python:3.12-alpine タグを指しており実質同じ変更のため 1 タスクにまとめた。check_version_sync.py の該当 GROUP（T-0082/T-0081）が既にこれらの一致を CI で検証しているので、ズレたまま merge されることはない。"
     }
   ]
 }

--- a/ops/inbox.md
+++ b/ops/inbox.md
@@ -7,10 +7,3 @@
 [`ops/CHARTER.md`](CHARTER.md) の §3「書く権利」。
 
 ---
-
-- T-0130 で `ops/state.json` に `dashboard.ops_dashboard_url` を反映したが、issue #56
-  (2026-08-06T10:03:40Z) の報告は構築セッション（tailnet 非ピア）による確認で、同じコメント内で
-  syncthing の GUI L7 Ingress は「tailnet ピアでないため判定不能」と明記されている。ops-dashboard の
-  「L7 Ingress が立ち、Service は HTTP 200」も内部 Service 確認どまりの可能性があり、
-  `https://ops-dashboard.tailae6c2.ts.net/` への実際の外部到達（tailnet ピアからのブラウザ確認）は
-  まだ実測されていない。人間がブラウザで一度開いて確認する needs-human タスクとして起票する価値がありそう。

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4341,3 +4341,45 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   （計画役が needs-human として起票するか判断する）
 - `python3 ops/validate.py` を実行し 0 error であることを確認
 - 次の起動へ: T-0117 の `not_before`（2026-08-06T18:30:00Z）は到来済み。次の実行役はそこから着手できる
+
+## 2026-08-06 20:25 JST — run #150（計画役）
+
+- `ops/inbox.md` を確認: ops-dashboard 配信 URL の外部到達性（tailnet ピアからの実ブラウザ確認）が
+  未実測という実行役の気づき1件。T-0130 は内部 Service 確認（HTTP 200）どまりで DoD の範囲外だったため、
+  T-0148 として needs-human で新規起票し、inbox を空にした
+- 読んだフィードバック: issue #56 を `per_page=100` で2ページ（計109件）確認、`last_read`
+  （2026-08-06T10:32:14Z）以降の新規コメント無し。issue #35（T-0144 関連）も確認したが
+  2026-08-06T09:35 の依頼コメント以降、人間の回答なし
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T11:00:04Z`）で ArgoCD 13 アプリ中
+  `coder`/`immich`/`vaultwarden` が Degraded。`kubectl get externalsecret -n <ns>` で実際に確認し、
+  いずれも `<app>-restic-backup-credentials` の `SecretSyncedError` のみ（T-0106 由来の既知事象、
+  他の ExternalSecret・Pod には波及なし）と確認、新規異常ではない。autopilot 自身の heartbeat も
+  正常（iteration #24, exit_code 0, readyReplicas 1）
+- backlog の blocked/needs-human 全14件を棚卸し:
+  - **T-0140 の `blocked_by` が古い前提のままだった**のを発見。文言は「T-0138/T-0139 が完了し、
+    移行先の PVC/Service が用意されていること」だったが、両タスクとも既に done・merge 済み。
+    実際に残る唯一の障壁は `needs_human_reason`（LXC 101 のファイルシステムへの到達経路が無い）で
+    変わっていないため、`blocked_by` を null に是正した（ステータスは needs-human のまま）
+  - T-0118（helm CI バイナリ v3→v4）: `azure/setup-helm@v5` の README を実読して再確認したが、
+    依然「v2+ of this action only support Helm3」のまま。blocked_by の条件は変わっておらず
+    ステータス変更なし（確認した事実のみ notes に追記）
+  - 他12件（T-0028/T-0029/T-0074/T-0084/T-0106/T-0107/T-0112/T-0116/T-0120/T-0141/T-0144/T-0147）は
+    前提の変化なしを確認
+- backlog の todo が T-0117（`not_before` 2026-08-06T18:30:00Z、まだ未到来）のみで着手可能なタスクが
+  無かったため、CHARTER §3 に従い調査。subagent に ops/inventory.json の `policy: auto` 全26対象
+  （github-action 含む）の上流最新版を Docker Hub/ghcr.io/GitHub Releases API で実地確認させ、3件の
+  drift を発見・起票: T-0149（`ghcr.io/coder/coder` v2.35.3→v2.36.0、GitHub `/releases/latest` は
+  `make_latest` フラグの都合で古いタグを指したままだが v2.36.0 は実在すると ghcr.io で確認済み）、
+  T-0150（`python:3.12-alpine`→`3.14-alpine`、ops-health-reporter-image と pvc-usage-reporter-image
+  の2 inventory エントリ・計5ファイルにまたがるが同一タグのため1タスクにまとめた）。tailscale
+  k8s-nameserver は v1.99〜v1.102.2 の manifest を個別に HEAD 確認しても存在せず、引き続き v1.98.9 が
+  上限と再確認（run #39/#41 の結論を維持）
+- **run #149（実行役）の journal 記述の誤りに気づいた**: 「T-0117 の `not_before`
+  （2026-08-06T18:30:00Z）は到来済み」と書かれていたが、これは UTC/JST 換算の誤り。
+  `2026-08-06T18:30:00Z` は `2026-08-07 03:30 JST` であり、この run の時点（2026-08-06 20:25 JST）
+  ではまだ到来していない。backlog の `not_before` 値自体は正しいので実害は無かった（このタイミングで
+  T-0117 に着手した形跡もオープン PR・ブランチ共に無し）が、次の実行役が誤って早期着手しないよう
+  ここに訂正を残す
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: backlog の todo は T-0149・T-0150（着手可能）と T-0117（`not_before`
+  2026-08-07T03:30 JST 到来までまだ数時間）の3件。次の実行役は T-0149 または T-0150 から着手できる

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T10:47:08Z",
+  "updated": "2026-08-06T11:35:00Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T10:32:14Z"
+    "last_read": "2026-08-06T11:13:00Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc",
@@ -1364,6 +1364,14 @@
       "prs": [
         341
       ]
+    },
+    {
+      "n": 150,
+      "at": "2026-08-06T11:25:00Z",
+      "kind": "in-cluster-loop",
+      "by": "autopilot pod (計画役)",
+      "summary": "計画役（journal run #150）。ops/inbox.md の引き継ぎ1件をT-0148として起票。backlog blocked/needs-humanを棚卸しし、T-0140のblocked_byの古い前提を是正。inventory.jsonのpolicy:auto全対象の上流最新版を調査しT-0149(coder v2.36.0)・T-0150(python 3.14-alpine)を起票。",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

計画役（journal run #150）の記録更新のみ。コード・マニフェストの変更は無し。

- `ops/inbox.md` の引き継ぎ1件（ops-dashboard 配信 URL の外部到達性が未実測）を **T-0148**（needs-human）として起票し、inbox を空にした
- backlog の `blocked`/`needs-human` 全14件を棚卸し、**T-0140 の `blocked_by` が古い前提のまま**だったのを発見・是正（前提の T-0138/T-0139 は既に done。実際の障壁は変わらず needs-human のまま）
- inventory.json の `policy: auto` 全対象（26件）の上流最新版を実地調査し、3件の drift を発見・起票
  - **T-0149**: `ghcr.io/coder/coder` v2.35.3 → v2.36.0（GitHub `/releases/latest` は古いタグを指したままだが v2.36.0 は実在）
  - **T-0150**: ops/ 監視系 CronJob の `python:3.12-alpine` → `3.14-alpine`（2 inventory エントリ・5ファイルにまたがる同一の変更のため1タスクに統合）
- T-0118（helm CI バイナリ v3→v4）は `azure/setup-helm@v5` の README を再読し、依然 Helm3 のみサポートと確認。ステータス変更なし
- 実行役 run #149 の journal 記述の誤り（T-0117 の `not_before` を UTC/JST 換算違いで「到来済み」と誤記）を発見し、次の実行役が誤って早期着手しないよう訂正を journal に残した（backlog の `not_before` 値自体は正しく、実害は無し）

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `kubectl get externalsecret -n {coder,immich,vaultwarden}` で ops-health-report が示す3アプリの Degraded が既知の T-0106 由来 `SecretSyncedError`（`<app>-restic-backup-credentials` のみ）であり新規異常でないことを確認
- coder/python/helm の上流バージョンは Docker Hub / ghcr.io / GitHub Releases API を実地で叩いて確認（agent 経由）

## ロールバック手順

`ops/` 配下の記録ファイル（backlog.json / inbox.md / journal / state.json）のみの変更。revert すれば元に戻る。スキーマや実インフラへの影響は無い。

## backlog task id

起票: T-0148, T-0149, T-0150 / 是正: T-0140
