### PR TITLE
ci(autopilot): images/autopilot 変更時の digest 更新漏れ検出スクリプトを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,9 @@ jobs:
           printf '%s' "$PR_BODY" > /tmp/pr_body.txt
           python3 head/ops/check_manifest_deletions.py base head /tmp/pr_body.txt
 
+      - name: Check autopilot image digest pin is updated alongside its Dockerfile
+        run: python3 head/ops/check_autopilot_image_pin.py base head
+
   terraform:
     name: terraform validate
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,9 +115,6 @@ jobs:
           printf '%s' "$PR_BODY" > /tmp/pr_body.txt
           python3 head/ops/check_manifest_deletions.py base head /tmp/pr_body.txt
 
-      - name: Check autopilot image digest pin is updated alongside its Dockerfile
-        run: python3 head/ops/check_autopilot_image_pin.py base head
-
   terraform:
     name: terraform validate
     runs-on: ubuntu-latest

--- a/ops/CHARTER.md
+++ b/ops/CHARTER.md
@@ -648,6 +648,15 @@ upstream リポジトリのファイル（例: `deploy/crds/bundle.yaml` のよ�
     close だけでは残る」対応を、この substrate では今後実際に実行できる。旧サンドボックス時代に
     残った孤児ブランチ（`git branch -r` で確認できるもの）の掃除は、内容が main と重複している
     ことを確認できたものから順に削除してよい
+- **`.github/workflows/**` を変更するコミットは `git push` 自体が拒否される。** `AUTOPILOT_GITHUB_TOKEN`
+  は classic PAT で `workflow` scope を持たず、GitHub 側が
+  `refusing to allow a Personal Access Token to create or update workflow ... without \`workflow\` scope`
+  で push を fail-closed に拒否する（2026-08-06 run #159 実測、T-0153）。旧サンドボックスの
+  §5.2「`.github/workflows/*.yml` は書けるが ruleset は書けない」は GitHub App の `workflows` 権限
+  前提の話で、この substrate の PAT ベースの credential には当てはまらない。CI に新しい検証を
+  足したいのに配線（ワークフロー側の1ステップ追加）だけが必要なときは、検証スクリプト本体は
+  実装・動作確認まで済ませて PR に含め、ワークフローファイルへの追記だけを `needs-human`
+  （`needs_human_reason` に追加すべき YAML の具体的な差分を書く）として切り出す
 - **`kubectl` が実際に動く。** in-cluster ServiceAccount `autopilot` + 専用 ClusterRole
   `autopilot-reader`（`apps/autopilot/rbac.yaml`）で、`get`/`list` のみ・書き込み動詞は無し。
   読めるもの: `pods`/`persistentvolumeclaims`/`nodes`/`namespaces`/`events`、

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2915,22 +2915,23 @@
       "title": "autopilot 自身のコンテナイメージ (apps/autopilot/deployment.yaml) が ops/inventory.json の監視対象外で、Dockerfile 変更と digest pin のずれを誰も検出できない",
       "kind": "ci",
       "risk": "low",
-      "status": "todo",
+      "status": "needs-human",
       "priority": 15,
       "why": "apps/autopilot/deployment.yaml は images/autopilot/Dockerfile を .github/workflows/build-autopilot-image.yml でビルドした ghcr.io/hikuohiku/homelab-autopilot の digest を手動 pin している（コメントに『Dockerfile の内容を変えたら、ビルドが終わった後この digest も手で更新する』と明記）。ops-health-reporter-image/ops-dashboard-image/pvc-usage-reporter-image は ops/inventory.json に登録され check_version_sync.py 相当の監視対象だが、autopilot 自身のこのイメージだけ inventory.json にエントリが無く、CI にも images/autopilot/** の変更と deployment.yaml の image 行変更を突き合わせる仕組みが無い。Dockerfile を変えた PR で digest 更新を忘れると、ワークフローは新しいイメージを push するのに Deployment は古いイメージを参照し続け、クラスタは古い autopilot のまま気づかれずに動く。全システムの正しさの根拠となる自分自身のイメージがこの唯一の抜けになっている（計画役 run #157 相当、subagent 調査で発見）",
       "dod": "images/autopilot/** を変更した PR で apps/autopilot/deployment.yaml の image 行（digest）も同じ PR で変更されていることを CI で検証する仕組みを追加する（ops/check_manifest_deletions.py や check_version_sync.py に相乗りさせるか新規スクリプトにするかは実装時に判断してよい）。あわせて ops/inventory.json に autopilot-image エントリを追加するか、digest pin の性質上 inventory.json のフォーマット（current/upstream 比較）に馴染まないなら理由を notes に書いて見送る。意図的に Dockerfile だけ変えて digest を更新しない diff を作り、CI が検出することを確認する",
-      "needs_human_reason": null,
+      "needs_human_reason": "検証スクリプト ops/check_autopilot_image_pin.py は実装・動作確認済み（PR #356）。残りは .github/workflows/ci.yml の manifest-diff job に1ステップ追加するだけだが、この起動の AUTOPILOT_GITHUB_TOKEN に workflow scope が無く .github/workflows/** への push が GitHub 側で拒否される（§5.5 に追記）。workflow scope 付きの credential で以下を追記して push してほしい:\n      - name: Check autopilot image digest pin is updated alongside its Dockerfile\n        run: python3 head/ops/check_autopilot_image_pin.py base head\n（manifest-diff job の『Check for unexplained object deletions』ステップの直後）",
       "blocked_by": null,
       "refs": [
         "apps/autopilot/deployment.yaml",
         "images/autopilot/Dockerfile",
         ".github/workflows/build-autopilot-image.yml",
         "ops/inventory.json",
-        "ops/check_version_sync.py"
+        "ops/check_version_sync.py",
+        "ops/check_autopilot_image_pin.py"
       ],
       "created": "2026-08-06",
-      "pr": null,
-      "notes": null
+      "pr": 356,
+      "notes": "run #159 (実行役): スクリプト本体は実装・動作確認済みで PR #356 として提出。ops/inventory.json への autopilot-image エントリ追加は見送り — inventory.json は current/upstream の比較モデル（外部リリースの追跡）が前提だが、このイメージは同じリポジトリの Dockerfile から都度ビルドされる自己完結物で比較すべき『upstream』が存在しないため、モデルに馴染まない。CI 配線は workflow scope 不足で push できず needs-human に切り出した"
     },
     {
       "id": "T-0154",

--- a/ops/check_autopilot_image_pin.py
+++ b/ops/check_autopilot_image_pin.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""apps/autopilot/deployment.yaml は images/autopilot/Dockerfile をビルドした
+ghcr.io/hikuohiku/homelab-autopilot の digest を手動 pin している（.github/workflows/
+build-autopilot-image.yml が main への push のたびに新しいイメージを push するが、
+Deployment 側の digest はコメントで「手で更新する」運用になっている）。
+
+images/autopilot/** を変更した PR で apps/autopilot/deployment.yaml の image 行
+（digest）を変え忘れると、ワークフローは新しいイメージを push するのに Deployment は
+古いイメージを参照し続け、クラスタが古い autopilot のまま気づかれずに動く。
+
+このスクリプトは PR の base と head、両方の worktree を比較し、
+images/autopilot/ 配下が変化しているのに apps/autopilot/deployment.yaml の
+image 行が変化していなければ失敗する（fail-closed）。images/autopilot/ が
+変化していなければ何もしない。
+
+CI (manifest-diff job) から呼ぶ。check_manifest_deletions.py と同じく、
+base/head 両方の worktree が既にチェックアウトされている前提。標準ライブラリのみ。
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+DEPLOYMENT_REL = "apps/autopilot/deployment.yaml"
+IMAGE_DIR_REL = "images/autopilot"
+IMAGE_LINE_RE = re.compile(r"^\s*image:\s*\S+\s*$", re.MULTILINE)
+
+
+def snapshot_dir(root: Path, rel_dir: str) -> dict[str, bytes]:
+    """rel_dir 配下の全ファイルを {相対パス: 中身} で返す。存在しなければ空。"""
+    d = root / rel_dir
+    if not d.exists():
+        return {}
+    return {
+        p.relative_to(d).as_posix(): p.read_bytes()
+        for p in sorted(d.rglob("*"))
+        if p.is_file()
+    }
+
+
+def extract_image_line(root: Path) -> str:
+    path = root / DEPLOYMENT_REL
+    if not path.exists():
+        raise ValueError(f"{DEPLOYMENT_REL} が見つからない ({root})")
+    text = path.read_text()
+    m = IMAGE_LINE_RE.search(text)
+    if not m:
+        raise ValueError(f"{DEPLOYMENT_REL}: image: 行が見つからない")
+    return m.group(0).strip()
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        sys.exit(f"usage: {sys.argv[0]} <base-worktree> <head-worktree>")
+
+    base_root = Path(sys.argv[1]).resolve()
+    head_root = Path(sys.argv[2]).resolve()
+
+    base_images = snapshot_dir(base_root, IMAGE_DIR_REL)
+    head_images = snapshot_dir(head_root, IMAGE_DIR_REL)
+
+    if base_images == head_images:
+        print(f"{IMAGE_DIR_REL} に変更なし、digest 変更チェックは対象外")
+        return 0
+
+    try:
+        base_image_line = extract_image_line(base_root)
+        head_image_line = extract_image_line(head_root)
+    except ValueError as e:
+        print(f"::error::{e}")
+        return 1
+
+    if base_image_line == head_image_line:
+        print(
+            f"::error::{IMAGE_DIR_REL} が変更されていますが、"
+            f"{DEPLOYMENT_REL} の image 行（digest）が変わっていません。"
+        )
+        print(
+            f"::error::  base: {base_image_line}\n::error::  head: {head_image_line}"
+        )
+        print(
+            "\nこの PR がマージされ build-autopilot-image.yml が新しい digest を push した後、"
+            f"{DEPLOYMENT_REL} の image 行をその digest に更新する PR を別途出してください。"
+        )
+        return 1
+
+    print(f"{IMAGE_DIR_REL} の変更に合わせて {DEPLOYMENT_REL} の digest も更新されています")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,50 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 356,
+      "title": "ci(autopilot): images/autopilot 変更時の digest 更新漏れ検出スクリプトを追加",
+      "url": "https://github.com/hikuohiku/homelab/pull/356",
+      "isDraft": false,
+      "createdAt": "2026-08-06T12:43:36Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        }
+      ],
+      "headRefName": "autopilot/T-0153-autopilot-image-pin-check",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 357,
+      "title": "feat(autopilot): レビュー役がダッシュボードを実際に見られるようにする",
+      "url": "https://github.com/hikuohiku/homelab/pull/357",
+      "mergedAt": "2026-08-06T12:44:32Z",
+      "headRefName": "autopilot/reviewer-can-see"
+    },
+    {
+      "number": 355,
+      "title": "ops(run #158): T-0153/T-0154 起票、run #157 の重複 PR を解消",
+      "url": "https://github.com/hikuohiku/homelab/pull/355",
+      "mergedAt": "2026-08-06T12:36:40Z",
+      "headRefName": "autopilot/T-0153-T-0154-plan-run158"
+    },
     {
       "number": 354,
       "title": "feat(ops): ダッシュボードを順番待ち中心に作り直す",
@@ -406,20 +450,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/296",
       "mergedAt": "2026-08-06T04:59:59Z",
       "headRefName": "autopilot/run104-nothing-actionable"
-    },
-    {
-      "number": 295,
-      "title": "docs(ops): T-0128 完了の記録更新 (run #103)",
-      "url": "https://github.com/hikuohiku/homelab/pull/295",
-      "mergedAt": "2026-08-06T04:49:56Z",
-      "headRefName": "autopilot/T-0128-docs-followup"
-    },
-    {
-      "number": 293,
-      "title": "feat(ops-dashboard): httpd を python:3.12-alpine の http.server に置き換えて再実装 (T-0128)",
-      "url": "https://github.com/hikuohiku/homelab/pull/293",
-      "mergedAt": "2026-08-06T04:39:35Z",
-      "headRefName": "autopilot/T-0128-python-http-server"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4552,3 +4552,26 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py` を実行し 0 error / 0 warning であることを確認
 - 次の起動へ: backlog の todo は T-0153・T-0154（着手可能）と T-0117（`not_before`
   2026-08-07T03:30 JST 到来までまだ数時間）の3件。次の実行役は T-0153 または T-0154 から着手できる
+
+## 2026-08-06 21:44 JST — run #159（実行役）
+
+- 前回の中断確認: オープン PR 0 件、`origin/autopilot/*` ブランチ 0 件。ローカル `main` は
+  `origin/main` と一致（cfb36d4）
+- 読んだフィードバック: issue #56 を2ページ（計109件）で確認、`last_read`
+  （2026-08-06T12:34:00Z）以降の新規コメント無し
+- やったこと: backlog の todo（T-0153, T-0117 は `not_before` 未到来のため対象外）から T-0153
+  に着手。`ops/check_autopilot_image_pin.py` を新設し、PR の base/head を比較して
+  `images/autopilot/` が変化しているのに `apps/autopilot/deployment.yaml` の digest 行が
+  変わっていない組み合わせを検出できるようにした（3パターンで手元検証済み）。
+  `.github/workflows/ci.yml` の `manifest-diff` job に配線しようとしたところ `git push` が
+  `refusing to allow a Personal Access Token to create or update workflow ... without
+  \`workflow\` scope` で拒否された。**この substrate の `AUTOPILOT_GITHUB_TOKEN` には
+  `workflow` scope が無く、`.github/workflows/**` を変更する commit は push できないと新たに
+  判明**（CHARTER §5.5 に追記）。ワークフロー配線を差し戻し、スクリプト単体を PR #356 として
+  提出。T-0153 は配線待ちの `needs-human` に変更し、`needs_human_reason` に追加すべき YAML
+  差分をそのまま書いた。`ops/inventory.json` への autopilot-image エントリ追加は、current/upstream
+  比較モデルに馴染まない（自己完結ビルドで比較対象の upstream が無い）ため見送り、backlog notes に
+  理由を残した
+- `python3 ops/validate.py` を実行し 0 error であることを確認
+- 次の起動へ: PR #356 の CI green・merge を見届けること。backlog の todo は T-0154 と T-0117
+  （`not_before` 到来まで）が残る

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T12:34:00Z",
+  "updated": "2026-08-06T12:44:00Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
@@ -1444,6 +1444,14 @@
       "by": "autopilot pod (計画役)",
       "summary": "計画役（journal run #158）。run #157 の重複記録（#350/#351）を発見し #350 merge・#351 close で解消。人間が同時刻に PR #353 でレビュー役の仕組みを追加したと確認。フィードバック・健全性に新規異常無し、inbox 空、backlog blocked/needs-human 全15件は前提変化なし。todo が枯れていたため subagent 調査で T-0153（autopilot 自身のイメージが inventory 監視対象外）・T-0154（review-log.md と backlog の突き合わせに機械検証が無い）の2件を新規起票。",
       "prs": []
+    },
+    {
+      "n": 159,
+      "at": "2026-08-06T12:44:00Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (実行役)",
+      "summary": "実行役（journal run #159）。T-0153（autopilot 自身のイメージ digest pin 未検証）に着手し ops/check_autopilot_image_pin.py を新設・動作確認。CI (ci.yml) への配線は AUTOPILOT_GITHUB_TOKEN に workflow scope が無く push 拒否されると判明（CHARTER §5.5 に追記）、配線を差し戻しスクリプト単体を PR #356 として提出。T-0153 は配線待ちの needs-human に変更。",
+      "prs": [356]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`apps/autopilot/deployment.yaml` の image digest pin は `images/autopilot/Dockerfile`
を手でビルドし直すたびに手動更新する運用（コメントに明記済み）だが、これまで
変更漏れを検出する機械検証が無かった。`ops/check_autopilot_image_pin.py` を
新設し、PR の base/head を比較して「`images/autopilot/` が変化しているのに
`apps/autopilot/deployment.yaml` の `image:` 行（digest）が変わっていない」
組み合わせを検出できるようにした。

**CI への配線（`.github/workflows/manifest-diff` job にこのスクリプトの呼び出しを
追加する1ステップ）は、この起動の `AUTOPILOT_GITHUB_TOKEN` に `workflow` scope が
無く `.github/workflows/ci.yml` への push 自体が拒否されるため含めていない。**
スクリプト単体は独立して動作確認済みで、CI に配線すればすぐ機能する。

## 検証したこと

- ローカルで base/head の一時ディレクトリを作り3パターンを確認:
  - `images/autopilot/` 無変更 → exit 0（チェック対象外）
  - `Dockerfile` 変更 + digest 未更新 → exit 1（エラーメッセージ出力）
  - `Dockerfile` 変更 + digest 更新 → exit 0
- `python3 ops/validate.py` / `check_version_sync.py` / `check_pvc_usage_script_sync.py` /
  `check_doc_commands.py` / `ops/dashboard/build.py` は全て問題なし

## ロールバック手順

`ops/check_autopilot_image_pin.py` を追加しただけで、既存のマニフェスト・ワークフローには
変更なし。revert すればスクリプトが消えるだけで実インフラへの影響はない。

## backlog task id

T-0153（CI 配線待ちのため `needs-human` として backlog に残す。別 PR で
`.github/workflows/ci.yml` の `manifest-diff` job に以下のステップを追加すれば完結する）:

```yaml
      - name: Check autopilot image digest pin is updated alongside its Dockerfile
        run: python3 head/ops/check_autopilot_image_pin.py base head
```
