### PR TITLE
feat(ops): ダッシュボードを順番待ち中心に作り直す

### DIFF
--- a/ops/dashboard/build.py
+++ b/ops/dashboard/build.py
@@ -11,10 +11,14 @@ token が無い環境（CI、手元実行）では push をスキップし、HTM
 従来どおり成功として扱う。
 
 設計方針:
-  - 主役は「人間が何をすればいいか」と「何が動いているか」。個々のタスクは既定で隠す
+  - この画面は 1 日数回、数秒だけ見られる。答えるのは 2 問だけ:
+    「いま何が起きているか」「自分は何をすればいいか」
+  - 主役は backlog の順番待ち。priority 昇順にそのまま並べる（backlog.json の
+    着手順そのもの）。集計バーではなく行を出す。次に来るものが読めないと意味がない
+  - 誰待ちか（あなた / autopilot / 条件）を行の形と色で示す。色だけに頼らず必ず語で書く
+  - 済んだこと・全タスク・クラスタの細部は畳む
+  - 書き置きフォームを同一オリジンの POST /feedback に出す。JS 無しで成立させる
   - 数はすべてこのファイルが backlog.json から数える。文章側で数えない（食い違いの元）
-  - PC では 2 カラム、狭い画面では 1 カラム
-  - 依存関係・進捗・時間推移は図で示す
 
 標準ライブラリのみ。入力が同じなら出力も同じ（生成時刻を除く）。
 """
@@ -42,6 +46,9 @@ API = "https://api.github.com"
 E = html.escape
 STALE: dict[str, str] = {}
 
+# 順番待ちに出す状態と、その並び順（priority が同値のときの安定化にも使う）
+OPEN_STATUSES = ("in_progress", "needs-human", "todo", "blocked")
+
 STATUS_META = {
     "todo": ("待ち", "idle"),
     "in_progress": ("作業中", "sig"),
@@ -51,23 +58,15 @@ STATUS_META = {
     "dropped": ("取り下げ", "idle"),
 }
 
-# 大きい粒度の「流れ」。色は識別のみを担う（dataviz 参照パレット先頭6スロット、light/dark 検証済み）。
-# light では一部が対サーフェス 3:1 未満のため、必ず可視ラベルを併記して色だけに頼らない。
-STREAMS = [
-    ("kiki", "器をつくる", ("meta", "feature"), "自律運用の土台そのもの"),
-    ("kenshou", "検証を固める", ("ci",), "壊れた変更を機械的に止める"),
-    ("tsuijuu", "版に追従する", ("upgrade",), "依存を塩漬けにしない"),
-    ("seiri", "食い違いを直す", ("refactor", "docs"), "記録と実態のずれを潰す"),
-    ("anzen", "安全を上げる", ("security",), "秘密と権限の扱い"),
-    ("chousa", "観測して探す", ("investigate",), "見えていないものを見る"),
-]
-KIND_TO_STREAM = {k: s[0] for s in STREAMS for k in s[2]}
-OTHER_STREAM = ("other", "運用記録", (), "journal とダッシュボード")
-ALL_STREAMS = STREAMS + [OTHER_STREAM]
-
-
-def stream_of(task: dict) -> str:
-    return task.get("stream") or KIND_TO_STREAM.get(task.get("kind", ""), "other")
+# backlog の kind をそのまま出さず、人間の語彙に寄せる。色は割り当てない
+# （識別色を増やすと、状態を示す赤/黄/緑が埋もれる）。
+KIND_LABEL = {
+    "investigate": "調査", "docs": "文書", "ci": "検証", "feature": "機能",
+    "upgrade": "版上げ", "chore": "雑務", "refactor": "整理", "security": "安全",
+    "meta": "器", "fix": "修正", "update": "版上げ", "infra": "基盤",
+    "migrate": "移行", "verify": "確認",
+}
+RISK_LABEL = {"low": "小", "medium": "中", "high": "大"}
 
 
 def load(name: str, default=None):
@@ -197,21 +196,48 @@ def parse_journal() -> list[dict]:
     return entries
 
 
-def rel_time(iso) -> str:
+def ts(iso):
+    """ISO8601 を datetime に。壊れていれば None。"""
     if not iso:
-        return "—"
+        return None
     try:
-        t = datetime.fromisoformat(str(iso).replace("Z", "+00:00"))
+        return datetime.fromisoformat(str(iso).replace("Z", "+00:00"))
     except ValueError:
-        return str(iso)
-    s = int((datetime.now(timezone.utc) - t).total_seconds())
-    if s < 0:
-        return "たった今"
-    if s < 3600:
-        return f"{s // 60} 分前"
-    if s < 86400:
-        return f"{s // 3600} 時間前"
-    return f"{s // 86400} 日前"
+        return None
+
+
+def age_seconds(iso, ref: datetime | None = None) -> float | None:
+    t = ts(iso)
+    if t is None:
+        return None
+    return ((ref or datetime.now(timezone.utc)) - t).total_seconds()
+
+
+def _span(sec: float) -> str:
+    sec = max(sec, 0)
+    if sec < 90:
+        return f"{int(sec)} 秒"
+    if sec < 5400:
+        return f"{int(sec // 60)} 分"
+    if sec < 172800:
+        return f"{int(sec // 3600)} 時間"
+    return f"{int(sec // 86400)} 日"
+
+
+def rel_time(iso) -> str:
+    sec = age_seconds(iso)
+    if sec is None:
+        return "—" if not iso else str(iso)
+    if sec < 0:
+        return "この後"
+    return _span(sec) + "前"
+
+
+def until_time(iso) -> str:
+    sec = age_seconds(iso)
+    if sec is None:
+        return "—"
+    return _span(-sec) + "後" if sec < 0 else "到来済み"
 
 
 def ci_state(pr: dict) -> tuple[str, str]:
@@ -238,352 +264,414 @@ def human_bytes(n) -> str:
     return "—"
 
 
+def parse_quantity(v) -> float:
+    """k8s の数量表記（Ki / Mi / Gi / n / m / 素の数）をバイトまたはコア数に直す。"""
+    s = str(v or "").strip()
+    m = re.fullmatch(r"(\d+(?:\.\d+)?)\s*([KMGTPE]i|[munkKMGT])?", s)
+    if not m:
+        return 0.0
+    num = float(m.group(1))
+    unit = m.group(2) or ""
+    factor = {
+        "": 1.0, "Ki": 1024.0, "Mi": 1024.0**2, "Gi": 1024.0**3,
+        "Ti": 1024.0**4, "Pi": 1024.0**5, "Ei": 1024.0**6,
+        "n": 1e-9, "u": 1e-6, "m": 1e-3,
+        "k": 1e3, "K": 1e3, "M": 1e6, "G": 1e9, "T": 1e12,
+    }.get(unit, 1.0)
+    return num * factor
+
+
+_INLINE_OK = re.compile(r"</?(?:a|code|b|strong|em|i|br|span|kbd|small)(?:\s[^<>]*)?/?>",
+                        re.IGNORECASE)
+
+
+def safe_html(s: str) -> str:
+    """human_action.steps は HTML を含んでよい（backlog.json の規約）。ただし
+    `kubectl logs <pod>` のようなプレースホルダも書かれるため、既知のインライン
+    タグ以外は文字として出す。素通しすると文書が壊れる（T-0112 の steps で実際に壊れた）。
+    """
+    out, last = [], 0
+    for m in _INLINE_OK.finditer(str(s)):
+        out.append(E(str(s)[last:m.start()]))
+        out.append(m.group(0))
+        last = m.end()
+    out.append(E(str(s)[last:]))
+    return "".join(out)
+
+
 def chip(text: str, tone: str) -> str:
     return f'<span class="chip chip--{tone}">{E(text)}</span>'
 
 
-def bar(segments, total: int) -> str:
-    if not total:
-        return ""
-    out = []
-    for n, tone, label in segments:
-        if not n:
-            continue
-        out.append(f'<span class="seg seg--{tone}" style="width:{n / total * 100:.4f}%" '
-                   f'title="{E(label)} {n} 件"></span>')
-    return f'<span class="bar">{"".join(out)}</span>'
+def dot(tone: str) -> str:
+    return f'<span class="dot dot--{tone}" aria-hidden="true"></span>'
 
 
-def _blocked_ids(t: dict):
+def meter(label: str, used: float, cap: float, extra: str, tone: str | None = None) -> str:
+    pct = (used / cap * 100) if cap else 0
+    tone = tone or ("crit" if pct > 85 else "warn" if pct > 70 else "ok")
+    return (f'<div class="meter"><div class="meter__top"><span>{E(label)}</span>'
+            f'<span class="meter__v">{E(extra)}</span></div>'
+            f'<span class="meter__track"><span class="meter__fill meter__fill--{tone}" '
+            f'style="width:{min(pct, 100):.1f}%"></span></span></div>')
+
+
+# ---------------------------------------------------------------- backlog
+
+
+def _blocked_ids(t: dict) -> list[str]:
     return re.findall(r"T-\d{4}", str(t.get("blocked_by", "")))
 
 
-def render_asks(tasks):
-    asks = [t for t in tasks if t["status"] == "needs-human"]
-    if not asks:
-        return ('<li><p class="empty">いまお願いしたいことはありません。'
-                'autopilot が自分で進められる状態です。</p></li>', 0)
-    blocked = [t for t in tasks if t["status"] == "blocked"]
+def _reason_ids(t: dict) -> list[str]:
+    """blocked_by に加えて needs_human_reason 側の T-xxxx も依存として拾う。"""
+    ids = _blocked_ids(t)
+    for extra in re.findall(r"T-\d{4}", str(t.get("needs_human_reason", ""))):
+        if extra not in ids:
+            ids.append(extra)
+    return ids
 
-    def unblocks(tid):
-        direct = [b for b in blocked if tid in _blocked_ids(b)]
-        indirect = []
-        for d in direct:
-            indirect += [b for b in blocked
-                         if d["id"] in _blocked_ids(b) and b not in direct and b not in indirect]
-        return direct + indirect
 
-    rows = []
-    for t in sorted(asks, key=lambda x: (-len(unblocks(x["id"])), x.get("priority", 999))):
-        un = unblocks(t["id"])
+def open_tasks(tasks: list[dict]) -> list[dict]:
+    """順番待ち。backlog.json の規約どおり priority 昇順、同値は ID 順。"""
+    live = [t for t in tasks if t.get("status") in OPEN_STATUSES]
+    return sorted(live, key=lambda t: (t.get("priority", 999), t.get("id", "")))
+
+
+def downstream(tasks: list[dict], tid: str) -> list[dict]:
+    """tid が片づくと動き出すもの（推移的）。"""
+    waiting = [t for t in tasks if t.get("status") in ("blocked", "needs-human")]
+    found, frontier = [], [tid]
+    while frontier:
+        cur = frontier.pop()
+        for w in waiting:
+            if w in found or w.get("id") == tid:
+                continue
+            if cur in _reason_ids(w):
+                found.append(w)
+                frontier.append(w["id"])
+    return found
+
+
+def wait_state(t: dict, ids_in_queue: set[str]) -> tuple[str, str, str]:
+    """(owner ラベル, tone, 待ち理由の一文) を返す。誰が動かすべきかを最初に置く。"""
+    status = t.get("status")
+    if status == "needs-human":
         ha = t.get("human_action") or {}
-        why = ha.get("why") or t.get("needs_human_reason") or t.get("why", "")
+        why = ha.get("why") or t.get("needs_human_reason") or t.get("why") or ""
+        return "あなた", "crit", str(why)
+    if status == "in_progress":
+        return "autopilot", "sig", "作業中"
+    if status == "todo":
+        nb = t.get("not_before")
+        if nb is not None and (age_seconds(nb) or 0) < 0:
+            # 返す文は呼び出し側でまとめてエスケープするので、ここでは素のまま
+            return "時刻待ち", "idle", f"{nb} まで着手しない（{until_time(nb)}）"
+        return "autopilot", "sig", "着手できる状態。次の巡回で取る"
+    dep = _blocked_ids(t)
+    reason = str(t.get("blocked_by") or "")
+    known = [d for d in dep if d in ids_in_queue]
+    if known:
+        return "他タスク待ち", "warn", reason
+    return "条件待ち", "warn", reason
+
+
+def render_queue(tasks: list[dict]) -> tuple[str, dict]:
+    live = open_tasks(tasks)
+    ids_in_queue = {t["id"] for t in live}
+    if not live:
+        return ('<li class="q__empty">順番待ちは空です。'
+                'autopilot が拾える仕事はいまありません。</li>', {"total": 0, "you": 0, "unblocks": 0})
+
+    rows, you, unblocks_total = [], 0, 0
+    for i, t in enumerate(live, 1):
+        owner, tone, reason = wait_state(t, ids_in_queue)
+        if t.get("status") == "needs-human":
+            you += 1
+        down = downstream(tasks, t["id"])
+        if t.get("status") == "needs-human":
+            unblocks_total += len(down)
+
+        ha = t.get("human_action") or {}
+        title = ha.get("summary") or t.get("title") or t["id"]
+
+        impact = ""
+        if down:
+            names = "、".join(E(str(d.get("title", ""))[:26]) for d in down[:3])
+            more = f"　ほか {len(down) - 3} 件" if len(down) > 3 else ""
+            impact = (f'<p class="q__impact">これが済むと <b>{len(down)} 件</b>が動く'
+                      f'<span class="q__impact__names">{names}{more}</span></p>')
+
+        # blocked_by / needs_human_reason 中の T-xxxx は同じ画面内の行へ飛ばす
+        def link_ids(s: str) -> str:
+            out = E(s)
+            for tid in sorted(set(re.findall(r"T-\d{4}", s)), reverse=True):
+                if tid in ids_in_queue:
+                    out = out.replace(tid, f'<a class="q__dep" href="#{tid}">{tid}</a>')
+            return out
+
+        reason_html = ""
+        if reason:
+            short = reason if len(reason) <= 150 else reason[:150] + "…"
+            reason_html = f'<p class="q__why">{link_ids(short)}</p>'
+            if len(reason) > 150:
+                reason_html += (f'<details class="q__more"><summary>理由の続き</summary>'
+                                f'<p>{link_ids(reason)}</p></details>')
+
         steps = ha.get("steps") or []
         links = ha.get("links") or []
-        effect = (f'<span class="ask__effect">これが済むと <b>{len(un)} 件</b>が動き出します</span>'
-                  if un else '<span class="ask__effect ask__effect--none">他を止めてはいません</span>')
-        if steps:
-            steps_html = ('<details class="ask__steps"><summary>手順を開く'
-                          f'（{len(steps)} ステップ）</summary><ol>'
-                          + "".join(f"<li>{s}</li>" for s in steps) + "</ol></details>")
-        else:
-            steps_html = ('<p class="ask__nosteps">手順が未整理です。autopilot に '
-                          '<code>human_action.steps</code> を書かせてください。</p>')
-        links_html = ("<p class=\"ask__links\">" + " ".join(
-            f'<a href="{E(l["url"])}">{E(l["label"])}</a>' for l in links) + "</p>") if links else ""
-        unlist = ""
-        if un:
-            unlist = ('<p class="ask__unblocks">解けるもの: '
-                      + "、".join(E(b["title"][:24]) for b in un[:4])
-                      + (f"　ほか {len(un) - 4} 件" if len(un) > 4 else "") + "</p>")
+        act = ""
+        if t.get("status") == "needs-human":
+            if steps:
+                act = ('<details class="q__act" open><summary>あなたの手順'
+                       f'（{len(steps)} ステップ）</summary><ol>'
+                       + "".join(f"<li>{safe_html(s)}</li>" for s in steps) + "</ol>")
+                if links:
+                    act += ('<p class="q__links">' + " ".join(
+                        f'<a href="{E(str(l.get("url", "")))}">{E(str(l.get("label") or l.get("url", "")))}</a>'
+                        for l in links) + "</p>")
+                act += "</details>"
+            else:
+                act = ('<p class="q__nosteps">手順がまだ書かれていません。'
+                       'autopilot に <code>human_action.steps</code> を書かせてください。</p>')
+
+        meta = [f'<span class="q__id">{E(t["id"])}</span>',
+                f'<span>優先度 {E(str(t.get("priority", "—")))}</span>']
+        if t.get("kind"):
+            meta.append(f'<span>{E(KIND_LABEL.get(t["kind"], t["kind"]))}</span>')
+        if t.get("risk"):
+            meta.append(f'<span>リスク {E(RISK_LABEL.get(t["risk"], t["risk"]))}</span>')
+        if t.get("pr"):
+            meta.append(f'<a href="https://github.com/{REPO}/pull/{E(str(t["pr"]))}">'
+                        f'PR #{E(str(t["pr"]))}</a>')
+
         rows.append(f"""
-      <li class="ask">
-        <div class="ask__head"><span class="ask__id">{E(t['id'])}</span>
-          <h3 class="ask__title">{E(ha.get('summary') or t['title'])}</h3></div>
-        {effect}
-        <p class="ask__why">{E(why)}</p>
-        {steps_html}{links_html}{unlist}
-      </li>""")
-    return "".join(rows), len(asks)
+        <li class="q__row q__row--{tone}" id="{E(t['id'])}">
+          <span class="q__rank" aria-hidden="true">{i}</span>
+          <div class="q__main">
+            <div class="q__head"><span class="q__owner q__owner--{tone}">{E(owner)}</span>
+              <h3 class="q__title">{E(str(title))}</h3></div>
+            <p class="q__meta">{"".join(meta)}</p>
+            {reason_html}{impact}{act}
+          </div>
+        </li>""")
+    summary = {"total": len(live), "you": you, "unblocks": unblocks_total}
+    return "".join(rows), summary
 
 
-def render_chain(tasks):
-    blocked = [t for t in tasks if t["status"] == "blocked"]
-    asks = [t for t in tasks if t["status"] == "needs-human"]
-    if not blocked:
-        return '<p class="empty">詰まっているものはありません。</p>'
-    roots = []
-    for a in asks:
-        direct = [b for b in blocked if a["id"] in _blocked_ids(b)]
-        if direct:
-            roots.append((a, direct))
-    if not roots:
-        return '<p class="empty">人間待ちが原因の詰まりはありません。</p>'
-    cols = []
-    for a, direct in sorted(roots, key=lambda x: -len(x[1])):
-        mids = []
-        total = len(direct)
-        for d in direct:
-            kids = [b for b in blocked if d["id"] in _blocked_ids(b)]
-            total += len(kids)
-            leaves = "".join(f'<span class="chain__leaf">{E(k["title"][:28])}</span>' for k in kids)
-            mids.append(f'<div class="chain__mid"><span class="chain__node chain__node--blocked">'
-                        f'{E(d["title"][:34])}</span>'
-                        + (f'<div class="chain__leaves">{leaves}</div>' if kids else "") + "</div>")
-        ha = a.get("human_action") or {}
-        cols.append(f"""
-      <div class="chain">
-        <div class="chain__root"><span class="chain__badge">あなた</span>
-          <span class="chain__node chain__node--ask">{E(ha.get('summary') or a['title'][:34])}</span>
-          <span class="chain__count">→ {total} 件が解ける</span></div>
-        <div class="chain__mids">{''.join(mids)}</div>
-      </div>""")
-    return f'<div class="chains">{"".join(cols)}</div>'
-
-
-def render_projects(tasks):
+def render_archive(tasks: list[dict]) -> str:
     rows = []
-    for sid, label, _k, blurb in ALL_STREAMS:
-        mine = [t for t in tasks if stream_of(t) == sid]
-        if not mine:
-            continue
-        c = {k: sum(1 for t in mine if t["status"] == k) for k in STATUS_META}
-        total = len(mine)
-        live = c["todo"] + c["in_progress"] + c["blocked"] + c["needs-human"]
-        segs = [(c["done"], "ok", "完了"), (c["dropped"], "idle", "取り下げ"),
-                (c["in_progress"], "sig", "作業中"), (c["todo"], "idle", "待ち"),
-                (c["blocked"], "warn", "詰まり"), (c["needs-human"], "crit", "あなた待ち")]
-        state = ("完了" if not live else f"あなた待ち {c['needs-human']}" if c["needs-human"]
-                 else f"詰まり {c['blocked']}" if c["blocked"] else f"進行中 {live}")
-        tone = ("ok" if not live else "crit" if c["needs-human"]
-                else "warn" if c["blocked"] else "sig")
-        rows.append(f"""
-      <li class="proj"><span class="proj__dot proj__dot--{sid}" aria-hidden="true"></span>
-        <div class="proj__body">
-          <div class="proj__head"><h3>{E(label)}</h3>{chip(state, tone)}</div>
-          <p class="proj__blurb">{E(blurb)}</p>
-          {bar(segs, total)}
-          <p class="proj__n">{c['done']} / {total} 完了</p>
-        </div></li>""")
+    order = {"needs-human": 0, "blocked": 1, "in_progress": 2, "todo": 3, "done": 4, "dropped": 5}
+    for t in sorted(tasks, key=lambda x: (order.get(x.get("status"), 9),
+                                          x.get("priority", 999), x.get("id", ""))):
+        label, tone = STATUS_META.get(t.get("status"), (str(t.get("status")), "idle"))
+        pr = (f'<a href="https://github.com/{REPO}/pull/{t["pr"]}">#{t["pr"]}</a>'
+              if t.get("pr") else "")
+        note = t.get("needs_human_reason") or t.get("blocked_by") or ""
+        rows.append(f'<tr data-status="{E(str(t.get("status")))}">'
+                    f'<td class="at__id">{E(t["id"])}</td><td>{chip(label, tone)}</td>'
+                    f'<td class="at__kind">{E(KIND_LABEL.get(t.get("kind", ""), t.get("kind", "")))}</td>'
+                    f'<td class="at__title">{E(str(t.get("title", "")))}'
+                    + (f'<span class="at__note">{E(str(note)[:110])}</span>' if note else "")
+                    + f'</td><td class="at__pr">{pr}</td></tr>')
     return "".join(rows)
 
 
-def render_health(h):
+# ---------------------------------------------------------------- pulse
+
+
+def loop_state(state: dict, runs: list[dict]) -> tuple[str, str, str]:
+    last = runs[-1] if runs else {}
+    gap = age_seconds(last.get("at"))
+    if gap is None:
+        return "idle", "起動の記録なし", "—"
+    tone = "crit" if gap > 7200 else "warn" if gap > 4500 else "ok"
+    text = {"ok": "動いています", "warn": "しばらく動きなし", "crit": "止まっているかも"}[tone]
+    # runs 配列は古い分が間引かれるので通算回数は最後の n を使う（len では過少になる）
+    total = last.get("n") if isinstance(last.get("n"), int) else len(runs)
+    return tone, text, f"最終起動 {rel_time(last.get('at'))}・通算 {total} 回"
+
+
+def health_freshness(h: dict | None) -> tuple[str, str]:
+    """レポート自体の鮮度。古いレポートを『いまの状態』として読ませない。"""
+    if not h:
+        return "crit", "レポート未着"
+    sec = age_seconds(h.get("generated_at"))
+    if sec is None:
+        return "warn", "生成時刻が読めない"
+    tone = "crit" if sec > 10800 else "warn" if sec > 5400 else "ok"
+    return tone, f"{rel_time(h.get('generated_at'))}の観測"
+
+
+def render_pulse(state, health, prs, runs) -> str:
+    cells = []
+
+    tone, text, sub = loop_state(state, runs)
+    cells.append(f'<div class="pulse__cell"><p class="pulse__k">autopilot ループ</p>'
+                 f'<p class="pulse__v">{dot(tone)}{E(text)}</p>'
+                 f'<p class="pulse__s">{E(sub)}</p></div>')
+
+    apps = (health or {}).get("applications") or []
+    bad = [a for a in apps if a.get("sync") != "Synced" or a.get("health") != "Healthy"]
+    ftone, fresh = health_freshness(health)
+    if apps:
+        atone = "crit" if bad else "ok"
+        atext = f"{len(apps) - len(bad)} / {len(apps)} 正常"
+        asub = ("落ちている: " + "、".join(E(str(a.get("name"))) for a in bad[:4])) if bad else fresh
+        if bad and ftone != "ok":
+            asub += f"（{fresh}）"
+    else:
+        atone, atext, asub = "warn", "状態が届いていない", fresh
+    cells.append(f'<div class="pulse__cell"><p class="pulse__k">homelab のアプリ</p>'
+                 f'<p class="pulse__v">{dot(atone)}{E(atext)}</p>'
+                 f'<p class="pulse__s">{asub}</p></div>')
+
+    if prs:
+        worst = "ok"
+        for p in prs:
+            t, _ = ci_state(p)
+            if t == "crit" or (t == "warn" and worst != "crit"):
+                worst = t
+        ptext = f"{len(prs)} 件が審査中"
+    else:
+        worst, ptext = "idle", "なし"
+    cells.append(f'<div class="pulse__cell"><p class="pulse__k">出している変更</p>'
+                 f'<p class="pulse__v">{dot(worst)}{E(ptext)}</p>'
+                 f'<p class="pulse__s">CI が通れば自分でマージします</p></div>')
+
+    ap = render_autopilot_self(health)
+    cells.append(ap)
+
+    pr_rows = ""
+    if prs:
+        items = []
+        for p in prs:
+            tone, label = ci_state(p)
+            items.append(f'<li class="pr pr--{tone}">{dot(tone)}'
+                         f'<a class="pr__t" href="{E(str(p.get("url", "")))}">'
+                         f'{E(str(p.get("title", ""))[:70])}</a>'
+                         f'<span class="pr__n">#{E(str(p.get("number")))}</span>'
+                         f'{chip(label, tone)}</li>')
+        pr_rows = f'<ul class="prs">{"".join(items)}</ul>'
+    return f'<div class="pulsebox"><div class="pulse">{"".join(cells)}</div>{pr_rows}</div>'
+
+
+def render_autopilot_self(h) -> str:
+    """T-0110: autopilot 自身（namespace autopilot）の readyReplicas と心拍。
+
+    経過時間はレポートの generated_at を基準に測る。now() を基準にすると、
+    レポートが古いだけでハング扱いになる（2026-08-06 に実際に誤検知した）。
+    """
+    ap = (h or {}).get("autopilot") or {}
+    if not ap or "error" in ap:
+        return ('<div class="pulse__cell"><p class="pulse__k">autopilot 自身</p>'
+                '<p class="pulse__v">' + dot("idle") + '観測なし</p>'
+                '<p class="pulse__s">健全性レポートに autopilot キーがありません</p></div>')
+    ref = ts(h.get("generated_at")) or datetime.now(timezone.utc)
+    dep = ap.get("deployment") or {}
+    hb = ap.get("heartbeat") or {}
+    start, end = hb.get("last_start"), hb.get("last_end")
+
+    tone, text, sub = "ok", "常駐しています", ""
+    if (dep.get("readyReplicas") or 0) < 1:
+        tone, text = "crit", "Pod が上がっていない"
+        sub = f"readyReplicas {dep.get('readyReplicas', 0)} / {dep.get('replicas', '?')}"
+    elif start and (not end or start.get("iteration", 0) > end.get("iteration", -1)):
+        elapsed = age_seconds(start.get("timestamp"), ref)
+        if elapsed is not None and elapsed > 3700:
+            tone, text = "crit", "ハングの疑い"
+            sub = (f"#{start.get('iteration')} が観測時点で {int(elapsed // 60)} 分実行中"
+                   "（timeout 3600 秒を超過）")
+        else:
+            text = f"#{start.get('iteration')} を実行中"
+            sub = f"開始 {rel_time(start.get('timestamp'))}"
+    elif end:
+        if end.get("exit_code") not in (0, None):
+            tone, text = "crit", f"#{end.get('iteration')} が異常終了"
+            sub = f"exit={end.get('exit_code')}・{rel_time(end.get('timestamp'))}"
+        else:
+            text = f"#{end.get('iteration')} まで正常"
+            sub = f"{end.get('elapsed_seconds', '?')} 秒で終了・{rel_time(end.get('timestamp'))}"
+    else:
+        tone, text, sub = "warn", "心拍がまだ無い", "loop.sh の心拍ログが読めていません"
+
+    ftone, fresh = health_freshness(h)
+    if ftone != "ok":
+        sub = f"{sub}（{fresh}）" if sub else fresh
+    return (f'<div class="pulse__cell"><p class="pulse__k">autopilot 自身</p>'
+            f'<p class="pulse__v">{dot(tone)}{E(text)}</p>'
+            f'<p class="pulse__s">{E(sub)}</p></div>')
+
+
+# ---------------------------------------------------------------- cluster
+
+
+def render_cluster(h) -> str:
     if not h:
         return ('<p class="empty">homelab からの状態がまだ届いていません。'
                 '<code>ops-health-report</code> ブランチを確認してください。</p>')
-    apps = h.get("applications", []) or []
-    bad = [a for a in apps if a.get("sync") != "Synced" or a.get("health") != "Healthy"]
-    issues = h.get("pod_issues", []) or []
+    out = []
+
+    apps = h.get("applications") or []
+    if apps:
+        cells = []
+        for a in sorted(apps, key=lambda x: str(x.get("name"))):
+            good = a.get("sync") == "Synced" and a.get("health") == "Healthy"
+            t = "ok" if good else "crit"
+            st = "正常" if good else f'{a.get("health")}/{a.get("sync")}'
+            cells.append(f'<li class="app app--{t}">{dot(t)}'
+                         f'<span class="app__n">{E(str(a.get("name")))}</span>'
+                         f'<span class="app__s">{E(str(st))}</span></li>')
+        out.append(f'<ul class="apps">{"".join(cells)}</ul>')
+
     nodes = h.get("nodes") or []
     nm = h.get("node_metrics") or []
-    node_html = ""
-    if nodes:
-        cap = (nodes[0].get("capacity") or {})
+    if nodes and nm:
+        cap = nodes[0].get("capacity") or {}
+        cpu_cap = parse_quantity(cap.get("cpu"))
+        mem_cap = parse_quantity(cap.get("memory"))
+        cpu_used = parse_quantity(nm[0].get("cpu"))
+        mem_used = parse_quantity(nm[0].get("memory"))
+        out.append('<p class="sub">ノード nixos</p>')
+        out.append(meter("CPU", cpu_used, cpu_cap, f"{cpu_used:.2f} / {cpu_cap:.0f} コア"))
+        out.append(meter("メモリ", mem_used, mem_cap,
+                         f"{human_bytes(mem_used)} / {human_bytes(mem_cap)}"))
 
-        def ki(v):
-            try:
-                return int(str(v).replace("Ki", "")) * 1024
-            except (TypeError, ValueError):
-                return 0
+    # PVC は「要求した容量に対してどれだけ使ったか」で見る。ノードの
+    # ephemeral-storage は kubelet の一時領域用の計算値でルート FS の大きさではない
+    # （health レポートの notes / T-0079）。分母に使わない。
+    used_by_pvc = {}
+    for grp in h.get("pvc_usage") or []:
+        for u in grp.get("usage") or []:
+            used_by_pvc[(grp.get("namespace"), u.get("pvc"))] = u.get("bytes")
+    known = []
+    for p in h.get("pvcs") or []:
+        b = used_by_pvc.get((p.get("namespace"), p.get("name")))
+        if b is None:
+            continue
+        cap = parse_quantity(p.get("capacity") or p.get("requested"))
+        known.append(meter(f'{p.get("namespace")}/{p.get("name")}', float(b), cap,
+                           f"{human_bytes(b)} / {human_bytes(cap)}"))
+    if known:
+        unmeasured = len(h.get("pvcs") or []) - len(known)
+        note = f"（実使用量が取れていない PVC が {unmeasured} 件）" if unmeasured > 0 else ""
+        out.append(f'<p class="sub">保存領域の使用量{E(note)}</p>' + "".join(known))
 
-        mem_cap, disk_cap = ki(cap.get("memory")), ki(cap.get("ephemeral-storage"))
-        try:
-            cpu_cap = float(cap.get("cpu") or 0)
-        except (TypeError, ValueError):
-            cpu_cap = 0.0
-        mem_used = ki(nm[0].get("memory")) if nm else 0
-        try:
-            cpu_used = int(str(nm[0]["cpu"]).replace("n", "")) / 1e9 if nm else 0.0
-        except (TypeError, ValueError, KeyError):
-            cpu_used = 0.0
-        pvc_bytes = 0
-        for grp in h.get("pvc_usage") or []:
-            for u in (grp.get("usage") or []):
-                try:
-                    pvc_bytes += int(u.get("bytes") or 0)
-                except (TypeError, ValueError):
-                    pass
-
-        def meter(label, used, cap_, extra):
-            pct = (used / cap_ * 100) if cap_ else 0
-            tone = "crit" if pct > 85 else "warn" if pct > 70 else "ok"
-            return (f'<div class="meter"><div class="meter__top"><span>{E(label)}</span>'
-                    f'<span class="meter__v">{E(extra)}</span></div>'
-                    f'<span class="meter__track"><span class="meter__fill meter__fill--{tone}" '
-                    f'style="width:{min(pct, 100):.1f}%"></span></span></div>')
-
-        node_html = (meter("CPU", cpu_used, cpu_cap, f"{cpu_used:.2f} / {cpu_cap:.0f} コア")
-                     + meter("メモリ", mem_used, mem_cap,
-                             f"{human_bytes(mem_used)} / {human_bytes(mem_cap)}")
-                     + meter("アプリのデータ", pvc_bytes, disk_cap,
-                             f"{human_bytes(pvc_bytes)} / {human_bytes(disk_cap)}"))
-    issue_html = ""
+    issues = h.get("pod_issues") or []
     if issues:
-        issue_html = ('<details class="hl__issues"><summary>再起動の多い Pod '
-                      f'{len(issues)} 件</summary><ul>'
-                      + "".join(f'<li>{E(str(p.get("namespace", "")))}/'
-                                f'{E(str(p.get("name", ""))[:32])} '
-                                f'<span>{E(str(p.get("restarts", "?")))} 回</span></li>'
-                                for p in issues[:10]) + "</ul></details>")
-    return (f'<p class="hl__apps">'
-            f'{chip(f"アプリ {len(apps) - len(bad)}/{len(apps)} 正常", "ok" if not bad else "crit")}'
-            f'<span class="hl__at">{E(rel_time(h.get("generated_at")))}の状態</span></p>'
-            f"{render_autopilot_self(h)}{node_html}{issue_html}")
+        out.append('<details class="fold"><summary>再起動の多い Pod '
+                   f'{len(issues)} 件</summary><ul class="kv">'
+                   + "".join(f'<li><span>{E(str(p.get("namespace", "")))}/'
+                             f'{E(str(p.get("name", ""))[:34])}</span>'
+                             f'<b>{E(str(p.get("restarts", "?")))} 回</b></li>'
+                             for p in issues[:12]) + "</ul></details>")
+    return "".join(out)
 
 
-def render_autopilot_self(h):
-    """T-0110: autopilot 自身（namespace autopilot）が report.py の autopilot キーで返す
-    readyReplicas とハートビート（loop.sh の心拍ログ）から、静かなハング/異常終了を示す。"""
-    ap = (h or {}).get("autopilot") or {}
-    if not ap or "error" in ap:
-        return ""
-    dep = ap.get("deployment") or {}
-    hb = ap.get("heartbeat") or {}
-    last_start, last_end = hb.get("last_start"), hb.get("last_end")
-
-    tone, msgs = "ok", []
-    if (dep.get("readyReplicas") or 0) < 1:
-        tone = "crit"
-        msgs.append("readyReplicas 0")
-
-    running = last_start and (not last_end or last_start["iteration"] > last_end["iteration"])
-    if running:
-        started = last_start["timestamp"]
-        try:
-            elapsed = int(
-                (datetime.now(timezone.utc)
-                 - datetime.fromisoformat(started.replace("Z", "+00:00"))).total_seconds()
-            )
-        except ValueError:
-            elapsed = None
-        if elapsed is not None and elapsed > 3700:
-            tone = "crit"
-            msgs.append(f"iteration #{last_start['iteration']} が {elapsed // 60} 分実行中"
-                        " (timeout 3600s 超、ハングの疑い)")
-        else:
-            msgs.append(f"iteration #{last_start['iteration']} 実行中（開始 {rel_time(started)}）")
-    elif last_end:
-        if last_end.get("exit_code") not in (0, None):
-            tone = "crit" if tone != "crit" else tone
-            msgs.append(f"iteration #{last_end['iteration']} exit={last_end['exit_code']}"
-                        f"（{rel_time(last_end['timestamp'])}）")
-        else:
-            msgs.append(f"iteration #{last_end['iteration']} 正常終了（{rel_time(last_end['timestamp'])}）")
-    else:
-        tone = "warn" if tone == "ok" else tone
-        msgs.append("心拍ログがまだ無い")
-
-    return f'<p class="hl__apps">{chip("autopilot " + " / ".join(msgs), tone)}</p>'
+# ---------------------------------------------------------------- misc
 
 
-def render_gantt(tasks, merged, runs):
-    pr2stream = {}
-    for t in tasks:
-        if t.get("pr"):
-            try:
-                pr2stream[int(t["pr"])] = stream_of(t)
-            except (TypeError, ValueError):
-                pass
-    marks = []
-    for p in merged:
-        ts = p.get("mergedAt")
-        if not ts:
-            continue
-        try:
-            marks.append((datetime.fromisoformat(ts.replace("Z", "+00:00")),
-                          pr2stream.get(p["number"], "other"), p))
-        except ValueError:
-            pass
-    if not marks:
-        return ""
-    run_times = []
-    for r in runs:
-        try:
-            run_times.append(datetime.fromisoformat(str(r.get("at", "")).replace("Z", "+00:00")))
-        except ValueError:
-            pass
-    t0 = min([m[0] for m in marks] + run_times)
-    t1 = datetime.now(timezone.utc)
-    span = max((t1 - t0).total_seconds(), 1)
-
-    def x(w):
-        return max(0.0, min(100.0, (w - t0).total_seconds() / span * 100))
-
-    ticks, cur = [], t0.replace(minute=0, second=0, microsecond=0)
-    while cur <= t1:
-        if cur >= t0:
-            ticks.append(f'<span class="gtick" style="left:{x(cur):.3f}%"><i></i>'
-                         f'<em>{cur.strftime("%H:%M")}</em></span>')
-        cur = datetime.fromtimestamp(cur.timestamp() + 6 * 3600, tz=timezone.utc)
-    lanes = []
-    for sid, label, _k, _b in ALL_STREAMS:
-        mine = [m for m in marks if m[1] == sid]
-        if not mine:
-            continue
-        dots = "".join(f'<span class="gmark gmark--{sid}" style="left:{x(w):.3f}%" '
-                       f'title="#{p["number"]} {E(p["title"])}"></span>'
-                       for w, _s, p in sorted(mine, key=lambda z: z[0]))
-        lanes.append(f'<div class="glane"><span class="glane__label">'
-                     f'<span class="proj__dot proj__dot--{sid}" aria-hidden="true"></span>'
-                     f'{E(label)}</span><span class="glane__track">{dots}</span>'
-                     f'<span class="glane__n">{len(mine)}</span></div>')
-    runs_html = "".join(f'<span class="grun" style="left:{x(w):.3f}%"></span>'
-                        for w in sorted(run_times))
-    return (f'<div class="gantt"><div class="glane gantt__runs">'
-            f'<span class="glane__label">起動</span>'
-            f'<span class="glane__track">{runs_html}</span>'
-            f'<span class="glane__n">{len(run_times)}</span></div>{"".join(lanes)}'
-            f'<div class="glane gantt__axis"><span class="glane__label"></span>'
-            f'<span class="glane__track">{"".join(ticks)}</span>'
-            f'<span class="glane__n"></span></div></div>')
-
-
-def render_detail(tasks):
-    rows = []
-    order = {"needs-human": 0, "blocked": 1, "in_progress": 2, "todo": 3, "done": 4, "dropped": 5}
-    for t in sorted(tasks, key=lambda x: (order.get(x["status"], 9), x.get("priority", 999), x["id"])):
-        label, tone = STATUS_META.get(t["status"], (t["status"], "idle"))
-        sid = stream_of(t)
-        sl = next((s[1] for s in ALL_STREAMS if s[0] == sid), sid)
-        pr = (f'<a href="https://github.com/hikuohiku/homelab/pull/{t["pr"]}">#{t["pr"]}</a>'
-              if t.get("pr") else "")
-        note = t.get("needs_human_reason") or t.get("blocked_by") or ""
-        rows.append(f'<tr data-status="{E(t["status"])}">'
-                    f'<td class="dt__id">{E(t["id"])}</td><td>{chip(label, tone)}</td>'
-                    f'<td class="dt__stream">{E(sl)}</td>'
-                    f'<td class="dt__title">{E(t["title"])}'
-                    + (f'<span class="dt__note">{E(str(note)[:110])}</span>' if note else "")
-                    + f'</td><td class="dt__pr">{pr}</td></tr>')
-    return "".join(rows)
-
-
-
-def render_now(prs, health, runs, cadence_min):
-    """いま何が動いているか。ページ内 JS で経過時間を刻む。"""
-    items = []
-    for p in prs:
-        tone, label = ci_state(p)
-        items.append(f'<li class="now__row now__row--{tone}"><span class="now__k">PR #{p["number"]}</span>'
-                     f'<span class="now__v">{E(p["title"][:44])}</span>'
-                     f'{chip(label, tone)}</li>')
-    jobs = (health or {}).get("running_jobs") or []
-    for j in jobs:
-        items.append(f'<li class="now__row now__row--sig"><span class="now__k">Job</span>'
-                     f'<span class="now__v">{E(str(j))}</span>{chip("実行中", "sig")}</li>')
-    if not items:
-        items.append('<li class="now__row now__row--idle"><span class="now__v">'
-                     'GitHub 上で動いているものはありません</span></li>')
-    last = runs[-1] if runs else {}
-    return (f'<ul class="now">{"".join(items)}</ul>'
-            f'<p class="now__meta">'
-            f'<span>最終起動 <b data-since="{E(str(last.get("at","")))}">—</b></span>'
-            f'<span>次の定期起動まで <b id="nextrun">—</b></span>'
-            f'<span>この画面は <b data-since="{datetime.now(timezone.utc).isoformat()}">—</b>の情報</span>'
-            f'</p>')
-
-
-def resolve_cadence(state):
+def resolve_cadence(state) -> str | None:
     """人間に見せる実行間隔。無効化されたクラウド routine の頻度をそのまま出さない。"""
     routines = state.get("routines") or []
     active = [r for r in routines if r.get("enabled", True)]
@@ -604,58 +692,54 @@ def resolve_cadence(state):
 def build() -> str:
     state = load("state.json", {}) or {}
     backlog = load("backlog.json", {"tasks": []}) or {"tasks": []}
-    tasks = backlog["tasks"]
+    tasks = backlog.get("tasks", [])
     prs, merged = fetch_prs()
     health = load_health()
     runs = state.get("runs", []) or []
     journal = parse_journal()
 
-    counts = {k: sum(1 for t in tasks if t["status"] == k) for k in STATUS_META}
-    asks_html, n_asks = render_asks(tasks)
-    auto_merged = [p for p in merged if str(p.get("headRefName", "")).startswith("autopilot/")]
-    last_run = runs[-1] if runs else {}
-    cadence = resolve_cadence(state)
+    queue_html, qs = render_queue(tasks)
+    n_done = sum(1 for t in tasks if t.get("status") == "done")
     fb = state.get("feedback", {}) or {}
 
-    alive_tone, alive_text = "idle", "起動の記録がありません"
-    try:
-        gap = (datetime.now(timezone.utc) - datetime.fromisoformat(
-            str(last_run.get("at")).replace("Z", "+00:00"))).total_seconds()
-        alive_tone, alive_text = (("crit", "止まっているかも") if gap > 7200 else
-                                  ("warn", "しばらく動きなし") if gap > 4500 else
-                                  ("ok", "動いています"))
-    except Exception:  # noqa: BLE001
-        pass
+    if qs["you"] == 0:
+        lede = ("いまあなたにお願いすることはありません。"
+                "上から順に autopilot が自分で片づけます。")
+    else:
+        extra = (f"それが済むと、さらに {qs['unblocks']} 件が動き出します。"
+                 if qs["unblocks"] else "")
+        lede = f"あなたの手が要るのは {qs['you']} 件。{extra}"
 
-    now_html = render_now(prs, health, runs, 60)
-    stale_html = (f'<p class="stale">PR 一覧を取得できませんでした。表示は'
-                  f'{E(rel_time(STALE.get("at")))}のキャッシュです。</p>') if STALE else ""
+    stale_html = (f'<p class="banner banner--warn">GitHub から PR 一覧を取得できませんでした。'
+                  f'「出している変更」は{E(rel_time(STALE.get("at")))}のキャッシュです。</p>'
+                  ) if STALE else ""
 
     runs_html = ""
     for e in journal[:3]:
         items = [E(re.sub(r"^\s*[-*]\s*", "", l)) for l in e["body"].splitlines()
                  if l.strip().startswith(("-", "*"))][:4]
-        runs_html += (f'<li class="run"><h4>{E(e["head"][:44])}</h4><ul>'
-                      + "".join(f"<li>{i[:110]}</li>" for i in items) + "</ul></li>")
+        runs_html += (f'<li class="jr"><h4>{E(e["head"][:52])}</h4><ul>'
+                      + "".join(f"<li>{i[:130]}</li>" for i in items) + "</ul></li>")
 
+    auto_merged = [p for p in merged if str(p.get("headRefName", "")).startswith("autopilot/")]
     done_html = "".join(
-        f'<li class="done"><a href="{E(p["url"])}">{E(p["title"][:54])}</a>'
+        f'<li class="dn"><a href="{E(str(p.get("url", "")))}">{E(str(p.get("title", ""))[:62])}</a>'
         f'<span>#{p["number"]} · {E(rel_time(p.get("mergedAt")))}</span></li>'
-        for p in (auto_merged or merged)[:8])
+        for p in (auto_merged or merged)[:10])
 
     return TEMPLATE.format(
         generated=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
-        stage=state.get("vision_stage", "?"), stage_label=E(state.get("vision_stage_label", "")),
-        alive_tone=alive_tone, alive_text=E(alive_text),
-        last_run=E(rel_time(last_run.get("at"))), cadence=E(cadence or "定期実行 未設定"),
-        n_asks=n_asks, n_blocked=counts["blocked"], n_done=counts["done"],
-        n_total=len(tasks), n_runs=len(runs),
-        asks=asks_html, chain=render_chain(tasks), projects=render_projects(tasks),
-        health=render_health(health), gantt=render_gantt(tasks, merged, runs),
-        detail=render_detail(tasks), runs=runs_html, done=done_html,
-        fb_url=E(fb.get("url") or "https://github.com/hikuohiku/homelab/issues"),
+        stage=E(str(state.get("vision_stage", "?"))),
+        stage_label=E(str(state.get("vision_stage_label", ""))),
+        cadence=E(resolve_cadence(state) or "巡回間隔 未設定"),
+        pulse=render_pulse(state, health, prs, runs),
+        queue=queue_html, n_queue=qs["total"], lede=E(lede),
+        cluster=render_cluster(health),
+        archive=render_archive(tasks), n_total=len(tasks), n_done=n_done,
+        runs=runs_html, done=done_html,
+        fb_url=E(str(fb.get("url") or f"https://github.com/{REPO}/issues")),
         fb_issue=E(str(fb.get("issue") or "?")), fb_read=E(rel_time(fb.get("last_read"))),
-        stale=stale_html, now=now_html,
+        stale=stale_html, repo=REPO,
     )
 
 
@@ -670,324 +754,347 @@ TEMPLATE = """<!doctype html>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>autopilot — homelab 当直記録</title>
 <style>
+/* 台帳（当直日誌）の見立て。罫線で区切り、面で囲わない。
+   数字と識別子は等幅、日本語の文は system-ui。飾りの識別色は置かず、
+   色は「誰待ちか」と「正常/注意/異常」だけに使う。 */
 :root {{
-  --ground:#eef0f4; --surface:#fbfcfe; --surface2:#f3f5f9; --line:#d8dce5;
-  --ink:#161a21; --muted:#5b6473;
-  --sig:#41528c; --sig-soft:#e3e7f4; --ok:#2c6f52; --ok-soft:#dfeee7;
-  --warn:#8a5c0d; --warn-soft:#f6ebd7; --crit:#983737; --crit-soft:#f7e2e2;
-  --idle:#6a7382; --idle-soft:#e6e9ef;
-  --serif: ui-serif, "Iowan Old Style", "Source Serif 4", "Hiragino Mincho ProN", Georgia, serif;
-  --sans: ui-sans-serif, system-ui, -apple-system, "Hiragino Kaku Gothic ProN", "Noto Sans JP", sans-serif;
-  --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
-  --r:4px;
+  --paper:#eaedf2; --sheet:#fbfcfd; --sheet2:#f2f4f8; --rule:#d2d8e1; --rule2:#e2e6ed;
+  --ink:#11151b; --ink2:#545e6c; --ink3:#7d8695;
+  --accent:#1d5876; --accent-soft:#dde9f0;
+  --ok:#2b6b4e; --ok-soft:#dcece3;
+  --warn:#8a5709; --warn-soft:#f5e9d4;
+  --crit:#96303a; --crit-soft:#f7e0e1;
+  --sig:#1d5876; --sig-soft:#dde9f0;
+  --idle:#69727f; --idle-soft:#e5e8ee;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", "JetBrains Mono", Menlo, Consolas,
+          "Noto Sans Mono", monospace;
+  --sans: system-ui, -apple-system, "Hiragino Kaku Gothic ProN", "Noto Sans JP",
+          "Yu Gothic UI", sans-serif;
+  --r:3px;
 }}
-.proj__dot--kiki,.gmark--kiki {{ background:#2a78d6; }}
-.proj__dot--kenshou,.gmark--kenshou {{ background:#eb6834; }}
-.proj__dot--tsuijuu,.gmark--tsuijuu {{ background:#1baf7a; }}
-.proj__dot--seiri,.gmark--seiri {{ background:#eda100; }}
-.proj__dot--anzen,.gmark--anzen {{ background:#e87ba4; }}
-.proj__dot--chousa,.gmark--chousa {{ background:#008300; }}
-.proj__dot--other,.gmark--other {{ background:#6a7382; }}
 @media (prefers-color-scheme: dark) {{
   :root {{
-    --ground:#0d0f14; --surface:#151922; --surface2:#1b202b; --line:#272d3a;
-    --ink:#e6e9f0; --muted:#8e97a7;
-    --sig:#96a6e0; --sig-soft:#1e2439; --ok:#63bd93; --ok-soft:#152a22;
-    --warn:#dcac5e; --warn-soft:#2c2415; --crit:#ef9190; --crit-soft:#2f1c1e;
-    --idle:#8e97a7; --idle-soft:#1c212b;
+    --paper:#0b0e13; --sheet:#131820; --sheet2:#1a202a; --rule:#242b37; --rule2:#1d232e;
+    --ink:#e4e8ef; --ink2:#98a2b1; --ink3:#79828f;
+    --accent:#7fc0e2; --accent-soft:#122733;
+    --ok:#5fbe91; --ok-soft:#12261d;
+    --warn:#ddab58; --warn-soft:#2a2213;
+    --crit:#f0908f; --crit-soft:#2e1a1c;
+    --sig:#7fc0e2; --sig-soft:#122733;
+    --idle:#8b95a4; --idle-soft:#1a202a;
   }}
-  .proj__dot--kiki,.gmark--kiki {{ background:#3987e5; }}
-  .proj__dot--kenshou,.gmark--kenshou {{ background:#d95926; }}
-  .proj__dot--tsuijuu,.gmark--tsuijuu {{ background:#199e70; }}
-  .proj__dot--seiri,.gmark--seiri {{ background:#c98500; }}
-  .proj__dot--anzen,.gmark--anzen {{ background:#d55181; }}
 }}
 :root[data-theme="dark"] {{
-  --ground:#0d0f14; --surface:#151922; --surface2:#1b202b; --line:#272d3a;
-  --ink:#e6e9f0; --muted:#8e97a7;
-  --sig:#96a6e0; --sig-soft:#1e2439; --ok:#63bd93; --ok-soft:#152a22;
-  --warn:#dcac5e; --warn-soft:#2c2415; --crit:#ef9190; --crit-soft:#2f1c1e;
-  --idle:#8e97a7; --idle-soft:#1c212b;
+  --paper:#0b0e13; --sheet:#131820; --sheet2:#1a202a; --rule:#242b37; --rule2:#1d232e;
+  --ink:#e4e8ef; --ink2:#98a2b1; --ink3:#79828f;
+  --accent:#7fc0e2; --accent-soft:#122733;
+  --ok:#5fbe91; --ok-soft:#12261d;
+  --warn:#ddab58; --warn-soft:#2a2213;
+  --crit:#f0908f; --crit-soft:#2e1a1c;
+  --sig:#7fc0e2; --sig-soft:#122733;
+  --idle:#8b95a4; --idle-soft:#1a202a;
 }}
-:root[data-theme="dark"] .proj__dot--kiki,:root[data-theme="dark"] .gmark--kiki{{background:#3987e5}}
-:root[data-theme="dark"] .proj__dot--kenshou,:root[data-theme="dark"] .gmark--kenshou{{background:#d95926}}
-:root[data-theme="dark"] .proj__dot--tsuijuu,:root[data-theme="dark"] .gmark--tsuijuu{{background:#199e70}}
-:root[data-theme="dark"] .proj__dot--seiri,:root[data-theme="dark"] .gmark--seiri{{background:#c98500}}
-:root[data-theme="dark"] .proj__dot--anzen,:root[data-theme="dark"] .gmark--anzen{{background:#d55181}}
+:root[data-theme="light"] {{
+  --paper:#eaedf2; --sheet:#fbfcfd; --sheet2:#f2f4f8; --rule:#d2d8e1; --rule2:#e2e6ed;
+  --ink:#11151b; --ink2:#545e6c; --ink3:#7d8695;
+  --accent:#1d5876; --accent-soft:#dde9f0;
+  --ok:#2b6b4e; --ok-soft:#dcece3;
+  --warn:#8a5709; --warn-soft:#f5e9d4;
+  --crit:#96303a; --crit-soft:#f7e0e1;
+  --sig:#1d5876; --sig-soft:#dde9f0;
+  --idle:#69727f; --idle-soft:#e5e8ee;
+}}
 
 *,*::before,*::after {{ box-sizing:border-box; }}
-body,h1,h2,h3,h4,p,ul,ol,li,table,details {{ margin:0; padding:0; }}
+body,h1,h2,h3,h4,p,ul,ol,li,table,details,figure,form {{ margin:0; padding:0; }}
 ul,ol {{ list-style:none; }}
-body {{ background:var(--ground); color:var(--ink); font-family:var(--sans); line-height:1.65;
-  -webkit-font-smoothing:antialiased; }}
-.wrap {{ max-width:1180px; margin:0 auto; padding:2rem 1.1rem 4rem;
-  display:flex; flex-direction:column; gap:1.5rem; }}
-a {{ color:var(--sig); }}
-.nowbox {{ background:var(--surface); border:1px solid var(--sig); border-radius:var(--r);
-  padding:.8rem .95rem; }}
-.now {{ display:flex; flex-direction:column; gap:.3rem; margin-top:.5rem; }}
-.now__row {{ display:flex; align-items:center; gap:.5rem; font-size:.85rem;
-  padding:.3rem .5rem; border-radius:var(--r); background:var(--surface2);
-  border-left:3px solid var(--idle); }}
-.now__row--ok{{border-left-color:var(--ok)}} .now__row--warn{{border-left-color:var(--warn)}}
-.now__row--crit{{border-left-color:var(--crit)}} .now__row--sig{{border-left-color:var(--sig)}}
-.now__row--idle {{ color:var(--muted); }}
-.now__k {{ font-family:var(--mono); font-size:.75rem; color:var(--muted); white-space:nowrap; }}
-.now__v {{ flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }}
-.now__meta {{ display:flex; flex-wrap:wrap; gap:.3rem 1.2rem; margin-top:.6rem;
-  font-size:.78rem; color:var(--muted); font-family:var(--mono); }}
-.now__meta b {{ color:var(--ink); font-weight:600; }}
-.mast {{ border-bottom:2px solid var(--ink); padding-bottom:.85rem;
-  display:flex; flex-wrap:wrap; align-items:baseline; gap:.5rem 1rem; }}
-.mast h1 {{ font-family:var(--serif); font-size:clamp(1.45rem,3vw,1.95rem); font-weight:600;
-  letter-spacing:-.01em; }}
-.mast__meta {{ font-family:var(--mono); font-size:.76rem; color:var(--muted);
-  display:flex; flex-wrap:wrap; gap:.3rem .9rem; margin-left:auto; }}
-.stats {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(132px,1fr)); gap:1px;
-  background:var(--line); border:1px solid var(--line); border-radius:var(--r); overflow:hidden; }}
-.stat {{ background:var(--surface); padding:.7rem .9rem; display:flex; flex-direction:column;
-  gap:.08rem; border-top:3px solid var(--idle); }}
-.stat--ok{{border-top-color:var(--ok)}} .stat--crit{{border-top-color:var(--crit)}}
-.stat--warn{{border-top-color:var(--warn)}} .stat--sig{{border-top-color:var(--sig)}}
-.stat__v {{ font-family:var(--mono); font-size:1.22rem; font-variant-numeric:tabular-nums;
-  letter-spacing:-.02em; }}
-.stat__l {{ font-size:.72rem; color:var(--muted); }}
-.cols {{ display:grid; grid-template-columns:1fr; gap:1.5rem; }}
-@media (min-width:920px) {{ .cols {{ grid-template-columns:1.6fr 1fr; align-items:start; }} }}
-.col {{ display:flex; flex-direction:column; gap:1.5rem; min-width:0; }}
-section {{ display:flex; flex-direction:column; gap:.65rem; }}
-h2 {{ font-family:var(--serif); font-size:1.06rem; font-weight:600;
-  display:flex; align-items:baseline; gap:.5rem; }}
-h2::after {{ content:""; flex:1; height:1px; background:var(--line); }}
-.lede {{ color:var(--muted); font-size:.82rem; margin-top:-.3rem; }}
-.empty {{ color:var(--muted); font-size:.86rem; background:var(--surface);
-  border:1px dashed var(--line); border-radius:var(--r); padding:.8rem .95rem; }}
-.card {{ background:var(--surface); border:1px solid var(--line); border-radius:var(--r); }}
-.chip {{ font-size:.71rem; padding:.08rem .46rem; border-radius:999px;
-  background:var(--idle-soft); color:var(--idle); white-space:nowrap; }}
-.chip--ok{{background:var(--ok-soft);color:var(--ok)}}
-.chip--warn{{background:var(--warn-soft);color:var(--warn)}}
-.chip--crit{{background:var(--crit-soft);color:var(--crit)}}
-.chip--sig{{background:var(--sig-soft);color:var(--sig)}}
-code {{ font-family:var(--mono); font-size:.75rem; background:var(--idle-soft);
+body {{ background:var(--paper); color:var(--ink); font-family:var(--sans);
+  font-size:16px; line-height:1.62; -webkit-font-smoothing:antialiased; }}
+a {{ color:var(--accent); }}
+a:focus-visible, button:focus-visible, summary:focus-visible, textarea:focus-visible {{
+  outline:2px solid var(--accent); outline-offset:2px; border-radius:2px; }}
+code {{ font-family:var(--mono); font-size:.78em; background:var(--idle-soft);
   padding:.06rem .3rem; border-radius:2px; }}
-.bar {{ display:flex; gap:2px; height:.48rem; }}
-.seg {{ display:block; border-radius:2px; min-width:3px; }}
-.seg--ok{{background:var(--ok)}} .seg--idle{{background:var(--idle)}}
-.seg--warn{{background:var(--warn)}} .seg--crit{{background:var(--crit)}} .seg--sig{{background:var(--sig)}}
-.asks {{ display:flex; flex-direction:column; gap:.65rem; }}
-.ask {{ background:var(--surface); border:1px solid var(--crit); border-left:4px solid var(--crit);
-  border-radius:var(--r); padding:.85rem .95rem; display:flex; flex-direction:column; gap:.4rem; }}
-.ask__head {{ display:flex; gap:.45rem; align-items:baseline; flex-wrap:wrap; }}
-.ask__id {{ font-family:var(--mono); font-size:.73rem; color:var(--muted); }}
-.ask__title {{ font-size:.99rem; font-weight:600; text-wrap:balance; }}
-.ask__effect {{ font-size:.8rem; color:var(--crit); background:var(--crit-soft);
-  align-self:flex-start; padding:.12rem .55rem; border-radius:var(--r); }}
-.ask__effect--none {{ color:var(--muted); background:var(--idle-soft); }}
-.ask__why {{ font-size:.85rem; color:var(--muted); }}
-.ask__steps summary {{ cursor:pointer; font-size:.84rem; font-weight:600; color:var(--sig);
-  padding:.25rem 0; }}
-.ask__steps ol {{ list-style:decimal; padding-left:1.35rem; display:flex; flex-direction:column;
-  gap:.35rem; font-size:.86rem; margin-top:.25rem; }}
-.ask__steps li::marker {{ color:var(--muted); font-family:var(--mono); font-size:.78rem; }}
-.ask__nosteps {{ font-size:.81rem; color:var(--warn); }}
-.ask__links a {{ font-size:.81rem; margin-right:.8rem; }}
-.ask__unblocks {{ font-size:.75rem; color:var(--muted); }}
-.chains {{ display:flex; flex-direction:column; gap:.7rem; }}
-.chain {{ background:var(--surface); border:1px solid var(--line); border-radius:var(--r);
-  padding:.75rem .85rem; display:flex; flex-direction:column; gap:.45rem; overflow-x:auto; }}
-.chain__root {{ display:flex; align-items:center; gap:.45rem; flex-wrap:wrap; }}
-.chain__badge {{ font-size:.67rem; background:var(--crit); color:var(--surface);
-  padding:.06rem .45rem; border-radius:999px; }}
-.chain__node {{ font-size:.83rem; padding:.24rem .55rem; border-radius:var(--r);
-  border:1px solid var(--line); background:var(--surface2); }}
-.chain__node--ask {{ border-color:var(--crit); background:var(--crit-soft); color:var(--crit);
-  font-weight:600; }}
-.chain__node--blocked {{ border-color:var(--warn); background:var(--warn-soft); color:var(--warn); }}
-.chain__count {{ font-size:.77rem; color:var(--muted); font-family:var(--mono); }}
-.chain__mids {{ display:flex; flex-direction:column; gap:.35rem; padding-left:1rem;
-  border-left:2px solid var(--line); margin-left:.45rem; }}
-.chain__mid {{ display:flex; flex-direction:column; gap:.25rem; }}
-.chain__leaves {{ display:flex; flex-wrap:wrap; gap:.25rem; padding-left:1rem; }}
-.chain__leaf {{ font-size:.74rem; color:var(--muted); background:var(--idle-soft);
-  padding:.12rem .42rem; border-radius:var(--r); }}
-.projs {{ display:flex; flex-direction:column; gap:.5rem; }}
-.proj {{ display:flex; gap:.55rem; background:var(--surface); border:1px solid var(--line);
-  border-radius:var(--r); padding:.65rem .85rem; }}
-.proj__dot {{ width:.58rem; height:.58rem; border-radius:2px; margin-top:.42rem; flex:none; }}
-.proj__body {{ flex:1; display:flex; flex-direction:column; gap:.25rem; min-width:0; }}
-.proj__head {{ display:flex; align-items:baseline; gap:.45rem; flex-wrap:wrap; }}
-.proj__head h3 {{ font-size:.92rem; font-weight:600; }}
-.proj__blurb {{ font-size:.77rem; color:var(--muted); }}
-.proj__n {{ font-size:.73rem; color:var(--muted); font-family:var(--mono);
-  font-variant-numeric:tabular-nums; }}
-.hl__apps {{ display:flex; align-items:center; gap:.45rem; flex-wrap:wrap; }}
-.hl__at {{ font-size:.74rem; color:var(--muted); font-family:var(--mono); }}
-.meter {{ display:flex; flex-direction:column; gap:.15rem; margin-top:.5rem; }}
-.meter__top {{ display:flex; justify-content:space-between; font-size:.79rem; gap:.5rem; }}
-.meter__v {{ font-family:var(--mono); font-size:.74rem; color:var(--muted);
-  font-variant-numeric:tabular-nums; }}
-.meter__track {{ height:.42rem; background:var(--idle-soft); border-radius:999px; overflow:hidden; }}
-.meter__fill {{ display:block; height:100%; border-radius:999px; }}
-.meter__fill--ok{{background:var(--ok)}} .meter__fill--warn{{background:var(--warn)}}
-.meter__fill--crit{{background:var(--crit)}}
-.hl__issues summary {{ cursor:pointer; font-size:.79rem; color:var(--muted); margin-top:.55rem; }}
-.hl__issues ul {{ font-size:.76rem; color:var(--muted); font-family:var(--mono);
-  display:flex; flex-direction:column; gap:.12rem; margin-top:.25rem; }}
-.gantt {{ background:var(--surface); border:1px solid var(--line); border-radius:var(--r);
-  padding:.7rem .85rem; display:flex; flex-direction:column; gap:.28rem; overflow-x:auto; }}
-.glane {{ display:grid; grid-template-columns:8.2rem 1fr 1.9rem; align-items:center; gap:.5rem;
-  min-width:28rem; }}
-.glane__label {{ font-size:.77rem; display:flex; align-items:center; gap:.3rem; white-space:nowrap; }}
-.glane__track {{ position:relative; height:.95rem; border-left:1px solid var(--line);
-  border-right:1px solid var(--line); }}
-.glane__track::before {{ content:""; position:absolute; inset:50% 0 auto 0; height:1px;
-  background:var(--line); }}
-.glane__n {{ font-family:var(--mono); font-size:.71rem; color:var(--muted); text-align:right; }}
-.gmark {{ position:absolute; top:50%; transform:translate(-50%,-50%); width:6px; height:10px;
-  border-radius:2px; box-shadow:0 0 0 2px var(--surface); }}
-.grun {{ position:absolute; top:2px; bottom:2px; width:2px; transform:translateX(-50%);
-  background:var(--muted); opacity:.45; }}
-.gantt__axis .glane__track {{ border:none; }}
-.gantt__axis .glane__track::before {{ display:none; }}
-.gtick {{ position:absolute; top:0; transform:translateX(-50%); display:flex;
-  flex-direction:column; align-items:center; }}
-.gtick i {{ width:1px; height:4px; background:var(--line); }}
-.gtick em {{ font-style:normal; font-family:var(--mono); font-size:.63rem; color:var(--muted); }}
-.run {{ background:var(--surface); border:1px solid var(--line); border-radius:var(--r);
-  padding:.55rem .8rem; }}
-.run h4 {{ font-family:var(--mono); font-size:.75rem; color:var(--sig); }}
-.run ul {{ font-size:.79rem; display:flex; flex-direction:column; gap:.12rem; margin-top:.2rem; }}
-.run li {{ padding-left:.75rem; position:relative; color:var(--muted); }}
-.run li::before {{ content:"›"; position:absolute; left:0; }}
-.done {{ display:flex; flex-direction:column; gap:.05rem; padding:.42rem .7rem;
-  background:var(--surface); border:1px solid var(--line); border-left:3px solid var(--ok);
-  border-radius:var(--r); }}
-.done a {{ font-size:.83rem; color:var(--ink); text-decoration:none; }}
-.done a:hover {{ color:var(--sig); text-decoration:underline; }}
-.done span {{ font-family:var(--mono); font-size:.69rem; color:var(--muted); }}
-.fb {{ background:var(--sig-soft); border:1px solid var(--sig); border-radius:var(--r);
-  padding:.95rem 1.05rem; display:flex; flex-direction:column; gap:.5rem; }}
-.fb h2 {{ color:var(--sig); }} .fb h2::after {{ background:var(--sig); opacity:.3; }}
-.fb p {{ font-size:.84rem; }}
-.fb__cta {{ align-self:flex-start; background:var(--sig); color:var(--surface);
-  padding:.42rem 1rem; border-radius:var(--r); text-decoration:none; font-weight:600;
-  font-size:.85rem; }}
-.fb__cta:focus-visible {{ outline:2px solid var(--ink); outline-offset:2px; }}
-.fb__meta {{ font-family:var(--mono); font-size:.73rem; color:var(--muted); }}
-.detail {{ background:var(--surface); border:1px solid var(--line); border-radius:var(--r);
-  padding:.85rem .95rem; }}
-.detail > summary {{ cursor:pointer; font-family:var(--serif); font-size:1rem; font-weight:600; }}
-.filters {{ display:flex; flex-wrap:wrap; gap:.3rem; margin:.75rem 0 .5rem; }}
-.filters button {{ font:inherit; font-size:.75rem; padding:.18rem .6rem; border-radius:999px;
-  border:1px solid var(--line); background:var(--surface2); color:var(--muted); cursor:pointer; }}
-.filters button[aria-pressed="true"] {{ background:var(--sig); color:var(--surface);
+
+.wrap {{ max-width:1120px; margin:0 auto; padding:1.6rem 1.05rem 4rem;
+  display:flex; flex-direction:column; gap:1.35rem; }}
+
+/* --- 見出し帯 --- */
+.mast {{ display:flex; flex-wrap:wrap; align-items:baseline; gap:.35rem .9rem;
+  border-bottom:2px solid var(--ink); padding-bottom:.6rem; }}
+.mast__h {{ font-family:var(--mono); font-size:1.02rem; font-weight:600;
+  letter-spacing:-.01em; }}
+.mast__stage {{ font-family:var(--mono); font-size:.74rem; color:var(--accent);
+  background:var(--accent-soft); padding:.05rem .45rem; border-radius:999px; }}
+.mast__meta {{ margin-left:auto; font-family:var(--mono); font-size:.72rem;
+  color:var(--ink3); display:flex; flex-wrap:wrap; gap:.2rem .9rem; }}
+
+.banner {{ font-size:.83rem; padding:.5rem .8rem; border-radius:var(--r); }}
+.banner--warn {{ background:var(--warn-soft); color:var(--warn);
+  border:1px solid var(--warn); }}
+.banner--ok {{ background:var(--ok-soft); color:var(--ok);
+  border:1px solid var(--ok); display:flex; align-items:center; gap:.45rem; }}
+.banner[hidden] {{ display:none; }}
+
+/* --- 脈拍 --- */
+.pulsebox {{ border:1px solid var(--rule); border-radius:var(--r); overflow:hidden;
+  background:var(--rule); display:flex; flex-direction:column; gap:1px; }}
+.pulse {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(215px,1fr));
+  gap:1px; background:var(--rule); }}
+.pulse__cell {{ background:var(--sheet); padding:.7rem .9rem .75rem;
+  display:flex; flex-direction:column; gap:.1rem; min-width:0; }}
+.pulse__k {{ font-family:var(--mono); font-size:.68rem; letter-spacing:.09em;
+  text-transform:uppercase; color:var(--ink3); }}
+.pulse__v {{ font-size:.99rem; font-weight:600; display:flex; align-items:center;
+  gap:.4rem; line-height:1.4; }}
+.pulse__s {{ font-size:.755rem; color:var(--ink2); line-height:1.45; }}
+.dot {{ width:.5rem; height:.5rem; border-radius:50%; flex:none;
+  background:var(--idle); box-shadow:0 0 0 3px var(--idle-soft); }}
+.dot--ok {{ background:var(--ok); box-shadow:0 0 0 3px var(--ok-soft); }}
+.dot--warn {{ background:var(--warn); box-shadow:0 0 0 3px var(--warn-soft); }}
+.dot--crit {{ background:var(--crit); box-shadow:0 0 0 3px var(--crit-soft); }}
+.dot--sig {{ background:var(--sig); box-shadow:0 0 0 3px var(--sig-soft); }}
+
+.prs {{ display:flex; flex-direction:column; gap:1px; background:var(--rule); }}
+.pr {{ background:var(--sheet); display:flex; align-items:center; gap:.5rem;
+  padding:.42rem .9rem; font-size:.83rem; min-width:0; }}
+.pr__t {{ flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis;
+  white-space:nowrap; color:var(--ink); text-decoration:none; }}
+.pr__t:hover {{ color:var(--accent); text-decoration:underline; }}
+.pr__n {{ font-family:var(--mono); font-size:.73rem; color:var(--ink3); }}
+
+/* --- 版面 --- */
+/* 狭い画面では書き置きを先頭に出す。順番待ちの下に置くと十数行ぶん
+   スクロールしないと辿り着けず、「セッションを開かずに残せる」意味が薄れる。 */
+.grid {{ display:flex; flex-direction:column; gap:1.35rem; min-width:0; }}
+.grid > .note {{ order:-1; }}
+.rail {{ display:flex; flex-direction:column; gap:1.35rem; min-width:0; }}
+@media (min-width:940px) {{
+  .grid {{ display:grid; grid-template-columns:minmax(0,1.8fr) minmax(0,1fr);
+    column-gap:2rem; row-gap:0; align-content:start; }}
+  .grid > .q-sec {{ grid-column:1; grid-row:1 / span 2; }}
+  .grid > .note {{ grid-column:2; grid-row:1; order:0; align-self:start; }}
+  .grid > .rail {{ grid-column:2; grid-row:2; margin-top:1.35rem; align-self:start; }}
+}}
+.sec {{ display:flex; flex-direction:column; gap:.55rem; min-width:0; }}
+.sec__h {{ display:flex; align-items:baseline; gap:.6rem; }}
+.sec__h h2 {{ font-family:var(--mono); font-size:.88rem; font-weight:600;
+  letter-spacing:.02em; white-space:nowrap; }}
+.sec__h::after {{ content:""; flex:1; height:1px; background:var(--rule); }}
+.sec__n {{ font-family:var(--mono); font-size:.72rem; color:var(--ink3);
+  font-variant-numeric:tabular-nums; order:3; }}
+.lede {{ font-size:.83rem; color:var(--ink2); }}
+.empty {{ font-size:.85rem; color:var(--ink2); border:1px dashed var(--rule);
+  border-radius:var(--r); padding:.7rem .85rem; }}
+.sub {{ font-family:var(--mono); font-size:.7rem; letter-spacing:.08em;
+  text-transform:uppercase; color:var(--ink3); margin-top:.9rem; }}
+
+.chip {{ font-family:var(--mono); font-size:.69rem; padding:.05rem .42rem;
+  border-radius:999px; background:var(--idle-soft); color:var(--idle);
+  white-space:nowrap; }}
+.chip--ok {{ background:var(--ok-soft); color:var(--ok); }}
+.chip--warn {{ background:var(--warn-soft); color:var(--warn); }}
+.chip--crit {{ background:var(--crit-soft); color:var(--crit); }}
+.chip--sig {{ background:var(--sig-soft); color:var(--sig); }}
+
+/* --- 順番待ち（台帳） --- */
+.q {{ display:flex; flex-direction:column; }}
+.q__empty {{ font-size:.85rem; color:var(--ink2); border:1px dashed var(--rule);
+  border-radius:var(--r); padding:.7rem .85rem; }}
+.q__row {{ display:grid; grid-template-columns:2.6rem minmax(0,1fr); gap:.85rem;
+  padding:.8rem .2rem .85rem 0; border-top:1px solid var(--rule2); }}
+.q__row:first-child {{ border-top:1px solid var(--rule); }}
+.q__row:target {{ background:var(--accent-soft); border-radius:var(--r);
+  padding-left:.55rem; padding-right:.55rem; }}
+.q__rank {{ font-family:var(--mono); font-size:1.32rem; font-weight:600;
+  font-variant-numeric:tabular-nums; color:var(--ink3); text-align:right;
+  line-height:1.35; letter-spacing:-.03em; }}
+.q__row--crit .q__rank {{ color:var(--crit); }}
+.q__main {{ display:flex; flex-direction:column; gap:.28rem; min-width:0; }}
+.q__head {{ display:flex; flex-wrap:wrap; align-items:baseline; gap:.45rem; }}
+.q__owner {{ font-family:var(--mono); font-size:.69rem; padding:.08rem .45rem;
+  border-radius:2px; white-space:nowrap; background:var(--idle-soft);
+  color:var(--idle); border:1px solid transparent; }}
+.q__owner--crit {{ background:var(--crit); color:var(--sheet); font-weight:600; }}
+.q__owner--sig {{ background:var(--sig-soft); color:var(--sig);
   border-color:var(--sig); }}
-.filters button:focus-visible {{ outline:2px solid var(--ink); outline-offset:2px; }}
-.tablewrap {{ overflow-x:auto; max-height:60vh; overflow-y:auto; }}
-table {{ border-collapse:collapse; width:100%; font-size:.81rem; }}
-th,td {{ text-align:left; padding:.38rem .55rem; border-bottom:1px solid var(--line);
-  vertical-align:top; }}
-th {{ font-size:.71rem; color:var(--muted); background:var(--idle-soft); position:sticky; top:0; }}
-.dt__id {{ font-family:var(--mono); font-size:.73rem; color:var(--muted); white-space:nowrap; }}
-.dt__stream {{ white-space:nowrap; color:var(--muted); font-size:.75rem; }}
-.dt__title {{ min-width:15rem; }}
-.dt__note {{ display:block; font-size:.71rem; color:var(--muted); margin-top:.12rem; }}
-.dt__pr {{ font-family:var(--mono); font-size:.73rem; white-space:nowrap; }}
-tr[hidden] {{ display:none; }}
-.detail__count {{ font-family:var(--mono); font-size:.73rem; color:var(--muted); }}
-.stale {{ background:var(--warn-soft); color:var(--warn); border:1px solid var(--warn);
-  border-radius:var(--r); padding:.45rem .8rem; font-size:.81rem; }}
-footer {{ color:var(--muted); font-size:.75rem; font-family:var(--mono);
-  border-top:1px solid var(--line); padding-top:.75rem; display:flex; flex-wrap:wrap;
-  gap:.3rem 1rem; }}
-@media (prefers-reduced-motion:reduce) {{ *{{transition:none!important;animation:none!important}} }}
+.q__owner--warn {{ background:var(--warn-soft); color:var(--warn); }}
+.q__title {{ font-size:.96rem; font-weight:600; line-height:1.5;
+  text-wrap:balance; flex:1; min-width:12rem; }}
+.q__row--crit .q__title {{ font-size:1.02rem; }}
+.q__meta {{ font-family:var(--mono); font-size:.71rem; color:var(--ink3);
+  display:flex; flex-wrap:wrap; gap:.15rem .75rem; }}
+.q__id {{ color:var(--ink2); }}
+.q__why {{ font-size:.815rem; color:var(--ink2); }}
+.q__dep {{ font-family:var(--mono); font-size:.95em; }}
+.q__more summary, .q__act summary {{ cursor:pointer; font-size:.79rem;
+  color:var(--accent); padding:.15rem 0; }}
+.q__more p {{ font-size:.8rem; color:var(--ink2); }}
+.q__impact {{ font-size:.79rem; color:var(--ink2); }}
+.q__impact b {{ color:var(--ink); }}
+.q__impact__names {{ display:block; font-size:.73rem; color:var(--ink3); }}
+.q__act {{ background:var(--sheet); border-left:2px solid var(--crit);
+  border-radius:0 var(--r) var(--r) 0; padding:.4rem .7rem .5rem; margin-top:.2rem; }}
+.q__act summary {{ color:var(--crit); font-weight:600; }}
+.q__act ol {{ list-style:decimal; padding-left:1.25rem; display:flex;
+  flex-direction:column; gap:.32rem; font-size:.83rem; margin-top:.3rem; }}
+.q__act li::marker {{ font-family:var(--mono); font-size:.76rem; color:var(--ink3); }}
+.q__links {{ margin-top:.4rem; font-size:.79rem; display:flex; flex-wrap:wrap;
+  gap:.2rem .8rem; }}
+.q__nosteps {{ font-size:.79rem; color:var(--warn); }}
+
+/* --- 書き置き --- */
+.note {{ display:flex; flex-direction:column; gap:.5rem;
+  background:var(--sheet); border:1px solid var(--accent);
+  border-top:3px solid var(--accent); border-radius:var(--r);
+  padding:.85rem .9rem .9rem; }}
+.note__h {{ font-family:var(--mono); font-size:.92rem; font-weight:600;
+  color:var(--accent); }}
+.note__p {{ font-size:.8rem; color:var(--ink2); }}
+.note textarea {{ font:inherit; font-size:.88rem; line-height:1.55; width:100%;
+  min-height:6.5rem; resize:vertical; color:var(--ink); background:var(--paper);
+  border:1px solid var(--rule); border-radius:var(--r); padding:.5rem .6rem; }}
+.note textarea::placeholder {{ color:var(--ink3); }}
+.note__foot {{ display:flex; flex-wrap:wrap; align-items:center; gap:.5rem .8rem; }}
+.note button {{ font:inherit; font-size:.85rem; font-weight:600; cursor:pointer;
+  color:var(--paper); background:var(--accent); border:1px solid var(--accent);
+  border-radius:var(--r); padding:.36rem 1.1rem; }}
+.note button:hover {{ filter:brightness(1.12); }}
+.note__alt {{ font-size:.74rem; color:var(--ink3); }}
+.note__alt a {{ color:var(--ink2); }}
+
+/* --- 計器 --- */
+.apps {{ display:flex; flex-direction:column; gap:.1rem; }}
+.app {{ display:flex; align-items:center; gap:.45rem; font-size:.79rem;
+  padding:.12rem 0; min-width:0; }}
+.app__n {{ font-family:var(--mono); flex:1; min-width:0; overflow:hidden;
+  text-overflow:ellipsis; white-space:nowrap; }}
+.app__s {{ font-size:.72rem; color:var(--ink3); }}
+.app--crit .app__s {{ color:var(--crit); }}
+.meter {{ display:flex; flex-direction:column; gap:.12rem; margin-top:.4rem; }}
+.meter__top {{ display:flex; justify-content:space-between; gap:.5rem;
+  font-size:.77rem; }}
+.meter__top span:first-child {{ overflow:hidden; text-overflow:ellipsis;
+  white-space:nowrap; font-family:var(--mono); font-size:.73rem; }}
+.meter__v {{ font-family:var(--mono); font-size:.72rem; color:var(--ink3);
+  font-variant-numeric:tabular-nums; white-space:nowrap; }}
+.meter__track {{ height:.36rem; background:var(--idle-soft); border-radius:999px;
+  overflow:hidden; }}
+.meter__fill {{ display:block; height:100%; border-radius:999px; }}
+.meter__fill--ok {{ background:var(--ok); }}
+.meter__fill--warn {{ background:var(--warn); }}
+.meter__fill--crit {{ background:var(--crit); }}
+.fold {{ margin-top:.7rem; }}
+.fold > summary {{ cursor:pointer; font-size:.78rem; color:var(--ink2); }}
+.kv {{ display:flex; flex-direction:column; gap:.08rem; margin-top:.3rem;
+  font-family:var(--mono); font-size:.73rem; color:var(--ink3); }}
+.kv li {{ display:flex; justify-content:space-between; gap:.6rem; }}
+.kv b {{ color:var(--ink2); font-weight:600; font-variant-numeric:tabular-nums; }}
+
+/* --- 記録 --- */
+.dn {{ display:flex; flex-direction:column; gap:.02rem; padding:.35rem 0;
+  border-top:1px solid var(--rule2); }}
+.dn:first-child {{ border-top:none; }}
+.dn a {{ font-size:.81rem; color:var(--ink); text-decoration:none; }}
+.dn a:hover {{ color:var(--accent); text-decoration:underline; }}
+.dn span {{ font-family:var(--mono); font-size:.69rem; color:var(--ink3); }}
+.jr {{ padding:.45rem 0; border-top:1px solid var(--rule2); }}
+.jr:first-child {{ border-top:none; }}
+.jr h4 {{ font-family:var(--mono); font-size:.74rem; color:var(--accent); }}
+.jr ul {{ font-size:.78rem; display:flex; flex-direction:column; gap:.1rem;
+  margin-top:.15rem; }}
+.jr li {{ padding-left:.8rem; position:relative; color:var(--ink2); }}
+.jr li::before {{ content:"›"; position:absolute; left:0; color:var(--ink3); }}
+
+/* --- 全タスク --- */
+.archive {{ border-top:1px solid var(--rule); padding-top:.8rem; }}
+.archive > summary {{ cursor:pointer; font-family:var(--mono); font-size:.85rem;
+  font-weight:600; }}
+.filters {{ display:flex; flex-wrap:wrap; gap:.3rem; margin:.7rem 0 .4rem; }}
+.filters button {{ font:inherit; font-family:var(--mono); font-size:.73rem;
+  padding:.15rem .6rem; border-radius:999px; border:1px solid var(--rule);
+  background:var(--sheet2); color:var(--ink2); cursor:pointer; }}
+.filters button[aria-pressed="true"] {{ background:var(--accent);
+  border-color:var(--accent); color:var(--paper); }}
+.acount {{ font-family:var(--mono); font-size:.72rem; color:var(--ink3); }}
+.tablewrap {{ overflow-x:auto; max-height:62vh; overflow-y:auto;
+  border:1px solid var(--rule); border-radius:var(--r); margin-top:.4rem; }}
+.tablewrap table {{ border-collapse:collapse; width:100%; font-size:.79rem;
+  background:var(--sheet); }}
+.tablewrap th, .tablewrap td {{ text-align:left; padding:.34rem .55rem;
+  border-bottom:1px solid var(--rule2); vertical-align:top; }}
+.tablewrap th {{ font-family:var(--mono); font-size:.7rem; color:var(--ink3);
+  background:var(--sheet2); position:sticky; top:0; z-index:1; }}
+.at__id {{ font-family:var(--mono); font-size:.72rem; color:var(--ink3);
+  white-space:nowrap; }}
+.at__kind {{ white-space:nowrap; color:var(--ink3); font-size:.74rem; }}
+.at__title {{ min-width:16rem; }}
+.at__note {{ display:block; font-size:.71rem; color:var(--ink3); margin-top:.1rem; }}
+.at__pr {{ font-family:var(--mono); font-size:.72rem; white-space:nowrap; }}
+.tablewrap tr[hidden] {{ display:none; }}
+
+footer {{ color:var(--ink3); font-size:.73rem; font-family:var(--mono);
+  border-top:1px solid var(--rule); padding-top:.7rem;
+  display:flex; flex-wrap:wrap; gap:.25rem 1.1rem; }}
+@media (prefers-reduced-motion:reduce) {{
+  * {{ transition:none !important; animation:none !important; }}
+}}
 </style>
 </head>
 <body>
 
 <div class="wrap">
   <header class="mast">
-    <h1>autopilot — homelab 当直記録</h1>
-    <span class="chip chip--sig">段階 {stage}・{stage_label}</span>
-    <span class="mast__meta"><span>{cadence}</span><span>生成 {generated}</span></span>
+    <span class="mast__h">autopilot — homelab 当直記録</span>
+    <span class="mast__stage">段階 {stage}・{stage_label}</span>
+    <span class="mast__meta"><span>巡回 {cadence}</span><span>生成 {generated}</span></span>
   </header>
 
+  <p class="banner banner--ok" id="sent" hidden>書き置きを預かりました。次の巡回で読まれます。</p>
+
   {stale}
+  {pulse}
 
-  <div class="stats">
-    <div class="stat stat--{alive_tone}"><span class="stat__v">{alive_text}</span>
-      <span class="stat__l">ループの状態（最終起動 {last_run}）</span></div>
-    <div class="stat stat--crit"><span class="stat__v">{n_asks}</span>
-      <span class="stat__l">あなたにお願いしたいこと</span></div>
-    <div class="stat stat--warn"><span class="stat__v">{n_blocked}</span>
-      <span class="stat__l">詰まっているもの</span></div>
-    <div class="stat stat--ok"><span class="stat__v">{n_done} / {n_total}</span>
-      <span class="stat__l">完了したタスク</span></div>
-    <div class="stat stat--sig"><span class="stat__v">{n_runs}</span>
-      <span class="stat__l">これまでの起動</span></div>
-  </div>
+  <div class="grid">
+    <section class="sec q-sec">
+      <div class="sec__h"><h2>順番待ち</h2><span class="sec__n">{n_queue} 件・優先度順</span></div>
+      <p class="lede">{lede}</p>
+      <ol class="q">{queue}</ol>
+    </section>
 
-  <section class="nowbox">
-    <h2>いま動いているもの</h2>
-    {now}
-  </section>
+    <form class="note" method="post" action="/feedback">
+        <h2 class="note__h">書き置き</h2>
+        <p class="note__p">殴り書きで構いません。指示も苦情も、ここに残せばセッションを開かずに届きます。</p>
+        <textarea name="body" required rows="5" maxlength="20000"
+          aria-label="autopilot への書き置き"
+          placeholder="例: ダッシュボードのここが見づらい / immich の写真が開けない / 今週は触らないで"></textarea>
+      <div class="note__foot">
+        <button type="submit">送る</button>
+        <span class="note__alt">届かないときは
+          <a href="{fb_url}">issue #{fb_issue}</a>（最後に読んだ: {fb_read}）</span>
+      </div>
+    </form>
 
-  <div class="cols">
-    <div class="col">
-      <section>
-        <h2>あなたにお願いしたいこと</h2>
-        <p class="lede">autopilot には手が届かない作業だけです。判断を求めることはありません。</p>
-        <ul class="asks">{asks}</ul>
+    <div class="rail">
+      <section class="sec">
+        <div class="sec__h"><h2>homelab の計器</h2></div>
+        {cluster}
       </section>
 
-      <section>
-        <h2>何が何を止めているか</h2>
-        <p class="lede">左のひとつが済むと、右の連鎖がまとめて動き出します。</p>
-        {chain}
+      <section class="sec">
+        <div class="sec__h"><h2>反映された変更</h2></div>
+        <ul>{done}</ul>
       </section>
 
-      <section>
-        <h2>いま進んでいること</h2>
-        <p class="lede">大きい流れごとの進み具合。個々のタスクは下の「詳細」にあります。</p>
-        <ul class="projs">{projects}</ul>
-      </section>
-
-      <section>
-        <h2>これまでの流れ</h2>
-        <p class="lede">印ひとつが homelab に反映された変更 1 件。横位置が時刻（UTC）。</p>
-        {gantt}
-      </section>
-    </div>
-
-    <div class="col">
-      <section class="card" style="padding:.85rem .95rem">
-        <h2>homelab の今</h2>
-        {health}
-      </section>
-
-      <section class="fb">
-        <h2>気づいたことを書く</h2>
-        <p>殴り書きで構いません。進め方への指摘は憲章に、やってほしいことはタスクとして取り込まれます。
-           読んだら 3 行以内で返信します。</p>
-        <a class="fb__cta" href="{fb_url}">issue #{fb_issue} に書く</a>
-        <span class="fb__meta">最後に読んだ: {fb_read}</span>
-      </section>
-
-      <section>
-        <h2>最近やったこと</h2>
-        <ul class="projs">{done}</ul>
-      </section>
-
-      <section>
-        <h2>直近の起動</h2>
-        <ul class="projs">{runs}</ul>
+      <section class="sec">
+        <div class="sec__h"><h2>直近の当直</h2></div>
+        <ul>{runs}</ul>
       </section>
     </div>
   </div>
 
-  <details class="detail">
-    <summary>タスクの詳細を開く（{n_total} 件）</summary>
+  <details class="archive">
+    <summary>全タスクを開く（{n_total} 件、うち完了 {n_done} 件）</summary>
     <div class="filters" role="group" aria-label="状態で絞り込む">
       <button type="button" data-f="all" aria-pressed="true">すべて</button>
       <button type="button" data-f="needs-human" aria-pressed="false">あなた待ち</button>
@@ -995,29 +1102,31 @@ footer {{ color:var(--muted); font-size:.75rem; font-family:var(--mono);
       <button type="button" data-f="todo" aria-pressed="false">待ち</button>
       <button type="button" data-f="in_progress" aria-pressed="false">作業中</button>
       <button type="button" data-f="done" aria-pressed="false">完了</button>
+      <button type="button" data-f="dropped" aria-pressed="false">取り下げ</button>
     </div>
-    <p class="detail__count" id="dcount"></p>
+    <p class="acount" id="acount"></p>
     <div class="tablewrap">
       <table>
-        <thead><tr><th>ID</th><th>状態</th><th>流れ</th><th>内容</th><th>PR</th></tr></thead>
-        <tbody id="dbody">{detail}</tbody>
+        <thead><tr><th>ID</th><th>状態</th><th>種別</th><th>内容</th><th>PR</th></tr></thead>
+        <tbody id="abody">{archive}</tbody>
       </table>
     </div>
   </details>
 
   <footer>
-    <span>hikuohiku/homelab</span>
-    <a href="https://github.com/hikuohiku/homelab/blob/main/ops/VISION.md">VISION</a>
-    <a href="https://github.com/hikuohiku/homelab/blob/main/ops/CHARTER.md">CHARTER</a>
-    <a href="https://github.com/hikuohiku/homelab/tree/main/ops/journal">journal</a>
+    <span>{repo}</span>
+    <a href="https://github.com/{repo}/blob/main/ops/VISION.md">VISION</a>
+    <a href="https://github.com/{repo}/blob/main/ops/CHARTER.md">CHARTER</a>
+    <a href="https://github.com/{repo}/tree/main/ops/journal">journal</a>
   </footer>
 </div>
 
 <script>
+/* 絞り込みだけ。ページの情報は JS 無しで全部読める（書き置きの送信も含む） */
 (function () {{
   var btns = Array.prototype.slice.call(document.querySelectorAll('.filters button'));
-  var rows = Array.prototype.slice.call(document.querySelectorAll('#dbody tr'));
-  var count = document.getElementById('dcount');
+  var rows = Array.prototype.slice.call(document.querySelectorAll('#abody tr'));
+  var count = document.getElementById('acount');
   function apply(f) {{
     var n = 0;
     rows.forEach(function (r) {{
@@ -1036,33 +1145,15 @@ footer {{ color:var(--muted); font-size:.75rem; font-family:var(--mono);
   apply('all');
 }})();
 
-// 経過時間と次回起動までを 1 秒ごとに更新する（データは静的だが、鮮度は生きた表示にする）
+/* 送信後にバックエンドが 303 で /?feedback=ok に戻す。受け取った印を出し、
+   再読み込みで残らないよう URL からは落とす。JS 無効なら出ないだけ（送信は成立する） */
 (function () {{
-  function fmt(sec) {{
-    if (sec < 0) sec = 0;
-    if (sec < 60) return Math.floor(sec) + ' 秒';
-    if (sec < 3600) return Math.floor(sec / 60) + ' 分';
-    return Math.floor(sec / 3600) + ' 時間 ' + Math.floor((sec % 3600) / 60) + ' 分';
+  if (window.location.search.indexOf('feedback=ok') === -1) return;
+  var el = document.getElementById('sent');
+  if (el) el.hidden = false;
+  if (window.history && window.history.replaceState) {{
+    window.history.replaceState(null, '', window.location.pathname);
   }}
-  var els = Array.prototype.slice.call(document.querySelectorAll('[data-since]'));
-  var next = document.getElementById('nextrun');
-  function tick() {{
-    var now = Date.now();
-    els.forEach(function (el) {{
-      var t = Date.parse(el.getAttribute('data-since'));
-      if (isNaN(t)) {{ el.textContent = '—'; return; }}
-      el.textContent = fmt((now - t) / 1000) + '前';
-    }});
-    if (next) {{
-      var d = new Date(now);
-      var mins = d.getUTCMinutes(), secs = d.getUTCSeconds();
-      var until = ((19 - mins + 60) % 60) * 60 - secs;
-      if (until <= 0) until += 3600;
-      next.textContent = fmt(until);
-    }}
-  }}
-  tick();
-  setInterval(tick, 1000);
 }})();
 </script>
 </body>
@@ -1147,4 +1238,4 @@ if __name__ == "__main__":
         except Exception as e:  # noqa: BLE001 — push 失敗させても HTML 生成自体は成功のまま終える
             print(f"warning: {DASHBOARD_BRANCH} への publish に失敗 ({e})", file=sys.stderr)
         else:
-            print(f"published to {DASHBOARD_BRANCH} branch")
+            print(f"published to branch {DASHBOARD_BRANCH}")


### PR DESCRIPTION
利用者の指摘: 「ダッシュボードのUIも全然見やすくない」「積んであるプロジェクトは優先度順に可視化して欲しい」

## 何が見づらかったか（生成して読んで特定）

- **「次に何が来るか」がどこにも無かった。** `priority` はデータにあるのに画面に一切出ていない。唯一のタスク一覧は `<details>` に畳まれた 152 行のテーブルで、**その 130 行が `done`**。順番待ちの実体（needs-human 8 / blocked 7 / todo 2）は読み取れない
- **同じ情報が 3 回出ていた**（stat タイル・ask カード・連鎖図）
- **最大の図が何にも答えていなかった。** ガントは merge 済み PR 60 個の点描で、「作業が起きた」以上の情報が無い
- **統計タイル 5 枚中 3 枚が虚栄値**（行動につながらない累積カウンタ）
- 密度が一様で、12 セクションが全部同じ大きさ。数秒では読めない
- フィードバックがページを離れる操作だった

## どう直したか

**順番待ちを主役に。** オープンな 17 件を `priority` 昇順で全部行として出す。行頭に**誰待ちか**を語で示す（あなた / autopilot / 他タスク待ち / 条件待ち / 時刻待ち）。あなた待ちの行は手順を開いた状態で表示。`blocked_by` の `T-xxxx` は同じ画面内の行へのアンカーにして `:target` で強調した（連鎖図の代わり。JS 不要で実際に辿れる）。

**脈拍帯**を最上部に 4 セル（ループ / アプリ / 出している変更 / autopilot 自身）。「いま何が起きているか」はここで完結する。

ガント・連鎖図・ストリーム進捗バー・識別色 7 種は削除。色は「誰待ちか」と正常/注意/異常にだけ使う。

**書き置きフォーム**を右レール先頭に置いた（狭い画面では最上部）。素の form で JS 無しでも成立する。#352 のバックエンドと接続する。

## ついでに見つかった実バグ 4 件

1. **PVC 使用量の分母にノードの `ephemeral-storage`（48.9 GiB）を使っていた。** health レポートの `notes` 自身が「ルート FS の大きさではない、使うな」と書いている値。PVC ごとの要求容量を分母にする表示へ
2. **autopilot のハング判定を `now()` 基準で測っていた。** レポートが古いだけで誤検知する。実際に旧出力は `iteration #42 が 562 分実行中（ハングの疑い）` と出していた。レポートの `generated_at` 基準に変更
3. `#nextrun` が「毎時 19 分」を決め打ちでカウントダウンしていた。その cloud routine は `enabled: false`。削除
4. **`human_action.steps` を無エスケープで挿入していた。** T-0112 の `kubectl logs -n immich <pod>` の `<pod>` がタグとして解釈され、以降の入れ子が壊れていた。インラインタグのホワイトリスト方式に

## 検証

生成成功、`<!doctype html>` 開始 `</html>` 終端、`HTMLParser` で閉じ残り 0・対応しない終了タグ 0。空 backlog / health 未着 / 壊れた数量表記 / `<script>` 混入タイトルの各劣化入力でも整形式の文書を出す。`<pod>` がエスケープされていることも確認済み。

**未確認: 実ブラウザでのレンダリング。** この環境にブラウザが無く、`ops-dashboard.tailae6c2.ts.net` は tailnet ピアでないと到達できない（T-0148 として既知）。ライト/ダークの実見えと折返しは見ていない。