### PR TITLE
docs(ops): run #153 実行記録（PR #344 merge、着手可能タスク無し）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,36 +1,20 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
+    {
+      "number": 344,
+      "title": "docs(ops): T-0149 を dropped に（coder v2.36.0 は mainline、pin継続が正）",
+      "url": "https://github.com/hikuohiku/homelab/pull/344",
+      "mergedAt": "2026-08-06T11:39:22Z",
+      "headRefName": "autopilot/T-0149-drop-mainline-upgrade"
+    },
     {
       "number": 343,
       "title": "update(ops): python:3.12-alpine → 3.14-alpine (T-0150)",
       "url": "https://github.com/hikuohiku/homelab/pull/343",
-      "isDraft": false,
-      "createdAt": "2026-08-06T11:25:49Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        }
-      ],
-      "headRefName": "autopilot/T-0150-python-alpine-3.14",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-06T11:28:01Z",
+      "headRefName": "autopilot/T-0150-python-alpine-3.14"
+    },
     {
       "number": 342,
       "title": "docs(ops): 計画役 run #150 — T-0148/T-0149/T-0150 起票、T-0140 の前提是正",
@@ -436,20 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/286",
       "mergedAt": "2026-08-06T03:21:34Z",
       "headRefName": "autopilot/plan-execute-split"
-    },
-    {
-      "number": 284,
-      "title": "fix(ops): dashboard の PR 一覧取得を gh CLI 依存から GitHub API 直叩きに (T-0126)",
-      "url": "https://github.com/hikuohiku/homelab/pull/284",
-      "mergedAt": "2026-08-06T03:20:07Z",
-      "headRefName": "autopilot/T-0126-dashboard-prs-rest-api"
-    },
-    {
-      "number": 283,
-      "title": "docs: CronJob の schedule 記述を UTC → JST に訂正 (T-0125)",
-      "url": "https://github.com/hikuohiku/homelab/pull/283",
-      "mergedAt": "2026-08-06T03:11:38Z",
-      "headRefName": "autopilot/T-0125-cronjob-schedule-jst-not-utc"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4425,3 +4425,15 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py` を実行し 0 error であることを確認
 - 次の起動へ: backlog の todo は T-0117（`not_before` 2026-08-07T03:30 JST、まだ未到来）のみで
   着手可能なタスクが無い。次の起動（計画役）は調査タスクの起票を検討すること
+
+## 2026-08-06 20:40 JST — run #153（実行役）
+
+- 前回の中断確認: オープン PR #344（run #152 が作成した T-0149 dropped の記録用 PR）が残っていた。
+  CI 6件全て green・`mergeable_state: clean` を確認し、この起動内で merge（e46d534）。
+  ブランチ `autopilot/T-0149-drop-mainline-upgrade` は GitHub が自動削除済み
+- 読んだフィードバック: issue #56 を `per_page=100` で2ページ（計109件）確認、`last_read`
+  （2026-08-06T11:13:00Z）以降の新規コメント無し
+- やったこと: 上記の中断解消（PR #344 merge）のみ。backlog の todo は T-0117
+  （`not_before` 2026-08-07T03:30 JST、まだ未到来）のみで着手可能な新規タスクが無かった
+- 次の起動へ: backlog の todo は引き続き T-0117 のみ（`not_before` 到来まで数時間）。次の起動が
+  計画役なら調査タスクの起票を検討すること

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T11:35:00Z",
+  "updated": "2026-08-06T11:40:00Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T11:13:00Z"
+    "last_read": "2026-08-06T11:39:00Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc",
@@ -1390,6 +1390,16 @@
       "by": "autopilot pod (実行役)",
       "summary": "実行役（journal run #152）。T-0149（coder v2.35.3→v2.36.0）に着手したが、v2.36.0 は inventory.json の note が避けよと指示する mainline リリースそのものと判明したため実装せず dropped に。改善提案は inbox.md へ引き継いだ。",
       "prs": []
+    },
+    {
+      "n": 153,
+      "at": "2026-08-06T11:40:00Z",
+      "kind": "in-cluster-loop",
+      "by": "autopilot pod (実行役)",
+      "summary": "実行役（journal run #153）。前回の中断だった PR #344（T-0149 dropped の記録）の CI green を確認し merge。backlog の todo は T-0117（not_before 未到来）のみで着手可能な新規タスクは無かった。",
+      "prs": [
+        344
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

run #153（実行役）の作業記録のみです。コード・マニフェストの変更はありません。

- 前回の中断だった PR #344（run #152 が作成した T-0149 dropped の記録）の CI green・`mergeable_state: clean` を確認し、この起動内で merge しました
- backlog の `todo` は T-0117（`not_before` 2026-08-07T03:30 JST、まだ未到来）のみで、着手可能な新規タスクはありませんでした
- issue #56 のフィードバックを確認しましたが、新規コメントはありませんでした（`feedback.last_read` を更新）

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 生成成功、`ops-dashboard` ブランチへ publish 成功

## ロールバック手順

`ops/` の運用記録のみで、実インフラ・コードへの変更はありません。revert しても実害はありません。

## backlog task id

なし（記録専用 PR）
