### PR TITLE
ops(run #154): 計画役 — inbox 2件を T-0151/T-0152 として起票

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 151,
-  "updated": "2026-08-06T11:30:00Z",
+  "next_id": 153,
+  "updated": "2026-08-06T11:49:11Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2868,6 +2868,46 @@
       "created": "2026-08-06",
       "pr": 343,
       "notes": "run #150（計画役）: 2つの inventory エントリ（ops-health-reporter-image は単独ファイル、pvc-usage-reporter-image は mirrors 4ファイル）にまたがるが、全て同一の python:3.12-alpine タグを指しており実質同じ変更のため 1 タスクにまとめた。check_version_sync.py の該当 GROUP（T-0082/T-0081）が既にこれらの一致を CI で検証しているので、ズレたまま merge されることはない。 run #151（実行役）: 実装・PR #343。3.13/3.14 の changelog を対象スクリプトが使う標準ライブラリ単位で確認し破壊的変更なしと判断（sqlite3.version/version_info, urllib.request.URLopener/FancyURLopener, urllib.parse.Quoter の削除はいずれも未使用）。apps/ops-dashboard/deployment.yaml と apps/coder/workspace-home-backup-cronjob.yaml にも python:3.12-alpine が残っているが、この inventory エントリの対象外のため触れず、ops/inbox.md に引き継いだ。"
+    },
+    {
+      "id": "T-0151",
+      "domain": "homelab",
+      "title": "ops-dashboard と coder workspace-home-backup の python:3.12-alpine を inventory に追加し 3.14-alpine へ揃える",
+      "kind": "chore",
+      "risk": "low",
+      "status": "todo",
+      "priority": 42,
+      "why": "T-0150（run #151, PR #343）は ops/inventory.json に既に登録済みの2エントリ（ops-health-reporter-image, pvc-usage-reporter-image）だけを 3.14-alpine に揃えた。実行役がその過程で apps/ops-dashboard/deployment.yaml と apps/coder/workspace-home-backup-cronjob.yaml にも python:3.12-alpine が残っているが、どちらの inventory エントリの対象（file/mirrors）にも含まれていないため素通りされていると気づき、ops/inbox.md へ引き継いだ（run #151）。inventory に無いバージョンは自動チェックの対象外のまま塩漬けになりうる（CHARTER §1「依存が塩漬けにならない」）。",
+      "dod": "(1) apps/ops-dashboard/deployment.yaml と apps/coder/workspace-home-backup-cronjob.yaml の python:3.12-alpine を 3.14-alpine に更新する（T-0150 で標準ライブラリの破壊的変更は無いと確認済みだが、この2ファイルが使うモジュール（http.server, json/urllib/subprocess 等）についても改めて確認する）。(2) ops/inventory.json にこの2ファイルを追跡対象として登録する。既存の pvc-usage-reporter-image と同一の python:*-alpine 更新ポリシーだが用途（http.server 配信 / workspace home backup orchestrator）が異なるため、既存エントリの mirrors に混ぜるか新規エントリにするかは実装時に判断してよい。(3) ops/check_version_sync.py の GROUPS がこの2ファイルを新たに束ねる場合はそちらも更新し、CI (kustomize build 等) が green であることを確認する。",
+      "blocked_by": null,
+      "refs": [
+        "apps/ops-dashboard/deployment.yaml",
+        "apps/coder/workspace-home-backup-cronjob.yaml",
+        "ops/inventory.json",
+        "ops/check_version_sync.py"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #153（計画役）: ops/inbox.md の引き継ぎ（run #151 実行役の気づき）を起票。"
+    },
+    {
+      "id": "T-0152",
+      "domain": "homelab",
+      "title": "inventory 定期チェックで note の除外指定（避けるべきバージョン）を突き合わせる運用を明文化する",
+      "kind": "chore",
+      "risk": "low",
+      "status": "todo",
+      "priority": 45,
+      "why": "T-0149（run #152 で dropped）の実例。ops/inventory.json の coder エントリには『stable チャンネルを追う（mainline の vX.XX.0 系は避ける）』という note が既に書かれていたが、run #150 の inventory 自動チェックは『upstream に新しいタグがあるか』だけを見て note の除外指定を突き合わせておらず、避けるべきと明記されていた v2.36.0 への更新タスクを一度起票してしまった（実害は出る前に run #152 で気づき dropped にできたが、1 タスク分の起票・調査・dropped 判断が無駄になった）。CHARTER §8「同じミスを2回した→機械的に防ぐ」がまだ1回目のため、次に同型のミスをする前に運用へ落とす。",
+      "dod": "CHARTER §3 のバージョン更新の作法（または該当する調査手順）に、『inventory.json の対象エントリに新しいタグが無いか調べるときは、同じエントリの note に除外・回避指定が無いかを必ず読み合わせる』旨を明文化する。可能であれば ops/ 配下のスクリプト（inventory 定期チェックの手順を担う部分があれば）にも同種のチェックを機械的に組み込めないか検討し、スクリプト化が難しい場合は CHARTER の手順記述のみで良い。",
+      "blocked_by": null,
+      "refs": [
+        "ops/CHARTER.md",
+        "ops/inventory.json"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #153（計画役）: ops/inbox.md の引き継ぎ（run #152 実行役の気づき、T-0149 dropped の教訓）を起票。"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 345,
+      "title": "docs(ops): run #153 実行記録（PR #344 merge、着手可能タスク無し）",
+      "url": "https://github.com/hikuohiku/homelab/pull/345",
+      "mergedAt": "2026-08-06T11:43:35Z",
+      "headRefName": "autopilot/run153-record-only"
+    },
+    {
       "number": 344,
       "title": "docs(ops): T-0149 を dropped に（coder v2.36.0 は mainline、pin継続が正）",
       "url": "https://github.com/hikuohiku/homelab/pull/344",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/285",
       "mergedAt": "2026-08-06T03:21:38Z",
       "headRefName": "autopilot/T-0126-record-pr-number"
-    },
-    {
-      "number": 286,
-      "title": "feat(autopilot): 計画役と実行役を分ける",
-      "url": "https://github.com/hikuohiku/homelab/pull/286",
-      "mergedAt": "2026-08-06T03:21:34Z",
-      "headRefName": "autopilot/plan-execute-split"
     }
   ]
 }

--- a/ops/inbox.md
+++ b/ops/inbox.md
@@ -7,16 +7,3 @@
 [`ops/CHARTER.md`](CHARTER.md) の §3「書く権利」。
 
 ---
-
-- run #151: T-0150（python 3.14-alpine 化）の作業中、`apps/ops-dashboard/deployment.yaml` と
-  `apps/coder/workspace-home-backup-cronjob.yaml` にも `python:3.12-alpine` が残っているのを見つけた。
-  どちらも `ops/inventory.json` に監視対象として登録されていない（`grep -rn "python:3.12-alpine" apps/`
-  で確認）。inventory へのエントリ追加＋更新タスクとして起票するか判断してほしい。
-- run #152: T-0149（coder v2.35.3→v2.36.0）を dropped にした。理由は backlog.json の notes 参照。
-  要点だけ書くと、`ops/inventory.json` の coder エントリには「stable チャンネルを追う（mainline の
-  v2.36.0 系は避ける）」という既存の note があり、v2.36.0 はまさにその note が避けよと言っている
-  対象だった（Coder の channel モデルは mainline=N/stable=N-1、v2.36.0 発行時点で現行 pin の
-  v2.35.3 が stable 相当）。run #150 の inventory 自動チェックは「新しいタグの有無」だけを見ており、
-  同じエントリ内の note（避けるべき対象の明記）を突き合わせていなかった。次回同種のチェックをする
-  ときに note を読み合わせる運用にするか、チェック手順（CHARTER §3 or 計画役向けプロンプト）に
-  明文化するかを検討してほしい。coder 自体は当面 v2.35.3 のままで問題ない（stable の最新）。

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4437,3 +4437,27 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   （`not_before` 2026-08-07T03:30 JST、まだ未到来）のみで着手可能な新規タスクが無かった
 - 次の起動へ: backlog の todo は引き続き T-0117 のみ（`not_before` 到来まで数時間）。次の起動が
   計画役なら調査タスクの起票を検討すること
+
+## 2026-08-06 20:49 JST — run #154（計画役）
+
+- 前回の中断確認: オープン PR 0 件
+- 読んだフィードバック: issue #56 を `per_page=100` で2ページ（計109件）確認、`last_read`
+  （2026-08-06T11:39:00Z）以降の新規コメント無し。issue #35（T-0144 待ち）・#37（T-0141 待ち）も
+  未回答のまま変化なし
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T11:30:04Z`）で ArgoCD 13 アプリ中
+  `coder`/`immich`/`vaultwarden` が Degraded。従来どおり T-0106 由来の既知 `SecretSyncedError`
+  のみ。`pod_issues` の restarts:19 常連（ノード再起動由来、既知）も変化なし。immich
+  `backup_listing` 最新ファイルは 2026-08-06T02:00 台で新鮮。autopilot 自身の heartbeat も正常
+  （iteration #27, exit_code 0, readyReplicas 1）。新規異常なし
+- やったこと: `ops/inbox.md` の2件をタスクに変換して起票し、inbox を空にした
+  - T-0151: `apps/ops-dashboard/deployment.yaml`・`apps/coder/workspace-home-backup-cronjob.yaml`
+    の `python:3.12-alpine` が `ops/inventory.json` の追跡対象外だった件（T-0150 のフォローアップ、
+    run #151 実行役の気づき）を、inventory 追加＋3.14-alpine 化タスクとして起票
+  - T-0152: T-0149（run #152 で dropped）の教訓（inventory の note にある除外指定を自動チェックが
+    突き合わせていなかった）を、CHARTER §3 の手順明文化タスクとして起票
+- backlog の棚卸し: blocked/needs-human 全15件の理由を確認したが、前提が古くなっているものは
+  無かった（T-0140/T-0148 は run #149、T-0118 は run #150 で直近に確認済み。T-0106/T-0120 の
+  B2 append-only キー発行依頼は docs/backup.md に既に明記済みと run #54 コメントで確認）
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: backlog の todo は T-0151・T-0152（着手可能）と T-0117（`not_before`
+  2026-08-07T03:30 JST 到来までまだ数時間）の3件。次の実行役は T-0151 または T-0152 から着手できる

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T11:40:00Z",
+  "updated": "2026-08-06T11:49:00Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T11:39:00Z"
+    "last_read": "2026-08-06T11:49:00Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc",
@@ -1400,6 +1400,14 @@
       "prs": [
         344
       ]
+    },
+    {
+      "n": 154,
+      "at": "2026-08-06T11:49:00Z",
+      "kind": "in-cluster-loop",
+      "by": "autopilot pod (計画役)",
+      "summary": "計画役（journal run #154）。ops/inbox.md の2件をT-0151・T-0152として起票しinboxを空にした。フィードバック・健全性レポートに新規異常なし。backlog blocked/needs-human 全件の理由を確認したが古い前提は無かった。",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

計画役（run #154）の記録更新のみ。コード・マニフェストの変更なし。

- `ops/inbox.md` の2件を backlog タスクへ変換し、inbox を空にした
  - **T-0151**: `apps/ops-dashboard/deployment.yaml` と `apps/coder/workspace-home-backup-cronjob.yaml` の `python:3.12-alpine` が `ops/inventory.json` の追跡対象外だった件（T-0150 のフォローアップ）を、inventory 追加＋3.14-alpine 化タスクとして起票
  - **T-0152**: T-0149（dropped）の教訓（inventory の note にある除外指定を自動チェックが突き合わせていなかった）を、CHARTER §3 の手順明文化タスクとして起票
- フィードバック issue #56 は `last_read` 以降新規コメント無し。issue #35/#37 も未回答のまま
- `ops-health-report`（generated_at 2026-08-06T11:30:04Z）を確認。ArgoCD の Degraded 3件は既知の T-0106 由来 `SecretSyncedError` のみ、pod_issues の restarts:19 常連も既知、新規異常なし
- backlog の blocked/needs-human 全15件の理由を棚卸ししたが、前提が古いものは無かった
- `ops/dashboard/index.html` を再生成し `ops-dashboard` ブランチへ publish 済み（`ops/dashboard/prs.json` キャッシュも合わせて更新）

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 例外なく完了、`ops-dashboard` ブランチへ publish 成功

## ロールバック手順

`ops/` の記録ファイル（backlog.json / inbox.md / journal / state.json / dashboard キャッシュ）のみの変更。revert すれば起票した T-0151/T-0152 が backlog から消えるだけで、実インフラ・スキーマへの影響は無い。

## backlog task id

T-0151, T-0152（新規起票）
