### PR TITLE
update(ops): python:3.12-alpine → 3.14-alpine (T-0150)

### DIFF
--- a/apps/coder/pvc-usage-cronjob.yaml
+++ b/apps/coder/pvc-usage-cronjob.yaml
@@ -196,7 +196,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: pvc-usage
-              image: python:3.12-alpine
+              image: python:3.14-alpine
               command: ["python", "/scripts/pvc_usage.py"]
               env:
                 - name: PVC_MOUNTS

--- a/apps/immich/pvc-usage-cronjob.yaml
+++ b/apps/immich/pvc-usage-cronjob.yaml
@@ -196,7 +196,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: pvc-usage
-              image: python:3.12-alpine
+              image: python:3.14-alpine
               command: ["python", "/scripts/pvc_usage.py"]
               env:
                 - name: PVC_MOUNTS

--- a/apps/ops-health-reporter/cronjob.yaml
+++ b/apps/ops-health-reporter/cronjob.yaml
@@ -26,7 +26,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: report
-              image: python:3.12-alpine
+              image: python:3.14-alpine
               command: ["python", "/scripts/report.py"]
               env:
                 - name: GITHUB_TOKEN

--- a/apps/vaultwarden/pvc-usage-cronjob.yaml
+++ b/apps/vaultwarden/pvc-usage-cronjob.yaml
@@ -196,7 +196,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: pvc-usage
-              image: python:3.12-alpine
+              image: python:3.14-alpine
               command: ["python", "/scripts/pvc_usage.py"]
               env:
                 - name: PVC_MOUNTS

--- a/apps/vaultwarden/restic-backup-cronjob.yaml
+++ b/apps/vaultwarden/restic-backup-cronjob.yaml
@@ -8,7 +8,7 @@
 # 仕組みで稼働中でも一貫性のあるコピーが取れる) を使い、db.sqlite3 だけ emptyDir へ
 # 一貫コピーしてから、本体の restic-backup コンテナが「PVC (db.sqlite3系とicon_cacheを除く) +
 # 一貫コピー済みdb.sqlite3」の2パスをまとめて1スナップショットにする。
-# python:3.12-alpine は標準ライブラリの sqlite3 モジュールを同梱しており、apk 等での
+# python:3.14-alpine は標準ライブラリの sqlite3 モジュールを同梱しており、apk 等での
 # パッケージ追加インストールが不要（ネットワーク先のパッケージリポジトリに依存しない）。
 # 参考: https://github.com/dani-garcia/vaultwarden/wiki/Backing-up-your-vault
 apiVersion: v1
@@ -75,7 +75,7 @@ spec:
           restartPolicy: Never
           initContainers:
             - name: sqlite-snapshot
-              image: python:3.12-alpine
+              image: python:3.14-alpine
               command: ["python", "/scripts/sqlite_backup.py"]
               env:
                 - name: SRC_DB

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2851,7 +2851,7 @@
       "title": "ops/ 監視系 CronJob の python ベースイメージを 3.12-alpine → 3.14-alpine に上げる",
       "kind": "update",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 40,
       "why": "計画役の run #150 の inventory 定期調査で、python:3.12-alpine より新しい 3.14-alpine（3.13-alpine も存在）が出ていると判明。対象は ops/inventory.json の ops-health-reporter-image と pvc-usage-reporter-image の2エントリで、後者は mirrors 4ファイルを含む。どちらも標準ライブラリのみで動く読み取り専用スクリプトで homelab 本体の到達性には影響しない（各エントリの observability_impact 参照）。",
       "dod": "対象5ファイル（apps/ops-health-reporter/cronjob.yaml、apps/immich/pvc-usage-cronjob.yaml、apps/coder/pvc-usage-cronjob.yaml、apps/vaultwarden/pvc-usage-cronjob.yaml、apps/vaultwarden/restic-backup-cronjob.yaml）の python:3.12-alpine を 3.14-alpine に揃えて更新し、ops/inventory.json の該当2エントリも更新する。3.13 を飛ばして 3.14 に上げる場合は CPython 3.13→3.14 の changelog（3.12→3.13 分も含め）に、これらのスクリプトが使う標準ライブラリ（json/urllib/subprocess/pathlib 等）の破壊的変更が無いか目を通す。",
@@ -2866,8 +2866,8 @@
         "ops/check_version_sync.py"
       ],
       "created": "2026-08-06",
-      "pr": null,
-      "notes": "run #150（計画役）: 2つの inventory エントリ（ops-health-reporter-image は単独ファイル、pvc-usage-reporter-image は mirrors 4ファイル）にまたがるが、全て同一の python:3.12-alpine タグを指しており実質同じ変更のため 1 タスクにまとめた。check_version_sync.py の該当 GROUP（T-0082/T-0081）が既にこれらの一致を CI で検証しているので、ズレたまま merge されることはない。"
+      "pr": 343,
+      "notes": "run #150（計画役）: 2つの inventory エントリ（ops-health-reporter-image は単独ファイル、pvc-usage-reporter-image は mirrors 4ファイル）にまたがるが、全て同一の python:3.12-alpine タグを指しており実質同じ変更のため 1 タスクにまとめた。check_version_sync.py の該当 GROUP（T-0082/T-0081）が既にこれらの一致を CI で検証しているので、ズレたまま merge されることはない。 run #151（実行役）: 実装・PR #343。3.13/3.14 の changelog を対象スクリプトが使う標準ライブラリ単位で確認し破壊的変更なしと判断（sqlite3.version/version_info, urllib.request.URLopener/FancyURLopener, urllib.parse.Quoter の削除はいずれも未使用）。apps/ops-dashboard/deployment.yaml と apps/coder/workspace-home-backup-cronjob.yaml にも python:3.12-alpine が残っているが、この inventory エントリの対象外のため触れず、ops/inbox.md に引き継いだ。"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,78 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 343,
+      "title": "update(ops): python:3.12-alpine → 3.14-alpine (T-0150)",
+      "url": "https://github.com/hikuohiku/homelab/pull/343",
+      "isDraft": false,
+      "createdAt": "2026-08-06T11:25:49Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        }
+      ],
+      "headRefName": "autopilot/T-0150-python-alpine-3.14",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 342,
+      "title": "docs(ops): 計画役 run #150 — T-0148/T-0149/T-0150 起票、T-0140 の前提是正",
+      "url": "https://github.com/hikuohiku/homelab/pull/342",
+      "mergedAt": "2026-08-06T11:18:59Z",
+      "headRefName": "autopilot/T-0148-ops-dashboard-external-check"
+    },
+    {
+      "number": 341,
+      "title": "docs(ops): T-0130 ops-dashboard 配信 URL を state.json/CHARTER に反映",
+      "url": "https://github.com/hikuohiku/homelab/pull/341",
+      "mergedAt": "2026-08-06T11:06:59Z",
+      "headRefName": "autopilot/T-0130-ops-dashboard-url"
+    },
+    {
+      "number": 340,
+      "title": "docs(ops): 計画役 run #148 — T-0130 の前提解消、T-0147 起票",
+      "url": "https://github.com/hikuohiku/homelab/pull/340",
+      "mergedAt": "2026-08-06T10:58:26Z",
+      "headRefName": "autopilot/T-0130-dashboard-url-todo"
+    },
+    {
+      "number": 339,
+      "title": "docs(ops): run #147（実行役）記録更新、PR #338 merge・actionable タスク無しを記録",
+      "url": "https://github.com/hikuohiku/homelab/pull/339",
+      "mergedAt": "2026-08-06T10:49:50Z",
+      "headRefName": "autopilot/run147-record-only"
+    },
+    {
+      "number": 338,
+      "title": "docs(ops): T-0146 cachix pull 検証の結果を記録",
+      "url": "https://github.com/hikuohiku/homelab/pull/338",
+      "mergedAt": "2026-08-06T10:45:35Z",
+      "headRefName": "autopilot/T-0146-cachix-pull-verification"
+    },
+    {
+      "number": 337,
+      "title": "docs(ops): run #145（計画役）記録更新、PR #336 の中断回収を記録",
+      "url": "https://github.com/hikuohiku/homelab/pull/337",
+      "mergedAt": "2026-08-06T10:34:34Z",
+      "headRefName": "autopilot/run145-planning-record"
+    },
     {
       "number": 336,
       "title": "docs(ops): run #144（計画役）記録更新、T-0146起票",
@@ -378,48 +450,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/283",
       "mergedAt": "2026-08-06T03:11:38Z",
       "headRefName": "autopilot/T-0125-cronjob-schedule-jst-not-utc"
-    },
-    {
-      "number": 282,
-      "title": "chore(ops): run #96 の実番号 (#281) を記録に反映",
-      "url": "https://github.com/hikuohiku/homelab/pull/282",
-      "mergedAt": "2026-08-06T03:01:14Z",
-      "headRefName": "autopilot/run96-pr-number"
-    },
-    {
-      "number": 281,
-      "title": "chore(ops): run #96 の記録更新（中断なし・進捗なし・健全性確認）",
-      "url": "https://github.com/hikuohiku/homelab/pull/281",
-      "mergedAt": "2026-08-06T02:59:40Z",
-      "headRefName": "autopilot/run96-wrapup"
-    },
-    {
-      "number": 280,
-      "title": "chore(autopilot): image ダイジェストコメントの実態乖離を修正 (T-0124)",
-      "url": "https://github.com/hikuohiku/homelab/pull/280",
-      "mergedAt": "2026-08-06T02:53:34Z",
-      "headRefName": "autopilot/T-0124-autopilot-image-pin-comment"
-    },
-    {
-      "number": 279,
-      "title": "chore(ops): run #94 の記録更新（中断なし・T-0117 継続待ち・健全性確認）",
-      "url": "https://github.com/hikuohiku/homelab/pull/279",
-      "mergedAt": "2026-08-06T02:44:12Z",
-      "headRefName": "autopilot/run94-wrapup"
-    },
-    {
-      "number": 278,
-      "title": "chore(ops): run #93 の記録更新（PR #276 merge・健全性確認）",
-      "url": "https://github.com/hikuohiku/homelab/pull/278",
-      "mergedAt": "2026-08-06T02:36:46Z",
-      "headRefName": "autopilot/run93-wrapup"
-    },
-    {
-      "number": 276,
-      "title": "chore(ops): T-0123 validate.py の PR-empty 警告ノイズを解消",
-      "url": "https://github.com/hikuohiku/homelab/pull/276",
-      "mergedAt": "2026-08-06T02:17:58Z",
-      "headRefName": "autopilot/T-0123-validate-pr-notes-warning-noise"
     }
   ]
 }

--- a/ops/inbox.md
+++ b/ops/inbox.md
@@ -7,3 +7,8 @@
 [`ops/CHARTER.md`](CHARTER.md) の §3「書く権利」。
 
 ---
+
+- run #151: T-0150（python 3.14-alpine 化）の作業中、`apps/ops-dashboard/deployment.yaml` と
+  `apps/coder/workspace-home-backup-cronjob.yaml` にも `python:3.12-alpine` が残っているのを見つけた。
+  どちらも `ops/inventory.json` に監視対象として登録されていない（`grep -rn "python:3.12-alpine" apps/`
+  で確認）。inventory へのエントリ追加＋更新タスクとして起票するか判断してほしい。

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -299,7 +299,7 @@
       "id": "ops-health-reporter-image",
       "kind": "image",
       "name": "python (ops-health-reporter CronJob)",
-      "current": "3.12-alpine",
+      "current": "3.14-alpine",
       "file": "apps/ops-health-reporter/cronjob.yaml",
       "match": "image: python:",
       "upstream": "dockerhub:library/python",
@@ -311,7 +311,7 @@
       "id": "pvc-usage-reporter-image",
       "kind": "image",
       "name": "python (pvc-usage-reporter CronJob)",
-      "current": "3.12-alpine",
+      "current": "3.14-alpine",
       "file": "apps/immich/pvc-usage-cronjob.yaml",
       "match": "image: python:",
       "mirrors": [

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4383,3 +4383,21 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py` を実行し 0 error であることを確認
 - 次の起動へ: backlog の todo は T-0149・T-0150（着手可能）と T-0117（`not_before`
   2026-08-07T03:30 JST 到来までまだ数時間）の3件。次の実行役は T-0149 または T-0150 から着手できる
+
+## 2026-08-06 20:26 JST — run #151（実行役）
+
+- 前回の中断確認: オープン PR 0 件、`autopilot/*` ブランチ残存なし。ローカル main は origin/main と一致
+- 読んだフィードバック: issue #56 の `last_read`（2026-08-06T10:32:14Z）以降、新規コメント無し
+- やったこと: backlog の todo のうち同 priority(40) で risk が低い T-0150（`python:3.12-alpine`→
+  `3.14-alpine`、ops-health-reporter/pvc-usage-reporter 系5ファイル + `ops/inventory.json`）に着手し
+  PR #343 を作成。対象スクリプトが使う標準ライブラリ（base64/datetime/json/os/re/sqlite3/ssl/
+  urllib.request/urllib.error）単位で Python 3.13/3.14 の changelog を確認し、3.14 で削除された
+  `sqlite3.version`/`version_info`・`urllib.request.URLopener`/`FancyURLopener`・
+  `urllib.parse.Quoter` はいずれも未使用と確認した。`ops/validate.py`・`ops/check_version_sync.py`
+  とも green。縛る変更（新しい失敗条件の導入）ではないため cooldown 対象外、CI green を待って
+  この起動内で merge する
+- 見つけたこと: `apps/ops-dashboard/deployment.yaml` と `apps/coder/workspace-home-backup-cronjob.yaml`
+  にも `python:3.12-alpine` が残っているが、どちらも T-0150 が対象とする inventory エントリの
+  範囲外（別コンポーネント）のため今回は触れず、`ops/inbox.md` に引き継いだ
+- 次の起動へ: PR #343 の CI green・merge を見届けたら、backlog の todo は T-0149（着手可能）と
+  T-0117（`not_before` 2026-08-07T03:30 JST）が残る

--- a/ops/state.json
+++ b/ops/state.json
@@ -1372,6 +1372,16 @@
       "by": "autopilot pod (計画役)",
       "summary": "計画役（journal run #150）。ops/inbox.md の引き継ぎ1件をT-0148として起票。backlog blocked/needs-humanを棚卸しし、T-0140のblocked_byの古い前提を是正。inventory.jsonのpolicy:auto全対象の上流最新版を調査しT-0149(coder v2.36.0)・T-0150(python 3.14-alpine)を起票。",
       "prs": []
+    },
+    {
+      "n": 151,
+      "at": "2026-08-06T11:26:00Z",
+      "kind": "in-cluster-loop",
+      "by": "autopilot pod (実行役)",
+      "summary": "実行役（journal run #151）。backlog の todo のうち同 priority で risk の低い T-0150（python:3.12-alpine → 3.14-alpine、ops-health-reporter/pvc-usage-reporter 系5ファイル + inventory.json）に着手し PR #343 を作成。",
+      "prs": [
+        343
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`ops/inventory.json` の `ops-health-reporter-image` / `pvc-usage-reporter-image` が管理する
python base image を `3.12-alpine` → `3.14-alpine` に上げた。対象は以下5ファイル:

- `apps/ops-health-reporter/cronjob.yaml`
- `apps/immich/pvc-usage-cronjob.yaml`
- `apps/coder/pvc-usage-cronjob.yaml`
- `apps/vaultwarden/pvc-usage-cronjob.yaml`
- `apps/vaultwarden/restic-backup-cronjob.yaml`（sqlite-snapshot initContainer）

いずれも読み取り専用の監視/バックアップ補助スクリプトで、homelab 本体の到達性・稼働には影響しない。

## 検証したこと

- 対象スクリプトが使う標準ライブラリ（`base64`/`datetime`/`json`/`os`/`re`/`sqlite3`/`ssl`/
  `urllib.request`/`urllib.error`）について、Python 3.13/3.14 の What's New・Removed セクション
  を確認した。3.14 で削除された `sqlite3.version`/`version_info`、`urllib.request` の
  `URLopener`/`FancyURLopener`、`urllib.parse.Quoter` はいずれも対象スクリプトで未使用
  （実際のコードを grep して確認済み）
- `python3 ops/validate.py` → 0 error
- `python3 ops/check_version_sync.py` → 全 group で ok（`pvc-usage-reporter-image` グループの
  4ファイルが揃って `3.14-alpine` になっていることを含む）
- `kubectl kustomize` で helm を使わない対象（ops-health-reporter/vaultwarden/coder の該当ファイル）
  は render 結果を目視確認。immich は `helmCharts` を含むため手元では `--enable-helm` が無く
  render できず、CI (`kustomize build --enable-helm`) に委ねる

## ロールバック手順

このコミットを revert し、5ファイルの image タグと `ops/inventory.json` の該当2エントリを
`3.12-alpine` に戻せば元に戻る。DB・PVC 等の永続データを扱わない読み取り専用スクリプトのため、
スキーマや状態の非対称は残らない。

## backlog task id

T-0150
