### PR TITLE
chore(ops): run #157 記録更新（新規タスク着手なし）

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,20 @@
   "open": [],
   "merged": [
     {
+      "number": 348,
+      "title": "docs(T-0152): inventory の note 除外指定を新タグ確認時に読み合わせる運用を明文化",
+      "url": "https://github.com/hikuohiku/homelab/pull/348",
+      "mergedAt": "2026-08-06T12:09:46Z",
+      "headRefName": "autopilot/T-0152-inventory-note-exclusion-check"
+    },
+    {
+      "number": 349,
+      "title": "fix(ops): ダッシュボードを完全な HTML 文書として出す",
+      "url": "https://github.com/hikuohiku/homelab/pull/349",
+      "mergedAt": "2026-08-06T12:06:38Z",
+      "headRefName": "autopilot/dashboard-charset"
+    },
+    {
       "number": 347,
       "title": "fix(T-0151): ops-dashboard / coder workspace-home-backup の python を 3.14-alpine に揃える",
       "url": "https://github.com/hikuohiku/homelab/pull/347",
@@ -406,20 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/290",
       "mergedAt": "2026-08-06T03:44:51Z",
       "headRefName": "autopilot/T-0127-dashboard-publish-branch"
-    },
-    {
-      "number": 289,
-      "title": "chore(ops): T-0129 を done に、記録更新 (run #99)",
-      "url": "https://github.com/hikuohiku/homelab/pull/289",
-      "mergedAt": "2026-08-06T03:37:54Z",
-      "headRefName": "autopilot/T-0129-mark-done"
-    },
-    {
-      "number": 287,
-      "title": "feat(autopilot): loop.sh が自分の更新を拾って exec し直す (T-0129)",
-      "url": "https://github.com/hikuohiku/homelab/pull/287",
-      "mergedAt": "2026-08-06T03:34:01Z",
-      "headRefName": "autopilot/T-0129-loop-self-reexec"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4491,3 +4491,20 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - backlog の todo は T-0117（`not_before` 2026-08-07T03:30 JST、まだ未到来）のみで着手可能な新規タスクは無し
 - `python3 ops/validate.py` を実行し 0 error であることを確認
 - 次の起動へ: T-0117 の `not_before` 到来（2026-08-07T03:30 JST）まで着手可能な todo は無い
+
+## 2026-08-06 21:11 JST — run #157（実行役）
+
+- 前回の中断確認: オープン PR #348（run #156 が作成した T-0152 の記録用 PR）が残っていた。CI 6件
+  全て green・`mergeable_state: clean` を確認し、この起動内で merge（4492451）。ブランチ
+  `autopilot/T-0152-inventory-note-exclusion-check` は GitHub が自動削除済み
+- 読んだフィードバック: issue #56 を `per_page=100` で確認（計100件）、`last_read`
+  （2026-08-06T11:58:00Z）以降の新規コメント無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T12:00:10Z`）で ArgoCD 13 アプリ中
+  `coder`/`immich`/`vaultwarden` が Degraded。従来どおり T-0106 由来の既知 `SecretSyncedError`
+  のみ。`pod_issues` の restarts:19 常連（既知）も変化なし。autopilot 自身の heartbeat も正常
+  （iteration #30, exit_code 0, readyReplicas 1）。新規異常なし
+- やったこと: 上記の中断解消（PR #348 merge）のみ。backlog の todo は T-0117
+  （`not_before` 2026-08-07T03:30 JST、まだ未到来）のみで着手可能な新規タスクが無かった
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: backlog の todo は引き続き T-0117 のみ（`not_before` 到来まで数時間）。次の起動が
+  計画役なら調査タスクの起票を検討すること

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T12:04:00Z",
+  "updated": "2026-08-06T12:11:00Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T12:04:00Z"
+    "last_read": "2026-08-06T12:11:00Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc",
@@ -1428,6 +1428,14 @@
       "prs": [
         348
       ]
+    },
+    {
+      "n": 157,
+      "at": "2026-08-06T12:11:00Z",
+      "kind": "in_cluster_loop",
+      "by": "in-cluster autopilot (executor)",
+      "summary": "実行役（journal run #157）。前回の中断PR #348（T-0152）を merge。issue #56 に新規フィードバック無し。健全性確認で新規異常無し（coder/immich/vaultwardenのDegradedは既知のT-0106由来）。backlog todoはT-0117のみでnot_before未到来のため新規タスク着手無し。",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

- `ops/journal/2026-08.md` に run #157（実行役）を追記
- `ops/state.json` の `runs` 配列に run #157 を追記、`feedback.last_read` を更新
- `ops/dashboard/prs.json` を最新化（#348, #349 の merge 反映）

## 背景

この起動でやったこと（コード・manifest の変更なし）:

- 前回の中断（オープン PR #348, T-0152 の記録用 PR）を CI green・`mergeable_state: clean`
  を確認したうえで merge した
- issue #56 を確認したが新規フィードバックなし
- `ops-health-report` で健全性を確認したが新規異常なし（coder/immich/vaultwarden の Degraded は
  T-0106 由来の既知事象のみ）
- backlog の todo は T-0117（`not_before: 2026-08-07T03:30 JST`）のみで着手可能な新規タスクが
  無かったため、新規タスクには着手していない

沈黙は「動いていない」と区別がつかないため、この運用記録のみを PR として残す
（`ops/CHARTER.md` §2）。

## 検証したこと

- `python3 ops/validate.py` → 0 error
- ドキュメント・運用記録のみの変更（コード・manifest の変更なし）

## ロールバック手順

このブランチの commit を revert すれば journal/state.json/dashboard キャッシュの追記が
元へ戻る。DB や実インフラへの変更は無いため、コードと状態の revert に不整合は残らない。

## backlog task id

なし（運用記録のみ）
