### PR TITLE
ops(run #157): 計画役の記録 — 新規異常・新規着手可能タスク無し

### DIFF
--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4491,3 +4491,30 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - backlog の todo は T-0117（`not_before` 2026-08-07T03:30 JST、まだ未到来）のみで着手可能な新規タスクは無し
 - `python3 ops/validate.py` を実行し 0 error であることを確認
 - 次の起動へ: T-0117 の `not_before` 到来（2026-08-07T03:30 JST）まで着手可能な todo は無い
+
+## 2026-08-06 21:17 JST — run #157（計画役）
+
+- 前回の中断確認: オープン PR 0 件、`origin/autopilot/*` ブランチ 0 件。ローカル `main` は
+  `origin/main` と一致（4492451、#348 merge 済み）。加えて #349（`autopilot/dashboard-charset`、
+  ダッシュボード charset 修正）が人間（hikuohiku）自身によって直接作成・merge 済みと判明したが、
+  autopilot の作業ではないため journal/state への追記対象外と判断した
+- 読んだフィードバック: issue #56 を `per_page=100` で確認、`last_read`（2026-08-06T12:04:00Z）
+  以降の新規コメント無し。依頼中の issue #35（T-0144 待ち、最終更新 2026-08-06T09:35:45Z）・
+  issue #37（T-0141 待ち、最終更新 2026-05-19T16:37:45Z）もいずれも未回答のまま変化なし
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T12:00:10Z`）で ArgoCD 13アプリ中
+  `coder`/`immich`/`vaultwarden` が Degraded。`kubectl get externalsecret -A` で直接確認し、
+  原因は引き続き `<app>-restic-backup-credentials` の `SecretSyncedError`（T-0106 既知）のみで、
+  他の ExternalSecret・Pod への波及が無いことを確認した。`pod_issues` の restarts:19 常連
+  （ノード再起動由来、既知）も変化なし。immich `backup_listing` 最新ファイルは
+  2026-08-06T02:00 台で新鮮。autopilot 自身の heartbeat も正常（iteration #31 start,
+  #30 end exit_code 0）。新規異常なし
+- `ops/inbox.md`: 空（前回計画回ですでに空、今回も追記なし）
+- backlog の棚卸し: blocked 7件・needs-human 8件全ての理由を確認したが、27分前の run #154 から
+  状況変化なし。T-0112 の前提（autopilot に `pods/log` 権限が無い）を `kubectl auth can-i get pods
+  --subresource=log -A` で改めて確認し、依然 `no`
+- todo は T-0117（`not_before` 2026-08-07T03:30 JST、未到来）のみで着手可能な新規タスクは無し
+- 新規起票の検討: PVC使用量（immich-library 350MB/immich-postgres-data 374MB、容量懸念なし）、
+  `docs/`・`Maintenance.md` と実態の整合を確認したが、記録に追加すべき乖離は見つからなかった
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: 着手可能な todo は無し（T-0117 は 03:30 JST 到来待ち）。次の計画回でも同じ状況が
+  続くようなら、フィードバック issue への問い出しを検討すること

--- a/ops/state.json
+++ b/ops/state.json
@@ -1428,6 +1428,14 @@
       "prs": [
         348
       ]
+    },
+    {
+      "n": 157,
+      "at": "2026-08-06T12:17:00Z",
+      "kind": "in_cluster_loop",
+      "by": "in-cluster autopilot (planner)",
+      "summary": "計画役（journal run #157）。フィードバック・健全性レポートに新規異常なし。inbox は空。backlog blocked/needs-human 全15件の理由を確認したが古い前提は無かった。着手可能な新規タスクは見つからず（todo は not_before 未到来の T-0117 のみ）、記録のみの PR。",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

計画役（journal run #157）の実行記録のみ。`ops/journal/2026-08.md` と `ops/state.json` の `runs` 配列に追記した。コード・マニフェストの変更は無い。

## やったこと

- `ops/inbox.md`: 空（前回計画回ですでに空、今回も追記なし）
- フィードバック issue #56: `last_read` 以降の新規コメント無し。依頼中の issue #35 / #37 も未回答のまま変化なし
- `ops-health-report` の健全性: ArgoCD 13アプリ中 coder/immich/vaultwarden が Degraded のままだが、`kubectl get externalsecret -A` で原因が引き続き T-0106 既知の `SecretSyncedError`（`<app>-restic-backup-credentials`）のみで他への波及が無いことを直接確認した。autopilot 自身の heartbeat も正常。新規異常なし
- backlog の blocked 7件・needs-human 8件全ての理由を棚卸ししたが、27分前の run #154 から状況変化なし（T-0112 の前提〈pods/log 権限が無い〉も `kubectl auth can-i` で再確認）
- 着手可能な新規タスクの捜索（PVC使用量、docs/ と実態の整合）も行ったが、追加すべき乖離は見つからなかった

## 検証したこと

- `python3 ops/validate.py` → `0 error, 0 warning`

## ロールバック手順

この PR は journal と `ops/state.json` の追記のみで、実インフラ・アプリケーションへの変更を含まない。問題があれば revert すればよく、データ整合性への影響は無い。

## backlog task id

該当タスクなし（計画役の定例記録）。