### PR TITLE
docs(ops): T-0149 を dropped に（coder v2.36.0 は mainline、pin継続が正）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2832,7 +2832,7 @@
       "title": "ghcr.io/coder/coder を v2.35.3 → v2.36.0 に上げる",
       "kind": "update",
       "risk": "medium",
-      "status": "todo",
+      "status": "dropped",
       "priority": 40,
       "why": "計画役の run #150 の inventory 定期調査（policy: auto 全対象の上流最新版チェック）で発見。ghcr.io の実タグ・GitHub Releases API で v2.36.0 (2026-08-04 公開) が存在し、v2.35.3 より新しいことを確認済み。",
       "dod": "CHARTER §4「バージョン更新の作法」に従い v2.35.3 → v2.36.0 のリリースノートを原文で確認し、破壊的変更が無いことを確かめたうえで apps/coder/ の image タグと ops/inventory.json を更新する。",
@@ -2843,7 +2843,7 @@
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "run #150（計画役）: GitHub の `/repos/coder/coder/releases/latest` は make_latest フラグの都合で v2.35.3 を指したままだが、v2.36.0 のリリース自体は実在し ghcr.io に イメージも存在する（agent 調査で確認）。実装時は `/releases/latest` を鵜呑みにせず、tag 指定（`/repos/coder/coder/releases/tags/v2.36.0`）でリリースノートを取得すること。"
+      "notes": "run #150（計画役）: GitHub の `/repos/coder/coder/releases/latest` は make_latest フラグの都合で v2.35.3 を指したままだが、v2.36.0 のリリース自体は実在し ghcr.io に イメージも存在する（agent 調査で確認）。実装時は `/releases/latest` を鵜呑みにせず、tag 指定（`/repos/coder/coder/releases/tags/v2.36.0`）でリリースノートを取得すること。 run #152（実行役）: 着手前に `ops/inventory.json` の coder エントリの note（『stable チャンネルを追う（mainline の v2.36.0 系は避ける）』）を読み直し、v2.36.0 自体がその note が名指しで避けよと書いている対象そのものだと気づいた。GitHub の v2.36.0 リリースノート原文でも「ステージング環境が無い企業ユーザーは、この版ではなく最新の stable をインストールすること」と明記されている。Coder 公式ドキュメント（coder.com/docs/install/releases）の channel モデルは mainline=N、stable=N-1、security=N-2 で、直近リリース列（v2.32.10/v2.33.11/v2.34.7/v2.35.3/v2.36.0、いずれも2026-08-06時点で published_at 実測）と突き合わせると、v2.36.0 発行時点で v2.35.3（現行 pin）はまさに stable 相当になる。つまり現行 pin は既に policy 通り stable の最新であり、v2.36.0 への更新はこの note が防ごうとしていた行為そのもの。当タスクは起票時の inventory 自動チェックが「新しいタグがある」というシグナルだけを見て、同じ inventory エントリ内の note（避けるべき対象）を突き合わせていなかったために生まれた誤検知と判断し dropped にした。再発防止の提案は ops/inbox.md に引き継いだ。"
     },
     {
       "id": "T-0150",

--- a/ops/inbox.md
+++ b/ops/inbox.md
@@ -12,3 +12,11 @@
   `apps/coder/workspace-home-backup-cronjob.yaml` にも `python:3.12-alpine` が残っているのを見つけた。
   どちらも `ops/inventory.json` に監視対象として登録されていない（`grep -rn "python:3.12-alpine" apps/`
   で確認）。inventory へのエントリ追加＋更新タスクとして起票するか判断してほしい。
+- run #152: T-0149（coder v2.35.3→v2.36.0）を dropped にした。理由は backlog.json の notes 参照。
+  要点だけ書くと、`ops/inventory.json` の coder エントリには「stable チャンネルを追う（mainline の
+  v2.36.0 系は避ける）」という既存の note があり、v2.36.0 はまさにその note が避けよと言っている
+  対象だった（Coder の channel モデルは mainline=N/stable=N-1、v2.36.0 発行時点で現行 pin の
+  v2.35.3 が stable 相当）。run #150 の inventory 自動チェックは「新しいタグの有無」だけを見ており、
+  同じエントリ内の note（避けるべき対象の明記）を突き合わせていなかった。次回同種のチェックをする
+  ときに note を読み合わせる運用にするか、チェック手順（CHARTER §3 or 計画役向けプロンプト）に
+  明文化するかを検討してほしい。coder 自体は当面 v2.35.3 のままで問題ない（stable の最新）。

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4401,3 +4401,27 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   範囲外（別コンポーネント）のため今回は触れず、`ops/inbox.md` に引き継いだ
 - 次の起動へ: PR #343 の CI green・merge を見届けたら、backlog の todo は T-0149（着手可能）と
   T-0117（`not_before` 2026-08-07T03:30 JST）が残る
+
+## 2026-08-06 20:34 JST — run #152（実行役）
+
+- 前回の中断確認: オープン PR 0 件、`autopilot/*` ブランチ残存なし。ローカル main は origin/main と一致
+- 読んだフィードバック: issue #56 を `per_page=100` で2ページ（計109件）確認、`last_read`
+  （2026-08-06T11:13:00Z）以降の新規コメント無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T11:30:04Z`）で ArgoCD 13 アプリ中
+  `coder`/`immich`/`vaultwarden` が Degraded。前回までと同じ T-0106 由来の既知 `SecretSyncedError`
+  と判断（新規異常の兆候なし）。autopilot 自身の heartbeat も正常（iteration #27, exit_code 0,
+  readyReplicas 1）
+- やったこと: backlog の todo（T-0149、coder v2.35.3→v2.36.0）に着手したが、実装前に
+  `ops/inventory.json` の coder エントリの note を読み直し、v2.36.0 が同じ note が名指しで避けよと
+  書いている対象そのものだと判明したため実装せず **dropped** にした。GitHub の v2.36.0 リリースノート
+  原文（`/repos/coder/coder/releases/tags/v2.36.0`）にも「ステージング環境が無い企業ユーザーは
+  最新の stable をインストールすること」と明記されており、Coder 公式ドキュメント
+  （coder.com/docs/install/releases）の channel モデル（mainline=N/stable=N-1/security=N-2）と
+  直近リリース列の実測を突き合わせると、v2.36.0 発行時点で現行 pin の v2.35.3 はすでに stable 最新
+  だった。詳細は backlog.json の T-0149 notes 参照
+- 見つけたこと: run #150 の inventory 自動チェックは「新しいタグの有無」のみを見ており、同じ
+  inventory エントリ内の note（避けるべき対象の明記）を突き合わせていなかった。次回同種チェックの
+  やり方の改善を `ops/inbox.md` に引き継いだ
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: backlog の todo は T-0117（`not_before` 2026-08-07T03:30 JST、まだ未到来）のみで
+  着手可能なタスクが無い。次の起動（計画役）は調査タスクの起票を検討すること

--- a/ops/state.json
+++ b/ops/state.json
@@ -1382,6 +1382,14 @@
       "prs": [
         343
       ]
+    },
+    {
+      "n": 152,
+      "at": "2026-08-06T11:34:00Z",
+      "kind": "in-cluster-loop",
+      "by": "autopilot pod (実行役)",
+      "summary": "実行役（journal run #152）。T-0149（coder v2.35.3→v2.36.0）に着手したが、v2.36.0 は inventory.json の note が避けよと指示する mainline リリースそのものと判明したため実装せず dropped に。改善提案は inbox.md へ引き継いだ。",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`ops/backlog.json` の T-0149（`ghcr.io/coder/coder` v2.35.3 → v2.36.0）を実装せず **dropped** にしました。コードやマニフェストの変更はありません（`ops/` の運用記録のみ）。

## 経緯

T-0149 は計画役（run #150）の inventory 自動チェックが「ghcr.io に v2.36.0 という新しいタグがある」ことだけを見て起票したタスクでした。しかし実装前に確認したところ、`ops/inventory.json` の coder エントリには元々こういう note がありました。

> stable チャンネルを追う（mainline の v2.36.0 系は避ける）

v2.36.0 はまさにこの note が名指しで避けよと言っている対象そのものでした。GitHub の v2.36.0 リリースノート原文にも「ステージング環境を持たない企業ユーザーはこの版ではなく最新の stable をインストールすること」と明記されています。Coder の公式リリースチャンネルモデル（mainline = 最新の N、stable = N-1）と実際のリリース履歴（v2.36.0 公開が 2026-08-04、直前の v2.35.3 が 2026-07-27）を突き合わせると、v2.36.0 が mainline に出た時点で現行 pin の v2.35.3 はすでに stable の最新版でした。つまり今回のアップグレードは不要どころか、既存の pin ポリシーに反する変更でした。

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- GitHub Releases API (`/repos/coder/coder/releases/tags/v2.36.0`) の原文、coder.com/docs/install/releases のチャンネルモデル説明、直近リリース一覧（v2.32.10〜v2.36.0）の `published_at` を突き合わせて確認

## ロールバック手順

`ops/` の記録更新のみで、実インフラ・コードへの変更はありません。この PR を revert すれば T-0149 は `todo` に戻ります（ただし戻すべき理由はありません）。

## 見つけたこと

同種の inventory 自動チェックが「note と突き合わせずに新しいタグの有無だけで起票する」構造上の弱さを持っていることが分かりました。再発防止の検討は `ops/inbox.md` に引き継ぎ、次の計画役が判断します。

## backlog task id

T-0149