### PR TITLE
fix(T-0151): ops-dashboard / coder workspace-home-backup の python を 3.14-alpine に揃える

### DIFF
--- a/apps/coder/workspace-home-backup-cronjob.yaml
+++ b/apps/coder/workspace-home-backup-cronjob.yaml
@@ -4,7 +4,7 @@
 # Backblaze B2 へバックアップする (T-0078)。docs/backup.md 参照。
 #
 # workspace は増減するため対象 PVC を静的にマニフェストへ書けない。この CronJob は
-# オーケストレータ役の Pod 1 個（python:3.12-alpine、標準ライブラリのみ）が
+# オーケストレータ役の Pod 1 個（python:3.14-alpine、標準ライブラリのみ）が
 # `app.kubernetes.io/name=coder-pvc` ラベルで対象 PVC を毎回列挙し、PVC ごとに
 # 使い捨ての Job（restic/restic イメージ、対象 PVC のみを readOnly マウント）を
 # Kubernetes API 経由で生成する。生成された Job は ttlSecondsAfterFinished で自動 GC
@@ -299,7 +299,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: spawn-backup-jobs
-              image: python:3.12-alpine
+              image: python:3.14-alpine
               command: ["python", "/scripts/spawn_backup_jobs.py"]
               env:
                 - name: PYTHONDONTWRITEBYTECODE

--- a/apps/ops-dashboard/deployment.yaml
+++ b/apps/ops-dashboard/deployment.yaml
@@ -84,9 +84,9 @@ spec:
         # alpine:3.22.5 の busybox パッケージには httpd が含まれず（busybox-extras
         # 側にのみ存在）CrashLoopBackOff (exitCode 127) になった (#291, run #101 で revert)。
         # apps/ops-health-reporter・apps/{coder,vaultwarden,immich}/pvc-usage-cronjob.yaml
-        # で既に実績のある python:3.12-alpine の標準ライブラリ http.server に置き換える。
+        # で既に実績のある python:3.14-alpine の標準ライブラリ http.server に置き換える。
         - name: httpd
-          image: python:3.12-alpine
+          image: python:3.14-alpine
           command: ["python3", "-m", "http.server", "8080", "--directory", "/www"]
           ports:
             - name: http

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2875,7 +2875,7 @@
       "title": "ops-dashboard と coder workspace-home-backup の python:3.12-alpine を inventory に追加し 3.14-alpine へ揃える",
       "kind": "chore",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 42,
       "why": "T-0150（run #151, PR #343）は ops/inventory.json に既に登録済みの2エントリ（ops-health-reporter-image, pvc-usage-reporter-image）だけを 3.14-alpine に揃えた。実行役がその過程で apps/ops-dashboard/deployment.yaml と apps/coder/workspace-home-backup-cronjob.yaml にも python:3.12-alpine が残っているが、どちらの inventory エントリの対象（file/mirrors）にも含まれていないため素通りされていると気づき、ops/inbox.md へ引き継いだ（run #151）。inventory に無いバージョンは自動チェックの対象外のまま塩漬けになりうる（CHARTER §1「依存が塩漬けにならない」）。",
       "dod": "(1) apps/ops-dashboard/deployment.yaml と apps/coder/workspace-home-backup-cronjob.yaml の python:3.12-alpine を 3.14-alpine に更新する（T-0150 で標準ライブラリの破壊的変更は無いと確認済みだが、この2ファイルが使うモジュール（http.server, json/urllib/subprocess 等）についても改めて確認する）。(2) ops/inventory.json にこの2ファイルを追跡対象として登録する。既存の pvc-usage-reporter-image と同一の python:*-alpine 更新ポリシーだが用途（http.server 配信 / workspace home backup orchestrator）が異なるため、既存エントリの mirrors に混ぜるか新規エントリにするかは実装時に判断してよい。(3) ops/check_version_sync.py の GROUPS がこの2ファイルを新たに束ねる場合はそちらも更新し、CI (kustomize build 等) が green であることを確認する。",
@@ -2887,8 +2887,8 @@
         "ops/check_version_sync.py"
       ],
       "created": "2026-08-06",
-      "pr": null,
-      "notes": "run #153（計画役）: ops/inbox.md の引き継ぎ（run #151 実行役の気づき）を起票。"
+      "pr": 347,
+      "notes": "run #153（計画役）: ops/inbox.md の引き継ぎ（run #151 実行役の気づき）を起票。run #155（実行役）: apps/ops-dashboard/deployment.yaml・apps/coder/workspace-home-backup-cronjob.yaml の python を 3.14-alpine に更新し、ops/inventory.json に単独エントリ（ops-dashboard-image, coder-workspace-home-backup-image）として新規登録した（#347）。いずれも mirrors を持たない単独ファイルのため check_version_sync.py の GROUPS への追加は不要と判断した。"
     },
     {
       "id": "T-0152",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,43 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 347,
+      "title": "fix(T-0151): ops-dashboard / coder workspace-home-backup の python を 3.14-alpine に揃える",
+      "url": "https://github.com/hikuohiku/homelab/pull/347",
+      "isDraft": false,
+      "createdAt": "2026-08-06T11:58:04Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        }
+      ],
+      "headRefName": "autopilot/T-0151-python-3.14-alpine-remaining",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 346,
+      "title": "ops(run #154): 計画役 — inbox 2件を T-0151/T-0152 として起票",
+      "url": "https://github.com/hikuohiku/homelab/pull/346",
+      "mergedAt": "2026-08-06T11:52:45Z",
+      "headRefName": "autopilot/run154-planning-record"
+    },
     {
       "number": 345,
       "title": "docs(ops): run #153 実行記録（PR #344 merge、着手可能タスク無し）",
@@ -413,13 +450,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/288",
       "mergedAt": "2026-08-06T03:33:50Z",
       "headRefName": "autopilot/loop-self-update"
-    },
-    {
-      "number": 285,
-      "title": "chore(ops): T-0126 の PR 番号 (#284) を記録に反映",
-      "url": "https://github.com/hikuohiku/homelab/pull/285",
-      "mergedAt": "2026-08-06T03:21:38Z",
-      "headRefName": "autopilot/T-0126-record-pr-number"
     }
   ]
 }

--- a/ops/inventory.json
+++ b/ops/inventory.json
@@ -325,6 +325,30 @@
       "observability_impact": "壊れるとその namespace の PVC 実使用量が pvc-usage-report ConfigMap に書き戻されなくなり、ops-health-reporter が集約する pvc_usage が古いまま止まる。読み取り専用 CronJob であり、壊れても homelab 本体の到達性・稼働には影響しない"
     },
     {
+      "id": "ops-dashboard-image",
+      "kind": "image",
+      "name": "python (ops-dashboard httpd container)",
+      "current": "3.14-alpine",
+      "file": "apps/ops-dashboard/deployment.yaml",
+      "match": "image: python:",
+      "upstream": "dockerhub:library/python",
+      "policy": "auto",
+      "note": "T-0151 で新設。ops-health-reporter-image/pvc-usage-reporter-image とは別ファイル・別用途（`python3 -m http.server` での静的ファイル配信のみ）のため、mirrors に混ぜず単独エントリにした。標準ライブラリの http.server のみを使うため patch/minor 更新はほぼ無害",
+      "observability_impact": "壊れると人間向けダッシュボードの配信が止まる。読み取り専用の配信コンテナであり、壊れても homelab 本体の到達性・稼働には影響しない"
+    },
+    {
+      "id": "coder-workspace-home-backup-image",
+      "kind": "image",
+      "name": "python (coder workspace-home-backup オーケストレータ)",
+      "current": "3.14-alpine",
+      "file": "apps/coder/workspace-home-backup-cronjob.yaml",
+      "match": "image: python:",
+      "upstream": "dockerhub:library/python",
+      "policy": "auto",
+      "note": "T-0151 で新設。ops-health-reporter-image/pvc-usage-reporter-image とは別ファイル・別用途（K8s API 経由で PVC ごとの restic backup Job を動的生成するオーケストレータ、json/os/ssl/time/urllib のみ使用）のため、mirrors に混ぜず単独エントリにした",
+      "observability_impact": "壊れると coder workspace home の backup Job が新規に作られなくなり、workspace データの復元手段が失われうる。ただし backup 自体は restic/restic イメージの子 Job が担うため、オーケストレータの一時的な不調が既存バックアップを壊すことはない"
+    },
+    {
       "id": "gha-setup-helm-version",
       "kind": "binary",
       "name": "helm (azure/setup-helm version input)",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4461,3 +4461,20 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py` を実行し 0 error であることを確認
 - 次の起動へ: backlog の todo は T-0151・T-0152（着手可能）と T-0117（`not_before`
   2026-08-07T03:30 JST 到来までまだ数時間）の3件。次の実行役は T-0151 または T-0152 から着手できる
+
+## 2026-08-06 20:58 JST — run #155（実行役）
+
+- 前回の中断確認: オープン PR 0 件、`origin/autopilot/*` ブランチも `git fetch --prune` 後に
+  0 件（ローカルに残っていた大量の `autopilot/*` ローカルブランチはリモートに既に存在しない
+  古いキャッシュだった）
+- 読んだフィードバック: issue #56 を `per_page=100` で2ページ（計109件）確認、`last_read`
+  （2026-08-06T11:49:00Z）以降の新規コメント無し
+- やったこと: T-0151（`apps/ops-dashboard/deployment.yaml`・
+  `apps/coder/workspace-home-backup-cronjob.yaml` の `python:3.12-alpine` を `3.14-alpine` に更新し、
+  `ops/inventory.json` に単独エントリ（`ops-dashboard-image`, `coder-workspace-home-backup-image`）
+  として新規登録）を完遂（#347）。両ファイルとも mirrors を持たない単独ファイルのため
+  `check_version_sync.py` の GROUPS への追加は不要と判断。`ops/validate.py`・
+  `ops/check_version_sync.py` を実行し 0 error / 全 GROUP ok を確認、`kubectl kustomize` で
+  レンダリング結果に `python:3.14-alpine` が反映されていることも確認した
+- 次の起動へ: backlog の todo は T-0152（着手可能）と T-0117（`not_before` 2026-08-07T03:30 JST
+  到来までまだ数時間）の2件。#347 の CI green・merge を見届けること

--- a/ops/state.json
+++ b/ops/state.json
@@ -6,7 +6,7 @@
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T11:49:00Z"
+    "last_read": "2026-08-06T11:58:00Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc",
@@ -1408,6 +1408,16 @@
       "by": "autopilot pod (計画役)",
       "summary": "計画役（journal run #154）。ops/inbox.md の2件をT-0151・T-0152として起票しinboxを空にした。フィードバック・健全性レポートに新規異常なし。backlog blocked/needs-human 全件の理由を確認したが古い前提は無かった。",
       "prs": []
+    },
+    {
+      "n": 155,
+      "at": "2026-08-06T11:58:00Z",
+      "kind": "in-cluster-loop",
+      "by": "autopilot pod (実行役)",
+      "summary": "実行役（journal run #155）。T-0151（ops-dashboard/coder workspace-home-backup の python を 3.14-alpine に揃え、inventory.json に2件新規登録）を完遂（#347）。オープン PR・autopilot ブランチとも中断無し、issue #56 に新規フィードバック無し。",
+      "prs": [
+        347
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`apps/ops-dashboard/deployment.yaml`（httpd コンテナ）と `apps/coder/workspace-home-backup-cronjob.yaml`（オーケストレータ）が使う `python:3.12-alpine` を `python:3.14-alpine` に更新した。T-0150 (#343) で `ops/inventory.json` 登録済みの2エントリ（ops-health-reporter-image / pvc-usage-reporter-image）だけ揃えられていたが、この2ファイルは inventory の対象外で素通りしていたため今回対象に含めた。あわせて `ops/inventory.json` に単独エントリとして2件（`ops-dashboard-image`, `coder-workspace-home-backup-image`）を追加し、今後の inventory 定期チェックの監視対象にした。

## 検証したこと

- 対象2ファイルが使う標準ライブラリ（`http.server` / `json`, `os`, `ssl`, `time`, `urllib`）は、T-0150 で確認済みの CPython 3.13/3.14 changelog（`sqlite3.version` 系・`urllib.request.URLopener`/`FancyURLopener`・`urllib.parse.Quoter` の削除等）の対象外で、破壊的変更なし
- `python3 ops/validate.py` → 0 error
- `python3 ops/check_version_sync.py` → 全 GROUP ok（この2ファイルは単独ファイルで mirrors が無いため GROUPS への追加は不要と判断）
- `kubectl kustomize apps/ops-dashboard` / `kubectl kustomize apps/coder` でレンダリング結果に `python:3.14-alpine` が反映されていることを確認

## ロールバック手順

このコミットを revert すれば `python:3.12-alpine` に戻る。両コンテナとも状態を持たない読み取り専用/オーケストレータ用途（DB 等のスキーマは関与しない）のため、revert によるデータ不整合は発生しない。

## backlog task id

T-0151
