### PR TITLE
fix(ops): ダッシュボードを完全な HTML 文書として出す

### DIFF
--- a/ops/dashboard/build.py
+++ b/ops/dashboard/build.py
@@ -659,7 +659,16 @@ def build() -> str:
     )
 
 
-TEMPLATE = """<title>autopilot — homelab 当直記録</title>
+# 完全な HTML 文書として出す。クラスタ内の ops-dashboard は python の http.server で
+# 配信していて Content-Type に charset を付けないため、文書側に <meta charset> が無いと
+# ブラウザが文字コードを推測して日本語が化ける（2026-08-06 に実際に化けた）。
+# サーバ設定に依存させないよう、文書側で完結させる。
+TEMPLATE = """<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>autopilot — homelab 当直記録</title>
 <style>
 :root {{
   --ground:#eef0f4; --surface:#fbfcfe; --surface2:#f3f5f9; --line:#d8dce5;
@@ -894,6 +903,8 @@ footer {{ color:var(--muted); font-size:.75rem; font-family:var(--mono);
   gap:.3rem 1rem; }}
 @media (prefers-reduced-motion:reduce) {{ *{{transition:none!important;animation:none!important}} }}
 </style>
+</head>
+<body>
 
 <div class="wrap">
   <header class="mast">
@@ -1054,6 +1065,8 @@ footer {{ color:var(--muted); font-size:.75rem; font-family:var(--mono);
   setInterval(tick, 1000);
 }})();
 </script>
+</body>
+</html>
 """
 
 


### PR DESCRIPTION
`ops-dashboard.tailae6c2.ts.net` で日本語が全て文字化けしていた。

## 原因

配信側（`python3 -m http.server`）は `Content-type: text/html` を返すだけで **charset を付けない**。そして `build.py` は Artifact に埋め込む前提で書かれているため、`<!doctype html>` も `<head>` も出さず、**文書側にも `<meta charset>` が無い**。結果、ブラウザが文字コードを推測して失敗していた。

Artifact 側では publish 時に skeleton が被さって charset が入るので、そちらでは化けない。**自前配信に移した時点で前提が崩れていた。**

## 変更

`build.py` が完全な HTML 文書を出すようにする。

```
<!doctype html>
<html lang="ja">
<head>
<meta charset="utf-8">
<meta name="viewport" content="width=device-width,initial-scale=1">
<title>…</title>
<style>…</style>
</head>
<body>…</body>
</html>
```

サーバ側に `charset utf-8` を足す直し方もあるが、**文書側で完結させる方を選んだ。** 配信方法が変わっても壊れないため（今回まさに配信方法が変わって壊れた）。`viewport` も無かったので併せて入れた。

## Artifact 版について

doctype を含むようになったので、Artifact に publish すると skeleton と二重になる。ブラウザは無視するので実害は無いが、**今後は自前ホストを正とする**。Artifact 版は当面の予備。