### PR TITLE
ops(run #161): T-0155/T-0156 を起票（計画役の記録）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 155,
-  "updated": "2026-08-06T11:49:11Z",
+  "next_id": 157,
+  "updated": "2026-08-06T13:00:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2954,6 +2954,49 @@
       "created": "2026-08-06",
       "pr": 359,
       "notes": "run #160: ops/validate.py に check_review_log() を追加。review-log.md の R-NNN（状態: 起票済 T-XXXX）と backlog task の why に含まれる R-NNN 参照の食い違いを検出する。review-log.md/backlog.json にダミーの食い違いエントリを一時的に追加して両方向（review-log→backlog 不在、backlog→review-log 不在、why に R-NNN 不足）の検出を手元で確認したうえで元に戻した。レビュー役の運用実績がまだ無いため warning 扱い（error 昇格は数サイクル運用後に検討、DoD どおり）。"
+    },
+    {
+      "id": "T-0155",
+      "domain": "homelab",
+      "title": "ops/CHARTER.md §6 が「ops/check_feedback.py はまだ CI に入っていない」と書いているが、同じコミットで既に CI に組み込み済み",
+      "kind": "docs",
+      "risk": "low",
+      "status": "todo",
+      "priority": 20,
+      "why": "計画役 run #161 相当の調査（subagent 調査で発見・自分で git blame / .github/workflows/ci.yml を読んで裏取り済み）。ops/CHARTER.md §6 手順5（756〜758行目付近）は『python3 ops/check_feedback.py を実行して0 errorを確認する。これはまだCIに入っていない』と書いているが、`.github/workflows/ci.yml` の `ops` job には既に `check human feedback ledger is consistent` ステップとして `python3 ops/check_feedback.py` が存在する。両方とも同一コミット cce1ca6（『人間の書き置きを issue 経由から台帳に移す』、feedback ledger 新設 PR #360）で追加されており、コミット本文には『ops/check_feedback.py を CI に繋いだ』と明記されているのに CHARTER 本文だけ古い前提のまま取り残された。CHARTER §1 は『実態とドキュメントが乖離していない』ことを健全性の定義に含めており、CHARTER 自身がこれに反する状態を放置しない",
+      "dod": "ops/CHARTER.md §6 手順5 の該当箇所から『これはまだ CI に入っていない（…) 気づいた回に足してよい』という一文を削除し、`.github/workflows/ci.yml` の `ops` job で既に検証されている旨に書き換える",
+      "needs_human_reason": null,
+      "blocked_by": null,
+      "refs": [
+        "ops/CHARTER.md",
+        ".github/workflows/ci.yml"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": ""
+    },
+    {
+      "id": "T-0156",
+      "domain": "homelab",
+      "title": "CLAUDE.md / apps/README.md のアプリ一覧・ディレクトリ構造が apps/kustomization.yaml の実態からずれ続けている（同型drift5回目、機械検証が無い）",
+      "kind": "ci",
+      "risk": "low",
+      "status": "todo",
+      "priority": 46,
+      "why": "計画役 run #161 相当の調査（subagent 調査で発見・自分で apps/kustomization.yaml / CLAUDE.md / apps/README.md を読んで裏取り済み）。apps/kustomization.yaml の resources は12件（syncthing/application.yaml を含む）だが、CLAUDE.md の『Apps』一覧・Directory Structure ツリーには syncthing が無く、apps/README.md の『ディレクトリ構造』ツリー（ops-dashboard/syncthing 抜け、8件のみ）と『期待される出力』の kubectl get application サンプル（apps/agent-rbac含め11件、ops-dashboard/syncthing 抜けで実際の13件に届かない）も同様にずれている。この種の drift は T-0057(run#24)・T-0089(run#42)・T-0094(run#47)・T-0134(run#125) で計4回、起票→手直しを繰り返しており、今回で5回目の再発。`just <recipe>` の記載漏れには ops/check_doc_commands.py という同型の自動検証が既にあるのに、アプリ一覧のずれだけは毎回人力の起票に頼ったままで、CHARTER §8『同じミスを2回した→CIかチェックリストで機械的に防ぐ』に反する状態が続いている",
+      "dod": "(1) まず CLAUDE.md の Apps 一覧・Directory Structure、apps/README.md のディレクトリ構造ツリー・kubectl get application サンプル出力を apps/kustomization.yaml の実態（12エントリ、agent-rbac/ops-dashboard/syncthing含む）に合わせて修正する。(2) ops/check_doc_commands.py と同型の新規スクリプト（例: ops/check_app_list_sync.py）を作り、apps/kustomization.yaml の resources から app ディレクトリ名一覧を機械的に抽出し、CLAUDE.md・apps/README.md がそれと矛盾しない（全件言及がある）ことを検証し .github/workflows/ci.yml の ops job に追加する。ドキュメントの自由記述（説明文・箇条書きの前後）まで固定フォーマットを強制すると壊れやすいので、検証は『kustomization.yaml にあるapp名がドキュメント中に一度も出現しない』ケースの検出に留める。意図的に1アプリを一覧から抜いた diff を作り CI が検出することを確認する",
+      "needs_human_reason": null,
+      "blocked_by": null,
+      "refs": [
+        "CLAUDE.md",
+        "apps/README.md",
+        "apps/kustomization.yaml",
+        "ops/check_doc_commands.py",
+        ".github/workflows/ci.yml"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": ""
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4597,3 +4597,35 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py` を実行し 0 error / 0 warning であることを確認
 - 次の起動へ: PR の CI green・merge を見届けること。backlog の todo は T-0117
   （`not_before` 2026-08-07T03:30 JST 到来まで）のみ残る
+
+## 2026-08-06 21:56 JST — run #161（計画役）
+
+- `ops/inbox.md` を確認: 見出し以下は空。変換対象なし
+- フィードバック取り込み: `ops-feedback` ブランチはまだ存在しない（`git ls-remote` で未確認、
+  ダッシュボードからの書き置きがまだ無い）。issue #56 を `per_page=100` で2ページ（計109件）
+  確認し、`ops/feedback.json` の `issue.cutoff`（2026-08-06T12:11:00Z）以降の新規コメント無し。
+  `ops/feedback.json` の `items` は空のまま。取り込み・判断すべきものなし
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T12:30:04Z`）で ArgoCD 13 アプリ中
+  `coder`/`immich`/`vaultwarden` が Degraded（従来どおり T-0106 由来の既知 `SecretSyncedError`
+  のみ）。`pod_issues` の restarts:19 常連も変化なし。autopilot 自身の heartbeat 正常
+  （iteration #34, exit_code 0, readyReplicas 1）。新規異常なし
+- backlog の blocked/needs-human 全14件（T-0028, T-0029, T-0074, T-0084, T-0106, T-0107, T-0112,
+  T-0116, T-0118, T-0120, T-0140, T-0141, T-0144, T-0147, T-0148, T-0153）を棚卸し。T-0112
+  （immich-postgres CrashLoop の FATAL ログ確認依頼、issue #56 に 2026-08-06T06:10:37Z 投稿済み）
+  は未返信、T-0144（issue #35 の人間回答待ち）も未返信と確認。他は前提が変わっていないことを
+  裏取り済み。古い前提のまま残っていたものは無し
+- todo は `T-0117`（`not_before` 2026-08-07T03:30 JST 未到来）のみで着手可能なタスクが枯れて
+  いたため、CHARTER §3 に従い Explore subagent に新規調査観点探しを依頼し、2件を自分でも
+  裏取りのうえ起票:
+  - **T-0155**: `ops/CHARTER.md` §6 手順5が「`ops/check_feedback.py` はまだ CI に入っていない」
+    と書いているが、同一コミット（cce1ca6, feedback ledger 新設 PR #360）で `.github/workflows/ci.yml`
+    の `ops` job に既に配線済みだったと判明（`git blame`・`ci.yml` を実際に読んで確認）。CHARTER
+    自身が §1 に掲げる「実態とドキュメントが乖離していない」に反する自己矛盾
+  - **T-0156**: `CLAUDE.md`/`apps/README.md` のアプリ一覧・ディレクトリ構造が `apps/kustomization.yaml`
+    の実態（12件、`syncthing`/`ops-dashboard`含む）からずれている（`syncthing`・`ops-dashboard`が
+    両ドキュメントとも抜け）。同型 drift は T-0057/T-0089/T-0094/T-0134 で既に4回起票・修正済みで
+    今回が5回目の再発。`ops/check_doc_commands.py`（`just` recipe の同型検証）を手本に、CI での
+    機械検証を新設する DoD にした（CHARTER §8「同じミスを2回した→CIかチェックリストで機械的に防ぐ」）
+- `python3 ops/validate.py` を実行し 0 error / 0 warning であることを確認
+- 次の起動へ: backlog の todo は T-0155（priority 20）・T-0156（priority 46）・T-0117
+  （`not_before` 未到来）の3件。T-0155 から着手するとよい

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T12:50:00Z",
+  "updated": "2026-08-06T13:00:00Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T12:34:00Z"
+    "last_read": "2026-08-06T13:00:00Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc",
@@ -1459,6 +1459,14 @@
       "kind": "in_cluster_loop",
       "by": "autopilot pod (実行役)",
       "summary": "実行役（journal run #160）。T-0154（review-log.md と backlog の突き合わせに機械検証が無い）に着手し ops/validate.py に check_review_log() を追加。R-NNN の起票済参照と task why の食い違いを warning で検出する。ダミーエントリで両方向の検出を確認したうえで元に戻した。",
+      "prs": []
+    },
+    {
+      "n": 161,
+      "at": "2026-08-06T13:00:00Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (計画役)",
+      "summary": "計画役（journal run #161）。inbox 空、フィードバック新規無し、健全性は既知の T-0106 由来 Degraded のみで新規異常無し。backlog blocked/needs-human 全14件の前提変化なし。todo が枯れていたため調査し、T-0155（CHARTER §6 の自己矛盾: check_feedback.py は既にCI配線済みなのに『まだ』と記述）・T-0156（アプリ一覧drift5回目、CI検証を新設するDoD）を起票。",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

計画役として1イテレーション分の巡回を実施した記録（`ops/` 配下のみ、コード・マニフェストの変更なし）。

- `ops/inbox.md`: 空を確認（変換対象なし）
- フィードバック: `ops-feedback` ブランチ未作成（書き置きまだ無し）、issue #56 に `ops/feedback.json` の cutoff（2026-08-06T12:11:00Z）以降の新規コメント無し
- 健全性（`ops-health-report` ブランチ, `generated_at: 2026-08-06T12:30:04Z`）: ArgoCD 13アプリ中 `coder`/`immich`/`vaultwarden` の Degraded は既知（T-0106 由来の `SecretSyncedError`）のみ、新規異常無し。autopilot 自身の heartbeat も正常
- backlog の `blocked`/`needs-human` 全14件を棚卸しし、古い前提のまま残っているものが無いことを確認
- backlog の `todo` が事実上 0 件（`T-0117` は `not_before` 未到来）だったため、新規調査観点を探し2件起票:
  - **T-0155**: `ops/CHARTER.md` §6 が「`ops/check_feedback.py` はまだ CI に入っていない」と書いているが、同一コミット（feedback ledger 新設 PR #360）で `.github/workflows/ci.yml` に既に配線済みだった自己矛盾
  - **T-0156**: `CLAUDE.md`/`apps/README.md` のアプリ一覧・ディレクトリ構造が `apps/kustomization.yaml` の実態（`syncthing`/`ops-dashboard` 含む12件）からずれている drift（同型の再発5回目）。今回は一回限りの手直しではなく、`ops/check_doc_commands.py` と同型の CI 検証を新設する DoD にした

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `ops/backlog.json` の diff が意図した追記（T-0155/T-0156の2エントリ + next_id/updated の更新）のみであることを `git diff` で確認

## ロールバック手順

`ops/` の記録のみの変更。revert すれば起票前の状態に戻る。データ・スキーマへの影響は無い。

## backlog task id

T-0155, T-0156（本 PR はこの2件を起票する記録PR。実装は次の実行役に委ねる）
