### PR TITLE
feat(ops-dashboard): ダッシュボードから autopilot へ指示を残せるようにする

### DIFF
--- a/apps/ops-dashboard/deployment.yaml
+++ b/apps/ops-dashboard/deployment.yaml
@@ -16,6 +16,10 @@ spec:
     metadata:
       labels:
         app: ops-dashboard
+      annotations:
+        # server.py は起動時にしか読まれない。ConfigMap の中身を変えても Deployment の
+        # spec は変わらず Pod は作り直されないので、変えたらこの値を上げる
+        ops-dashboard/server-revision: "1"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -85,9 +89,32 @@ spec:
         # 側にのみ存在）CrashLoopBackOff (exitCode 127) になった (#291, run #101 で revert)。
         # apps/ops-health-reporter・apps/{coder,vaultwarden,immich}/pvc-usage-cronjob.yaml
         # で既に実績のある python:3.14-alpine の標準ライブラリ http.server に置き換える。
+        #
+        # 配信そのものは `python3 -m http.server` と同じ SimpleHTTPRequestHandler のまま。
+        # server.py はそれを継承して `POST /feedback` だけを足し、ダッシュボードの
+        # フォームから来た文章を GitHub issue #56（人間からのフィードバック窓口、
+        # CHARTER §6）へコメントとして投稿する。窓口は増やさない
         - name: httpd
           image: python:3.14-alpine
-          command: ["python3", "-m", "http.server", "8080", "--directory", "/www"]
+          command: ["python3", "/config/server.py"]
+          env:
+            - name: WWW_ROOT
+              value: /www
+            - name: PORT
+              value: "8080"
+            - name: FEEDBACK_REPO
+              value: hikuohiku/homelab
+            # ops/state.json の feedback.issue と一致させる（窓口を移すときは両方直す）
+            - name: FEEDBACK_ISSUE
+              value: "56"
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: ops-dashboard-github-token
+                  key: token
+                  # Secret がまだ無くても静的配信は動かす（投稿だけが 503 になり、
+                  # 画面にその旨が出る）。起動できない条件を増やさない
+                  optional: true
           ports:
             - name: http
               containerPort: 8080
@@ -95,6 +122,9 @@ spec:
           volumeMounts:
             - name: www
               mountPath: /www
+              readOnly: true
+            - name: server
+              mountPath: /config
               readOnly: true
           resources:
             requests:
@@ -121,3 +151,6 @@ spec:
       volumes:
         - name: www
           emptyDir: {}
+        - name: server
+          configMap:
+            name: ops-dashboard-server

--- a/apps/ops-dashboard/external-secret.yaml
+++ b/apps/ops-dashboard/external-secret.yaml
@@ -1,0 +1,25 @@
+# ダッシュボードのフォームから issue #56 へコメントを投稿するためのトークン。
+# Requires: ClusterSecretStore 'doppler' (apps/external-secrets/cluster-secret-store.yaml)
+#
+# autopilot と同じ AUTOPILOT_GITHUB_TOKEN を使う（Issues write を持つことは実測済み）。
+# 別トークンを起こさないのは、この経路が投稿するのは autopilot 自身のフィードバック
+# issue へのコメントだけで、autopilot が既に持っている権限を超えないため。
+# トークンはサーバプロセス（server.py）の中だけで使い、配信するページには出さない。
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ops-dashboard-github-token
+  namespace: ops-dashboard
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler
+  target:
+    name: ops-dashboard-github-token
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: token
+      remoteRef:
+        key: AUTOPILOT_GITHUB_TOKEN

--- a/apps/ops-dashboard/kustomization.yaml
+++ b/apps/ops-dashboard/kustomization.yaml
@@ -2,6 +2,22 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - external-secret.yaml
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+
+configMapGenerator:
+  - name: ops-dashboard-server
+    namespace: ops-dashboard
+    files:
+      - server.py
+
+generatorOptions:
+  # 名前にハッシュを付けない（autopilot / ops-health-reporter と同じ）。付けると
+  # スクリプトを直すたびに ConfigMap 名が変わり、CI の manifest-diff が
+  # 「オブジェクトが消えた」と判定して毎回 allow-delete の明記を要求する
+  # （ops/check_manifest_deletions.py）。
+  # server.py は起動時にしか読まれないので、中身を変えたときは Deployment 側の
+  # ops-dashboard/server-revision アノテーションも上げて Pod を作り直す
+  disableNameSuffixHash: true

--- a/apps/ops-dashboard/server.py
+++ b/apps/ops-dashboard/server.py
@@ -1,0 +1,233 @@
+"""ops-dashboard の配信 + ダッシュボードからの指示投稿口。
+
+静的配信（fetcher が /www に置く index.html）はこれまで通り
+`python3 -m http.server` と同じ SimpleHTTPRequestHandler が担う。
+そこに `POST /feedback` だけを足し、フォームの本文を GitHub issue
+（人間からのフィードバック窓口。CHARTER §6）へコメントとして投稿する。
+
+新しい protocol は作らない。autopilot は今まで通り issue のコメントだけを読む。
+
+標準ライブラリのみ（イメージは python:3.14-alpine のまま、pip install しない）。
+トークン (GITHUB_TOKEN) はこのプロセスの中だけで使い、応答にもページにも一切出さない。
+"""
+
+import html
+import http.server
+import json
+import os
+import socketserver
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+WWW_ROOT = os.environ.get("WWW_ROOT", "/www")
+PORT = int(os.environ.get("PORT", "8080"))
+REPO = os.environ.get("FEEDBACK_REPO", "hikuohiku/homelab")
+ISSUE = os.environ.get("FEEDBACK_ISSUE", "56")
+TOKEN = os.environ.get("GITHUB_TOKEN", "").strip()
+
+# issue コメント 1 件の上限は 65536 文字。手前で切って、超えたら黙って捨てずに断る
+MAX_BODY_CHARS = 20000
+# リクエスト全体のバイト上限（フォーム 1 フィールドしか無いので余裕を持たせた値）
+MAX_REQUEST_BYTES = 256 * 1024
+
+ISSUE_URL = "https://github.com/{}/issues/{}".format(REPO, ISSUE)
+
+# autopilot がコメントの出所を機械的に判別できるようにする印。
+# これより下がフォームに入力された本文そのもの。
+MARKER = "<!-- source: ops-dashboard -->"
+HEADER = (
+    MARKER + "\n"
+    + "**ops-dashboard から投稿**（tailnet 内のダッシュボード画面のフォーム経由。"
+    + "投稿者の個人認証はしていない）\n\n---\n\n"
+)
+
+PAGE = """<!doctype html>
+<html lang="ja"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{title}</title>
+<style>
+ body {{ font-family: ui-sans-serif, system-ui, sans-serif; line-height: 1.6;
+        max-width: 46rem; margin: 3rem auto; padding: 0 1rem; }}
+ .bad {{ border-left: 4px solid #c0392b; padding-left: 1rem; }}
+ textarea {{ width: 100%; min-height: 12rem; }}
+</style></head><body>
+<div class="bad">
+<h1>{title}</h1>
+<p>{detail}</p>
+</div>
+{recovery}
+<p><a href="/">ダッシュボードに戻る</a></p>
+</body></html>
+"""
+
+
+def error_page(status, title, detail, typed_text=None):
+    """失敗したことが画面で分かる形にする。
+
+    黙って 303 で戻すと「書けたつもり」になるので、投稿できなかったときは
+    エラーページを返す。入力した文章はそのまま返して、GitHub に手で貼り直せるようにする
+    （ダッシュボードは 60 秒ごとに差し替わるため、戻ると入力は消える）。
+    """
+    recovery = ""
+    if typed_text:
+        recovery = (
+            "<p>入力した内容は失われていない。下をコピーして "
+            '<a href="{url}">issue #{issue}</a> に直接書けば、autopilot は同じように読む。</p>'
+            "<textarea readonly>{text}</textarea>"
+        ).format(url=ISSUE_URL, issue=ISSUE, text=html.escape(typed_text))
+    body = PAGE.format(
+        title=html.escape(title), detail=html.escape(detail), recovery=recovery
+    ).encode("utf-8")
+    return status, body
+
+
+def post_comment(text):
+    """issue にコメントを 1 件作る。(status, payload) を返す。"""
+    payload = json.dumps({"body": HEADER + text}).encode("utf-8")
+    req = urllib.request.Request(
+        "https://api.github.com/repos/{}/issues/{}/comments".format(REPO, ISSUE),
+        data=payload,
+        method="POST",
+        headers={
+            "Authorization": "Bearer " + TOKEN,
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "homelab-ops-dashboard",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            raw = resp.read()
+            return resp.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            return e.code, json.loads(raw)
+        except Exception:  # noqa: BLE001 — GitHub が JSON を返さないこともある
+            return e.code, {"message": raw.decode("utf-8", errors="replace")[:500]}
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    # 静的配信の挙動（パス解決・ディレクトリトラバーサル対策）は親のまま使い、
+    # POST だけを足す。translate_path は上書きしない
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=WWW_ROOT, **kwargs)
+
+    def _respond(self, status, body, headers=None):
+        self.send_response(status)
+        for k, v in (headers or {"Content-Type": "text/html; charset=utf-8"}).items():
+            self.send_header(k, v)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
+    def _fail(self, status, title, detail, typed_text=None):
+        status, body = error_page(status, title, detail, typed_text)
+        self._respond(status, body)
+
+    def do_POST(self):  # noqa: N802 — http.server の命名規約
+        if urllib.parse.urlparse(self.path).path != "/feedback":
+            self._fail(404, "そのようなページは無い", "POST を受けるのは /feedback だけ。")
+            return
+
+        try:
+            length = int(self.headers.get("Content-Length") or 0)
+        except ValueError:
+            length = -1
+        if length <= 0:
+            self._fail(400, "本文が空", "フォームの内容が届かなかった。")
+            return
+        if length > MAX_REQUEST_BYTES:
+            self._fail(413, "入力が大きすぎる", "送信できるのは 256 KiB まで。")
+            return
+
+        raw = self.rfile.read(length)
+        # 素の form encoding しか受けない。JSON など他の形は解釈しない
+        fields = urllib.parse.parse_qs(raw.decode("utf-8", errors="replace"))
+        text = (fields.get("body") or [""])[0]
+        # フォームは CRLF で送ってくる。issue に素直に載る形へ寄せ、
+        # 制御文字（NUL 等）は落とす
+        text = text.replace("\r\n", "\n").replace("\r", "\n")
+        text = "".join(c for c in text if c in "\n\t" or ord(c) >= 0x20)
+        text = text.strip()
+
+        if not text:
+            self._fail(400, "本文が空", "何も書かれていないので投稿しなかった。")
+            return
+        if len(text) > MAX_BODY_CHARS:
+            # 黙って切ると指示の後半が消えたことに気づけない。断って人間に分割させる
+            self._fail(
+                413,
+                "本文が長すぎる",
+                "{} 文字あった。{} 文字までにするか、分けて投稿してほしい。".format(
+                    len(text), MAX_BODY_CHARS
+                ),
+                text,
+            )
+            return
+
+        if not TOKEN:
+            self._fail(
+                503,
+                "投稿できない（トークン未設定）",
+                "GITHUB_TOKEN がコンテナに渡っていない。ExternalSecret "
+                "'ops-dashboard-github-token' と Doppler の AUTOPILOT_GITHUB_TOKEN を確認する。",
+                text,
+            )
+            return
+
+        try:
+            status, payload = post_comment(text)
+        except Exception as e:  # noqa: BLE001 — 到達不能・TLS・タイムアウト等
+            sys.stderr.write("feedback: post failed: {}: {}\n".format(type(e).__name__, e))
+            self._fail(
+                502,
+                "GitHub に届かなかった",
+                "{}: {}".format(type(e).__name__, e),
+                text,
+            )
+            return
+
+        if status != 201:
+            message = ""
+            if isinstance(payload, dict):
+                message = str(payload.get("message", ""))[:300]
+            sys.stderr.write("feedback: github returned {} {}\n".format(status, message))
+            self._fail(
+                502,
+                "GitHub が受け付けなかった",
+                "HTTP {}{}".format(status, ("（" + message + "）") if message else ""),
+                text,
+            )
+            return
+
+        sys.stderr.write("feedback: posted {} chars to issue #{}\n".format(len(text), ISSUE))
+        # 成功時だけリダイレクト。クエリはダッシュボード側が「投稿できた」表示に使える
+        self._respond(
+            303,
+            b"",
+            {"Location": "/?feedback=ok", "Content-Type": "text/plain; charset=utf-8"},
+        )
+
+    def log_message(self, fmt, *args):
+        # 本文はログに出さない（指示の中身をログへ二重に残さない）
+        sys.stderr.write("%s - %s\n" % (self.address_string(), fmt % args))
+
+
+class Server(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    # GitHub API 呼び出しの間も静的配信と probe を止めない（単一スレッドだと
+    # 遅い POST が liveness probe を巻き添えにして Pod ごと再起動させる）
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+if __name__ == "__main__":
+    sys.stderr.write(
+        "ops-dashboard: serving {} on :{} (feedback -> {} #{}, token={})\n".format(
+            WWW_ROOT, PORT, REPO, ISSUE, "set" if TOKEN else "MISSING"
+        )
+    )
+    Server(("", PORT), Handler).serve_forever()


### PR DESCRIPTION
人間がフィードバックを渡す口が GitHub issue #56 しか無く、セッションを開くか issue を直接開く必要があった。**ダッシュボードにフォームを置き、そこから同じ issue にコメントする。**

autopilot 側は今までどおり #56 を読むだけでよく、**新しい仕組みは増えていない**。

## 実装

配信コンテナを `python3 -m http.server` から `server.py` に差し替える。`SimpleHTTPRequestHandler` を継承し `do_POST` だけを足したもので、静的配信の経路（`translate_path` 含む）は触っていない。標準ライブラリのみ、イメージも `python:3.14-alpine` のまま。

トークンは既存の `AUTOPILOT_GITHUB_TOKEN`（Issues write を持つことは実測済み）を ExternalSecret で持ってくる。**サーバプロセス内だけで使い、応答にもページにも出さない。** Secret が無くてもダッシュボードの閲覧は止まらない（`optional: true`）。

`ThreadingMixIn` にしてある。単一スレッドのままだと GitHub 呼び出し中に liveness probe が巻き添えになって Pod が再起動する。

## 失敗したときに何が見えるか

黙って成功したように見せない。

| 状況 | 画面 |
|---|---|
| GitHub が拒否 / 到達不能 | 502 と理由 |
| トークン未設定 | 503 と確認先 |
| 本文が空 | 400 |
| 20000 文字超 | 413 と実際の文字数 |

失敗ページは**入力した文章を `textarea` で返す**。ダッシュボードは 60 秒ごとに差し替わるので、戻ると入力が消えるため。issue #56 に直接書けば同じように読まれる旨のリンクも添える。

長い入力は切らずに断る。切ると後半が消えたことに気づけないため。

## 検証

`server.py` を実際に起動して確認した（tailnet 越しの経路はマージ前には存在しないため未実測）。

- 静的 GET 200 / ディレクトリトラバーサル 404、ファイル内容の漏れなし
- 無効トークンでの POST → 502、**応答にトークン文字列は出ない**
- 空 body → 400、`/feedback` 以外への POST → 404

入力はシェルを通らず、`json.dumps` で JSON 化するのみ。制御文字を落とし CRLF を LF に正規化。エコー時は `html.escape`。出所を示す印は入力で消せない位置に置いてある。tailnet 内限定という前提には依存していない。

フォーム本体は `ops/dashboard/build.py` 側で別 PR。この PR だけでは口が開くだけで、まだ誰も投稿できない。