### PR TITLE
feat(ops): review-log.md と backlog の R-NNN 参照食い違いを機械検証する

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2939,7 +2939,7 @@
       "title": "ops/review-log.md の R-NNN と backlog タスクの起票状態の突き合わせが手作業（LLM 判断）任せで、機械検証が無い",
       "kind": "ci",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 55,
       "why": "PR #353（人間、run #157 直後に merge）で追加されたレビュー役の仕組み（ops/CHARTER.md §3、ops/review-log.md）は、レビュー役が書く R-NNN エントリの `状態`（未処理/起票済 T-XXXX/完了/却下）と、計画役が起票する task の `why` に含める R-NNN 参照が食い違わないことを、CHARTER の手順記述と計画役の注意力だけに頼っている。T-0145（journal run 番号と state.json runs 配列の追随）と構造的に同型の『2箇所が一致しているはずだが機械検証が無い』パターンで、review-log.md/inbox.md/ops/validate.py いずれにも R-NNN や review-log.md への参照は無い（計画役 run #157 相当、subagent 調査で確認）。レビュー役はまだ一度も実行されていない（REVIEW_EVERY=12、直近の run は #157）ため今は実害が無いが、初回実行後に放置すると T-0145 と同じ経路で気づかれないまま乖離する",
       "dod": "ops/validate.py に ops/review-log.md をパースし、(a) `状態: 起票済 T-XXXX` のエントリについて対応する task が backlog.json に存在し、task の `why` にその R-NNN が含まれているか、(b) backlog.json の task の `why` に R-NNN 参照があるのに review-log.md 側にその id のエントリが無い、の食い違いを検出するチェックを追加する。レビュー役がまだ一度も実行されておらず review-log.md に実データが無いため、意図的に食い違うダミーエントリを一時的に追加して検出できることを確認したうえで元に戻す。初回は warning 扱いとし（新しい運用のため誤検出の余地を残す）、数サイクル運用して安定したら error 昇格を検討する旨を notes に残す",
@@ -2952,8 +2952,8 @@
         "ops/CHARTER.md"
       ],
       "created": "2026-08-06",
-      "pr": null,
-      "notes": null
+      "pr": "PENDING_PR_NUMBER",
+      "notes": "run #160: ops/validate.py に check_review_log() を追加。review-log.md の R-NNN（状態: 起票済 T-XXXX）と backlog task の why に含まれる R-NNN 参照の食い違いを検出する。review-log.md/backlog.json にダミーの食い違いエントリを一時的に追加して両方向（review-log→backlog 不在、backlog→review-log 不在、why に R-NNN 不足）の検出を手元で確認したうえで元に戻した。レビュー役の運用実績がまだ無いため warning 扱い（error 昇格は数サイクル運用後に検討、DoD どおり）。"
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2952,7 +2952,7 @@
         "ops/CHARTER.md"
       ],
       "created": "2026-08-06",
-      "pr": "PENDING_PR_NUMBER",
+      "pr": 359,
       "notes": "run #160: ops/validate.py に check_review_log() を追加。review-log.md の R-NNN（状態: 起票済 T-XXXX）と backlog task の why に含まれる R-NNN 参照の食い違いを検出する。review-log.md/backlog.json にダミーの食い違いエントリを一時的に追加して両方向（review-log→backlog 不在、backlog→review-log 不在、why に R-NNN 不足）の検出を手元で確認したうえで元に戻した。レビュー役の運用実績がまだ無いため warning 扱い（error 昇格は数サイクル運用後に検討、DoD どおり）。"
     }
   ]

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,36 +1,68 @@
 {
   "open": [
     {
-      "number": 356,
-      "title": "ci(autopilot): images/autopilot 変更時の digest 更新漏れ検出スクリプトを追加",
-      "url": "https://github.com/hikuohiku/homelab/pull/356",
+      "number": 358,
+      "title": "fix(ops): 実ブラウザで見つかった描画の破綻を直す",
+      "url": "https://github.com/hikuohiku/homelab/pull/358",
       "isDraft": false,
-      "createdAt": "2026-08-06T12:43:36Z",
+      "createdAt": "2026-08-06T12:51:46Z",
       "statusCheckRollup": [
         {
-          "conclusion": "SUCCESS"
+          "conclusion": "QUEUED"
         },
         {
-          "conclusion": "SUCCESS"
+          "conclusion": "QUEUED"
         },
         {
-          "conclusion": "SUCCESS"
+          "conclusion": "IN_PROGRESS"
         },
         {
-          "conclusion": "SUCCESS"
+          "conclusion": "IN_PROGRESS"
         },
         {
-          "conclusion": "SUCCESS"
+          "conclusion": "IN_PROGRESS"
         },
         {
-          "conclusion": "SUCCESS"
+          "conclusion": "IN_PROGRESS"
         }
       ],
-      "headRefName": "autopilot/T-0153-autopilot-image-pin-check",
-      "autoMergeRequest": null
+      "headRefName": "autopilot/dashboard-render-fixes",
+      "autoMergeRequest": {
+        "enabled_by": {
+          "login": "hikuohiku",
+          "id": 105905033,
+          "node_id": "U_kgDOBk_7iQ",
+          "avatar_url": "https://avatars.githubusercontent.com/u/105905033?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/hikuohiku",
+          "html_url": "https://github.com/hikuohiku",
+          "followers_url": "https://api.github.com/users/hikuohiku/followers",
+          "following_url": "https://api.github.com/users/hikuohiku/following{/other_user}",
+          "gists_url": "https://api.github.com/users/hikuohiku/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/hikuohiku/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/hikuohiku/subscriptions",
+          "organizations_url": "https://api.github.com/users/hikuohiku/orgs",
+          "repos_url": "https://api.github.com/users/hikuohiku/repos",
+          "events_url": "https://api.github.com/users/hikuohiku/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/hikuohiku/received_events",
+          "type": "User",
+          "user_view_type": "public",
+          "site_admin": false
+        },
+        "merge_method": "merge",
+        "commit_title": null,
+        "commit_message": null
+      }
     }
   ],
   "merged": [
+    {
+      "number": 356,
+      "title": "ci(autopilot): images/autopilot 変更時の digest 更新漏れ検出スクリプトを追加",
+      "url": "https://github.com/hikuohiku/homelab/pull/356",
+      "mergedAt": "2026-08-06T12:46:24Z",
+      "headRefName": "autopilot/T-0153-autopilot-image-pin-check"
+    },
     {
       "number": 357,
       "title": "feat(autopilot): レビュー役がダッシュボードを実際に見られるようにする",
@@ -443,13 +475,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/297",
       "mergedAt": "2026-08-06T05:03:23Z",
       "headRefName": "autopilot/run106-nothing-actionable"
-    },
-    {
-      "number": 296,
-      "title": "docs(ops): run #105 記録更新（着手可能タスクなし・state.json 記録漏れ復元）",
-      "url": "https://github.com/hikuohiku/homelab/pull/296",
-      "mergedAt": "2026-08-06T04:59:59Z",
-      "headRefName": "autopilot/run104-nothing-actionable"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4575,3 +4575,25 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py` を実行し 0 error であることを確認
 - 次の起動へ: PR #356 の CI green・merge を見届けること。backlog の todo は T-0154 と T-0117
   （`not_before` 到来まで）が残る
+
+## 2026-08-06 21:50 JST — run #160（実行役）
+
+- 前回の中断確認: オープン PR 0 件、`origin/autopilot/*` ブランチ 0 件。ローカル `main` は
+  `origin/main` と一致（fdb9440、#356 merge 済み）
+- 読んだフィードバック: issue #56 を2ページ（計109件）で確認、`last_read`
+  （2026-08-06T12:34:00Z）以降の新規コメント無し
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T12:30:04Z`）で ArgoCD 13 アプリ中
+  `coder`/`immich`/`vaultwarden` が Degraded。従来どおり T-0106 由来の既知 `SecretSyncedError`
+  のみ。`pod_issues` の restarts:19 常連（既知）も変化なし。autopilot 自身の heartbeat も正常
+  （iteration #34, exit_code 0, readyReplicas 1）。新規異常なし
+- やったこと: backlog の todo（T-0154, T-0117 は `not_before` 未到来のため対象外）から T-0154
+  に着手。`ops/validate.py` に `check_review_log()` を追加し、`ops/review-log.md` の R-NNN
+  （`状態: 起票済 T-XXXX`）と backlog task の `why` に含まれる R-NNN 参照が食い違っていないかを
+  検査するようにした。review-log.md は初回レビュー未実行で空のため、DoD どおり両ファイルに
+  ダミーの食い違いエントリを一時的に追加し、(a) review-log にあるが backlog に無い、(b) backlog
+  にあるが review-log に無い、(c) 起票済だが why に R-NNN が無い、の3パターンいずれも warning で
+  検出できることを手元で確認したうえで元に戻した（`git diff` が空であることを確認済み）。
+  実運用実績が無いため初回は warning 扱いのまま（error 昇格は見送り、notes に理由を残した）
+- `python3 ops/validate.py` を実行し 0 error / 0 warning であることを確認
+- 次の起動へ: PR の CI green・merge を見届けること。backlog の todo は T-0117
+  （`not_before` 2026-08-07T03:30 JST 到来まで）のみ残る

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T12:44:00Z",
+  "updated": "2026-08-06T12:50:00Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
@@ -1452,6 +1452,14 @@
       "by": "autopilot pod (実行役)",
       "summary": "実行役（journal run #159）。T-0153（autopilot 自身のイメージ digest pin 未検証）に着手し ops/check_autopilot_image_pin.py を新設・動作確認。CI (ci.yml) への配線は AUTOPILOT_GITHUB_TOKEN に workflow scope が無く push 拒否されると判明（CHARTER §5.5 に追記）、配線を差し戻しスクリプト単体を PR #356 として提出。T-0153 は配線待ちの needs-human に変更。",
       "prs": [356]
+    },
+    {
+      "n": 160,
+      "at": "2026-08-06T12:50:00Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (実行役)",
+      "summary": "実行役（journal run #160）。T-0154（review-log.md と backlog の突き合わせに機械検証が無い）に着手し ops/validate.py に check_review_log() を追加。R-NNN の起票済参照と task why の食い違いを warning で検出する。ダミーエントリで両方向の検出を確認したうえで元に戻した。",
+      "prs": []
     }
   ]
 }

--- a/ops/validate.py
+++ b/ops/validate.py
@@ -163,6 +163,60 @@ def check_conflict_markers() -> None:
                 err(f"{path.relative_to(ROOT)}:{lineno}: git の conflict marker が残っている ({line!r})")
 
 
+REVIEW_LOG_ENTRY_RE = re.compile(r"^## (R-\d+) — .*$", re.MULTILINE)
+REVIEW_LOG_STATUS_RE = re.compile(r"^- 状態:\s*(.+)$", re.MULTILINE)
+REVIEW_LOG_FILED_RE = re.compile(r"起票済\s*(T-\d{4})")
+TASK_R_REF_RE = re.compile(r"R-\d+")
+
+
+def parse_review_log(text: str) -> dict[str, str]:
+    entries: dict[str, str] = {}
+    matches = list(REVIEW_LOG_ENTRY_RE.finditer(text))
+    for i, m in enumerate(matches):
+        rid = m.group(1)
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        block = text[m.end():end]
+        status_m = REVIEW_LOG_STATUS_RE.search(block)
+        entries[rid] = status_m.group(1).strip() if status_m else ""
+    return entries
+
+
+def check_review_log(backlog) -> None:
+    # T-0154: review-log.md の R-NNN (状態: 起票済 T-XXXX) と backlog task の why に
+    # 含まれる R-NNN 参照が食い違っていないかを検査する。レビュー役はまだ一度も実行されて
+    # おらず運用実績が無いため、初回は warning に留める（error 昇格は数サイクル運用後に検討）。
+    path = OPS / "review-log.md"
+    if not path.exists():
+        return
+    entries = parse_review_log(path.read_text())
+    if not entries:
+        return
+
+    tasks = backlog.get("tasks", []) if backlog else []
+    tasks_by_id = {t.get("id"): t for t in tasks}
+
+    why_refs: dict[str, list[str]] = {}
+    for t in tasks:
+        for rid in TASK_R_REF_RE.findall(t.get("why", "") or ""):
+            why_refs.setdefault(rid, []).append(t.get("id", "?"))
+
+    for rid, status in entries.items():
+        m = REVIEW_LOG_FILED_RE.search(status)
+        if not m:
+            continue
+        tid = m.group(1)
+        task = tasks_by_id.get(tid)
+        if task is None:
+            warn(f"review-log.md: {rid} は「起票済 {tid}」だが backlog.json に {tid} が存在しない")
+            continue
+        if rid not in (task.get("why", "") or ""):
+            warn(f"review-log.md: {rid} は「起票済 {tid}」だが {tid} の why に {rid} が含まれていない")
+
+    for rid, tids in why_refs.items():
+        if rid not in entries:
+            warn(f"backlog.json: {', '.join(tids)} の why が {rid} を参照しているが review-log.md に {rid} のエントリが無い")
+
+
 def check_state(s) -> None:
     for k in ("updated", "runs", "feedback"):
         if k not in s:
@@ -233,6 +287,7 @@ def main() -> int:
 
     if backlog:
         check_backlog(backlog)
+        check_review_log(backlog)
     if inventory:
         check_inventory(inventory)
     if state:


### PR DESCRIPTION
## 変更点

`ops/validate.py` に `check_review_log()` を追加した。レビュー役が書く `ops/review-log.md` の R-NNN エントリ（`状態: 起票済 T-XXXX`）と、計画役が起票する backlog task の `why` に含まれる R-NNN 参照が食い違っていないかを検査する。

- review-log.md の R-NNN が「起票済 T-XXXX」なのに、backlog.json に T-XXXX が存在しない
- 同上で T-XXXX は存在するが、その task の `why` に R-NNN が含まれていない
- backlog task の `why` が R-NNN を参照しているのに、review-log.md にその id のエントリが無い

これまでは CHARTER §3 の手順記述と計画役の注意力だけに頼っていて機械検証が無かった（T-0145 と同型のパターン）。

## 検証したこと

- `python3 ops/validate.py` が 0 error / 0 warning で通ることを確認（現状 review-log.md は空のため検出対象なし）
- DoD どおり、review-log.md と backlog.json にダミーの食い違いエントリを一時的に追加し、3パターン（review-log→backlog 不在／backlog→review-log 不在／起票済だが why に R-NNN 不足）いずれも warning で検出できることを確認したうえで元に戻した。`git diff` が空であることも確認済み

## ロールバック手順

`ops/validate.py` の `check_review_log()` とその呼び出し行を revert すれば元に戻る。状態を持つファイルではないため、revert 後にデータの不整合が残ることはない。

## backlog task id

T-0154
