### PR TITLE
ops(run #158): T-0153/T-0154 起票、run #157 の重複 PR を解消

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_id": 153,
+  "next_id": 155,
   "updated": "2026-08-06T11:49:11Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
@@ -2908,6 +2908,51 @@
       "created": "2026-08-06",
       "pr": 348,
       "notes": "run #153（計画役）: ops/inbox.md の引き継ぎ（run #152 実行役の気づき、T-0149 dropped の教訓）を起票。 実行役（run #156）: CHARTER §4 バージョン更新の作法に、inventory.json の note の除外指定を新タグ発見時に必ず読み合わせる旨を明文化して完遂。専用の自動チェックスクリプトは対象外（『新しいタグの有無』の判定自体が upstream 調査に依存し機械的な突き合わせの対象データが無いため、CHARTER の手順記述のみで DoD を満たす）。"
+    },
+    {
+      "id": "T-0153",
+      "domain": "homelab",
+      "title": "autopilot 自身のコンテナイメージ (apps/autopilot/deployment.yaml) が ops/inventory.json の監視対象外で、Dockerfile 変更と digest pin のずれを誰も検出できない",
+      "kind": "ci",
+      "risk": "low",
+      "status": "todo",
+      "priority": 15,
+      "why": "apps/autopilot/deployment.yaml は images/autopilot/Dockerfile を .github/workflows/build-autopilot-image.yml でビルドした ghcr.io/hikuohiku/homelab-autopilot の digest を手動 pin している（コメントに『Dockerfile の内容を変えたら、ビルドが終わった後この digest も手で更新する』と明記）。ops-health-reporter-image/ops-dashboard-image/pvc-usage-reporter-image は ops/inventory.json に登録され check_version_sync.py 相当の監視対象だが、autopilot 自身のこのイメージだけ inventory.json にエントリが無く、CI にも images/autopilot/** の変更と deployment.yaml の image 行変更を突き合わせる仕組みが無い。Dockerfile を変えた PR で digest 更新を忘れると、ワークフローは新しいイメージを push するのに Deployment は古いイメージを参照し続け、クラスタは古い autopilot のまま気づかれずに動く。全システムの正しさの根拠となる自分自身のイメージがこの唯一の抜けになっている（計画役 run #157 相当、subagent 調査で発見）",
+      "dod": "images/autopilot/** を変更した PR で apps/autopilot/deployment.yaml の image 行（digest）も同じ PR で変更されていることを CI で検証する仕組みを追加する（ops/check_manifest_deletions.py や check_version_sync.py に相乗りさせるか新規スクリプトにするかは実装時に判断してよい）。あわせて ops/inventory.json に autopilot-image エントリを追加するか、digest pin の性質上 inventory.json のフォーマット（current/upstream 比較）に馴染まないなら理由を notes に書いて見送る。意図的に Dockerfile だけ変えて digest を更新しない diff を作り、CI が検出することを確認する",
+      "needs_human_reason": null,
+      "blocked_by": null,
+      "refs": [
+        "apps/autopilot/deployment.yaml",
+        "images/autopilot/Dockerfile",
+        ".github/workflows/build-autopilot-image.yml",
+        "ops/inventory.json",
+        "ops/check_version_sync.py"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": null
+    },
+    {
+      "id": "T-0154",
+      "domain": "homelab",
+      "title": "ops/review-log.md の R-NNN と backlog タスクの起票状態の突き合わせが手作業（LLM 判断）任せで、機械検証が無い",
+      "kind": "ci",
+      "risk": "low",
+      "status": "todo",
+      "priority": 55,
+      "why": "PR #353（人間、run #157 直後に merge）で追加されたレビュー役の仕組み（ops/CHARTER.md §3、ops/review-log.md）は、レビュー役が書く R-NNN エントリの `状態`（未処理/起票済 T-XXXX/完了/却下）と、計画役が起票する task の `why` に含める R-NNN 参照が食い違わないことを、CHARTER の手順記述と計画役の注意力だけに頼っている。T-0145（journal run 番号と state.json runs 配列の追随）と構造的に同型の『2箇所が一致しているはずだが機械検証が無い』パターンで、review-log.md/inbox.md/ops/validate.py いずれにも R-NNN や review-log.md への参照は無い（計画役 run #157 相当、subagent 調査で確認）。レビュー役はまだ一度も実行されていない（REVIEW_EVERY=12、直近の run は #157）ため今は実害が無いが、初回実行後に放置すると T-0145 と同じ経路で気づかれないまま乖離する",
+      "dod": "ops/validate.py に ops/review-log.md をパースし、(a) `状態: 起票済 T-XXXX` のエントリについて対応する task が backlog.json に存在し、task の `why` にその R-NNN が含まれているか、(b) backlog.json の task の `why` に R-NNN 参照があるのに review-log.md 側にその id のエントリが無い、の食い違いを検出するチェックを追加する。レビュー役がまだ一度も実行されておらず review-log.md に実データが無いため、意図的に食い違うダミーエントリを一時的に追加して検出できることを確認したうえで元に戻す。初回は warning 扱いとし（新しい運用のため誤検出の余地を残す）、数サイクル運用して安定したら error 昇格を検討する旨を notes に残す",
+      "needs_human_reason": null,
+      "blocked_by": null,
+      "refs": [
+        "ops/review-log.md",
+        "ops/inbox.md",
+        "ops/validate.py",
+        "ops/CHARTER.md"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": null
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,34 @@
   "open": [],
   "merged": [
     {
+      "number": 354,
+      "title": "feat(ops): ダッシュボードを順番待ち中心に作り直す",
+      "url": "https://github.com/hikuohiku/homelab/pull/354",
+      "mergedAt": "2026-08-06T12:31:50Z",
+      "headRefName": "autopilot/dashboard-redesign"
+    },
+    {
+      "number": 353,
+      "title": "feat(autopilot): レビュー役を追加する（利用者視点・アーキテクチャ）",
+      "url": "https://github.com/hikuohiku/homelab/pull/353",
+      "mergedAt": "2026-08-06T12:27:57Z",
+      "headRefName": "autopilot/reviewer-roles"
+    },
+    {
+      "number": 350,
+      "title": "chore(ops): run #157 記録更新（新規タスク着手なし）",
+      "url": "https://github.com/hikuohiku/homelab/pull/350",
+      "mergedAt": "2026-08-06T12:27:09Z",
+      "headRefName": "autopilot/run157-record-only"
+    },
+    {
+      "number": 352,
+      "title": "feat(ops-dashboard): ダッシュボードから autopilot へ指示を残せるようにする",
+      "url": "https://github.com/hikuohiku/homelab/pull/352",
+      "mergedAt": "2026-08-06T12:25:17Z",
+      "headRefName": "autopilot/dashboard-feedback-intake"
+    },
+    {
       "number": 348,
       "title": "docs(T-0152): inventory の note 除外指定を新タグ確認時に読み合わせる運用を明文化",
       "url": "https://github.com/hikuohiku/homelab/pull/348",
@@ -392,34 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/293",
       "mergedAt": "2026-08-06T04:39:35Z",
       "headRefName": "autopilot/T-0128-python-http-server"
-    },
-    {
-      "number": 294,
-      "title": "docs(ops): 計画役 run #102 の記録更新（backlog 見直し・inventory 調査）",
-      "url": "https://github.com/hikuohiku/homelab/pull/294",
-      "mergedAt": "2026-08-06T04:34:12Z",
-      "headRefName": "autopilot/plan-run102-backlog-review"
-    },
-    {
-      "number": 292,
-      "title": "revert: ops-dashboard httpd CrashLoopBackOff を revert (T-0128)",
-      "url": "https://github.com/hikuohiku/homelab/pull/292",
-      "mergedAt": "2026-08-06T04:12:41Z",
-      "headRefName": "autopilot/T-0128-revert-broken-httpd"
-    },
-    {
-      "number": 291,
-      "title": "feat(ops-dashboard): dashboard index.html を tailscale 経由で配信する (T-0128)",
-      "url": "https://github.com/hikuohiku/homelab/pull/291",
-      "mergedAt": "2026-08-06T03:56:01Z",
-      "headRefName": "autopilot/T-0128-ops-dashboard-hosting"
-    },
-    {
-      "number": 290,
-      "title": "feat(ops): dashboard HTML を ops-dashboard ブランチへ自動 push する (T-0127)",
-      "url": "https://github.com/hikuohiku/homelab/pull/290",
-      "mergedAt": "2026-08-06T03:44:51Z",
-      "headRefName": "autopilot/T-0127-dashboard-publish-branch"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4508,3 +4508,47 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py` を実行し 0 error であることを確認
 - 次の起動へ: backlog の todo は引き続き T-0117 のみ（`not_before` 到来まで数時間）。次の起動が
   計画役なら調査タスクの起票を検討すること
+
+## 2026-08-06 21:34 JST — run #158（計画役）
+
+- 前回の中断確認: オープン PR が3件残っていた。#350（run #157 実行役の記録）と #351（run #157
+  計画役の記録）が、同じ in-cluster loop から同時刻に起動した異なるセッションによる同一 run 番号
+  （#157）の重複記録と判明（`ops/journal/2026-08.md`/`ops/state.json` の同じ末尾に追記する内容で
+  base commit も同一）。#350 を先に merge し（CI green・`mergeable_state: clean`）、#351 は
+  merge しようとしたところ `405 merge conflicts` で失敗したため、内容（フィードバック・健全性・
+  backlog 棚卸しに新規異常/新規タスク無し）を issue #351 のコメントで説明したうえで close し、
+  ブランチも削除した。#352（`feat(ops-dashboard): ダッシュボードから autopilot へ指示を残せる
+  ようにする`）は author が `hikuohiku`（人間）本人と確認できたため、autopilot の作業対象外として
+  一切触れず放置。その後 #353（同じく人間、レビュー役 3 種の仕組み追加）とあわせて main に merge
+  済みと確認
+- 読んだフィードバック: issue #56 を `per_page=100` で2ページ（計109件）確認、`last_read`
+  （2026-08-06T12:11:00Z）以降の新規コメント無し。依頼中の issue #35・#37 も未回答のまま変化なし
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T12:00:10Z`、30分強で境界付近だが
+  新規異常なし）で ArgoCD 13 アプリ中 `coder`/`immich`/`vaultwarden` が Degraded。従来どおり
+  T-0106 由来の既知 `SecretSyncedError` のみと確認。`pod_issues` の restarts:19 常連（既知）も
+  変化なし。autopilot 自身の heartbeat も正常（`readyReplicas` 1、`last_end` iteration #30
+  exit_code 0）
+- `ops/inbox.md`: 空。変換対象なし
+- backlog の棚卸し: blocked 7件・needs-human 8件全ての理由を確認したが、直前の run #154/#150 から
+  状況変化なし。T-0112（pods/log 権限が無い）の前提を `kubectl auth can-i get pods
+  --subresource=log -A` で自分でも再確認し、依然 `no`
+- **人間が run #157 の直後（同時刻帯）に自力で PR #353 を merge し、autopilot にレビュー役
+  （利用者視点／アーキテクチャ視点の2レンズ、`REVIEW_EVERY=12`）を追加した**と判明。
+  `ops/CHARTER.md` §3・`ops/review-log.md`・`apps/autopilot/prompt-review-{user,arch}.md` が
+  新設され、`ops/inbox.md` のヘッダーも「実行役・レビュー役から計画役への引き継ぎ」に更新済み。
+  レビュー役はまだ一度も実行されていない（次回 `REVIEW_EVERY` 到達時）
+- やったこと: backlog の todo が T-0117（`not_before` 未到来）のみで着手可能な新規タスクが無かった
+  ため、CHARTER §3 に従い subagent に新しい調査観点探し（既存 backlog の131件の done タスクと
+  重複しない角度）を依頼し、2件発見・起票:
+  - T-0153: autopilot 自身のコンテナイメージ（`apps/autopilot/deployment.yaml` の digest pin）が
+    `ops/inventory.json`/`check_version_sync.py` の監視対象外で、`images/autopilot/Dockerfile`
+    変更後の digest 更新漏れを機械検出する仕組みが無い
+  - T-0154: 新設されたレビュー役の `ops/review-log.md`（R-NNN 台帳）と backlog タスクの起票状態の
+    突き合わせが CHARTER の手順記述と計画役の注意力だけに依存しており、`ops/validate.py` に
+    機械検証が無い（T-0145 と同型のパターン）。レビュー役が未実行のため実害は無いが、先に
+    仕組みを用意しておく
+  - subagent はダッシュボードがレビュー役の指摘を表示しない件も見つけたが、利用者視点レンズが
+    初回実行時に自己発見しうる領域と判断し、今回は起票を見送った
+- `python3 ops/validate.py` を実行し 0 error / 0 warning であることを確認
+- 次の起動へ: backlog の todo は T-0153・T-0154（着手可能）と T-0117（`not_before`
+  2026-08-07T03:30 JST 到来までまだ数時間）の3件。次の実行役は T-0153 または T-0154 から着手できる

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T12:11:00Z",
+  "updated": "2026-08-06T12:34:00Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T12:11:00Z"
+    "last_read": "2026-08-06T12:34:00Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc",
@@ -1435,6 +1435,14 @@
       "kind": "in_cluster_loop",
       "by": "in-cluster autopilot (executor)",
       "summary": "実行役（journal run #157）。前回の中断PR #348（T-0152）を merge。issue #56 に新規フィードバック無し。健全性確認で新規異常無し（coder/immich/vaultwardenのDegradedは既知のT-0106由来）。backlog todoはT-0117のみでnot_before未到来のため新規タスク着手無し。",
+      "prs": []
+    },
+    {
+      "n": 158,
+      "at": "2026-08-06T12:34:00Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (計画役)",
+      "summary": "計画役（journal run #158）。run #157 の重複記録（#350/#351）を発見し #350 merge・#351 close で解消。人間が同時刻に PR #353 でレビュー役の仕組みを追加したと確認。フィードバック・健全性に新規異常無し、inbox 空、backlog blocked/needs-human 全15件は前提変化なし。todo が枯れていたため subagent 調査で T-0153（autopilot 自身のイメージが inventory 監視対象外）・T-0154（review-log.md と backlog の突き合わせに機械検証が無い）の2件を新規起票。",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

計画役（journal run #158）の運用記録のみ。コード・マニフェストの変更は無い。

- run #157 の重複記録 PR（#350 実行役 / #351 計画役。同一 in-cluster loop の異なるセッションが同時刻に同じ run 番号で起動していた）を発見。#350 を merge、#351 は merge 後に conflict したため close（内容自体は独立に再検証済み、実質的な差分は失われていない）
- issue #56 の未読フィードバック無し（last_read 以降新規コメント0件）
- `ops-health-report` に新規異常無し（coder/immich/vaultwarden の Degraded は T-0106 由来の既知事象のみ）
- `ops/inbox.md` は空
- backlog の blocked 7件・needs-human 8件全ての理由を棚卸ししたが前提の変化なし
- todo が枯れていた（`not_before` 未到来の T-0117 のみ）ため、subagent に新しい調査観点探しを依頼し2件起票:
  - **T-0153**: autopilot 自身のコンテナイメージ（`apps/autopilot/deployment.yaml` の digest pin）が `ops/inventory.json`/`check_version_sync.py` の監視対象外。`images/autopilot/Dockerfile` を変更した PR で digest 更新を忘れても機械検出できない
  - **T-0154**: 直前に人間が追加したレビュー役の仕組み（`ops/review-log.md` の R-NNN 台帳）と backlog の起票状態の突き合わせが CHARTER の手順記述任せで、`ops/validate.py` に機械検証が無い（T-0145 と同型）

副次的に、人間自身が run #157 の直後に PR #353（レビュー役3種の追加、利用者視点／アーキテクチャ視点）を merge していたと確認した。この PR には触れていない。

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 正常終了、`ops-dashboard` ブランチへ publish 済み
- ドキュメント・運用記録のみの変更（コード・manifest の変更なし）

## ロールバック手順

この branch の commit を revert すれば journal/state.json/backlog.json/dashboard キャッシュの追記が元へ戻る（T-0153/T-0154 は起票取り消しになる）。DB や実インフラへの変更は無いため、コードと状態の revert に不整合は残らない。

## backlog task id

T-0153, T-0154（本 PR で新規起票。実装は次の実行役）