### PR TITLE
docs: apps/kustomization.yaml のアプリ一覧をCLAUDE.md/apps/README.mdへ反映 (T-0156)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Terraform で VM プロビジョニング、NixOS でOS構成、Kubernetes (Argo
 - **Networking**: Tailscale
 - **Secrets**: SOPS, External Secrets Operator
 - **Auth**: Dex (Google OAuth)
-- **Apps**: ArgoCD, Dex, External Secrets Operator, Tailscale Operator, Immich, Vaultwarden, Coder, ops-health-reporter, autopilot, ops-dashboard
+- **Apps**: ArgoCD, agent-rbac, Dex, External Secrets Operator, Tailscale Operator, Immich, Vaultwarden, Coder, ops-health-reporter, autopilot, ops-dashboard, syncthing
 
 ## Directory Structure
 
@@ -33,6 +33,7 @@ apps/                — Kubernetes manifests (ArgoCD applications)
   ops-health-reporter/ — autopilot 向け ArgoCD/k8s 健全性レポーター（CronJob）
   autopilot/           — 自律運用エージェント本体（Deployment + loop.sh の常駐ループ）
   ops-dashboard/       — 人間向けダッシュボードの配信（Deployment、ops-dashboard ブランチの index.html を fetch して http.server で配信）
+  syncthing/           — Syncthing（P2P ファイル同期）
 .sops.yaml            — SOPS 設定（暗号鍵の対象範囲）
 nix/images/proxmox-cloud/secrets.yaml — SOPS 暗号化ファイル（単一ファイル、トップレベルの secrets/ ディレクトリは存在しない）
 ```

--- a/apps/README.md
+++ b/apps/README.md
@@ -75,7 +75,9 @@ coder                Synced        Healthy
 dex                  Synced        Healthy
 external-secrets     Synced        Healthy
 immich               Synced        Healthy
+ops-dashboard        Synced        Healthy
 ops-health-reporter  Synced        Healthy
+syncthing            Synced        Healthy
 tailscale-operator   Synced        Healthy
 vaultwarden          Synced        Healthy
 ```
@@ -127,7 +129,9 @@ apps/
 ├── vaultwarden/
 ├── coder/
 ├── ops-health-reporter/
-└── autopilot/
+├── autopilot/
+├── ops-dashboard/
+└── syncthing/
 ```
 
 各アプリは以下の構造:

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 157,
-  "updated": "2026-08-06T13:00:00Z",
+  "updated": "2026-08-06T13:30:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2981,11 +2981,11 @@
       "title": "CLAUDE.md / apps/README.md のアプリ一覧・ディレクトリ構造が apps/kustomization.yaml の実態からずれ続けている（同型drift5回目、機械検証が無い）",
       "kind": "ci",
       "risk": "low",
-      "status": "todo",
+      "status": "needs-human",
       "priority": 46,
       "why": "計画役 run #161 相当の調査（subagent 調査で発見・自分で apps/kustomization.yaml / CLAUDE.md / apps/README.md を読んで裏取り済み）。apps/kustomization.yaml の resources は12件（syncthing/application.yaml を含む）だが、CLAUDE.md の『Apps』一覧・Directory Structure ツリーには syncthing が無く、apps/README.md の『ディレクトリ構造』ツリー（ops-dashboard/syncthing 抜け、8件のみ）と『期待される出力』の kubectl get application サンプル（apps/agent-rbac含め11件、ops-dashboard/syncthing 抜けで実際の13件に届かない）も同様にずれている。この種の drift は T-0057(run#24)・T-0089(run#42)・T-0094(run#47)・T-0134(run#125) で計4回、起票→手直しを繰り返しており、今回で5回目の再発。`just <recipe>` の記載漏れには ops/check_doc_commands.py という同型の自動検証が既にあるのに、アプリ一覧のずれだけは毎回人力の起票に頼ったままで、CHARTER §8『同じミスを2回した→CIかチェックリストで機械的に防ぐ』に反する状態が続いている",
       "dod": "(1) まず CLAUDE.md の Apps 一覧・Directory Structure、apps/README.md のディレクトリ構造ツリー・kubectl get application サンプル出力を apps/kustomization.yaml の実態（12エントリ、agent-rbac/ops-dashboard/syncthing含む）に合わせて修正する。(2) ops/check_doc_commands.py と同型の新規スクリプト（例: ops/check_app_list_sync.py）を作り、apps/kustomization.yaml の resources から app ディレクトリ名一覧を機械的に抽出し、CLAUDE.md・apps/README.md がそれと矛盾しない（全件言及がある）ことを検証し .github/workflows/ci.yml の ops job に追加する。ドキュメントの自由記述（説明文・箇条書きの前後）まで固定フォーマットを強制すると壊れやすいので、検証は『kustomization.yaml にあるapp名がドキュメント中に一度も出現しない』ケースの検出に留める。意図的に1アプリを一覧から抜いた diff を作り CI が検出することを確認する",
-      "needs_human_reason": null,
+      "needs_human_reason": "ドキュメント修正（CLAUDE.md の Apps 一覧・Directory Structure、apps/README.md のディレクトリ構造ツリー・kubectl get application サンプル出力）と検証スクリプトops/check_app_list_sync.py は実装・動作確認済み（実際に手元で app 名を1件除いたdiff を作り検出することを確認済み）で PR に含めた。残りは .github/workflows/ci.ymlの ops job に1ステップ追加するだけだが、この起動の AUTOPILOT_GITHUB_TOKEN に workflow scope が無く .github/workflows/** への push が GitHub 側で拒否される（T-0153 と同型、CHARTER §5.5）。workflow scope 付きの credential で ops job の「check docs reference only existing just recipes」ステップの直後に以下を追記してpush してほしい:\n      - name: check app list in docs matches apps/kustomization.yaml\n        run: python3 ops/check_app_list_sync.py",
       "blocked_by": null,
       "refs": [
         "CLAUDE.md",
@@ -2996,7 +2996,7 @@
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": ""
+      "notes": "run (実行役): CLAUDE.md / apps/README.md のアプリ一覧を apps/kustomization.yaml の実態（12件、agent-rbac/ops-dashboard/syncthing含む）に合わせて修正し、ops/check_app_list_sync.py を新規実装・動作確認済み。.github/workflows/ci.yml への配線は workflow scope 不足で push できず needs-human に切り出した（T-0153 と同型）"
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -2995,8 +2995,8 @@
         ".github/workflows/ci.yml"
       ],
       "created": "2026-08-06",
-      "pr": null,
-      "notes": "run (実行役): CLAUDE.md / apps/README.md のアプリ一覧を apps/kustomization.yaml の実態（12件、agent-rbac/ops-dashboard/syncthing含む）に合わせて修正し、ops/check_app_list_sync.py を新規実装・動作確認済み。.github/workflows/ci.yml への配線は workflow scope 不足で push できず needs-human に切り出した（T-0153 と同型）"
+      "pr": 363,
+      "notes": "run #163 (実行役): CLAUDE.md / apps/README.md のアプリ一覧を apps/kustomization.yaml の実態（12件、agent-rbac/ops-dashboard/syncthing含む）に合わせて修正し、ops/check_app_list_sync.py を新規実装・動作確認済み。.github/workflows/ci.yml への配線は workflow scope 不足で push できず needs-human に切り出した（T-0153 と同型）"
     }
   ]
 }

--- a/ops/check_app_list_sync.py
+++ b/ops/check_app_list_sync.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+apps/kustomization.yaml の resources と、人間向けドキュメント（CLAUDE.md /
+apps/README.md）のアプリ一覧が乖離していないか検証する。CI (ops job) から実行する。
+
+同型の drift（T-0057/T-0089/T-0094/T-0134）を4回起票・手直ししており、
+T-0156 でようやく機械検証を足す。apps/kustomization.yaml の resources から
+app ディレクトリ名を機械的に抽出し、各ドキュメントの本文にその名前が
+一度も出現しない場合だけを検出する（自由記述の順序・表現までは強制しない）。
+"""
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML missing")
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# アプリ名がドキュメント中に出現していることを要求するファイル。
+DOC_PATHS = [
+    "CLAUDE.md",
+    "apps/README.md",
+]
+
+RESOURCE_RE = re.compile(r"^([a-zA-Z0-9_-]+)/application\.yaml$")
+
+
+def extract_app_names(kustomization_path: Path) -> list:
+    data = yaml.safe_load(kustomization_path.read_text())
+    resources = data.get("resources", [])
+    names = []
+    for r in resources:
+        m = RESOURCE_RE.match(r.strip())
+        if m:
+            names.append(m.group(1))
+    return names
+
+
+def main() -> int:
+    kustomization_path = ROOT / "apps" / "kustomization.yaml"
+    if not kustomization_path.exists():
+        print(f"::error::{kustomization_path} が見つからない", file=sys.stderr)
+        return 1
+
+    app_names = extract_app_names(kustomization_path)
+    if not app_names:
+        print("::error::apps/kustomization.yaml から app 名を1つも抽出できなかった", file=sys.stderr)
+        return 1
+
+    errors = []
+    for rel_path in DOC_PATHS:
+        doc_path = ROOT / rel_path
+        if not doc_path.exists():
+            errors.append(f"{rel_path}: ファイルが存在しない")
+            continue
+        text = doc_path.read_text()
+        for app in app_names:
+            if app not in text:
+                errors.append(f"{rel_path}: app `{app}` への言及が無い")
+
+    if errors:
+        for e in errors:
+            print(f"::error::{e}")
+        print(
+            f"\n{len(errors)} 件の drift。apps/kustomization.yaml の app: {sorted(app_names)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"ok: app {len(app_names)} 件、ドキュメント {len(DOC_PATHS)} 件を確認")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,5 +1,32 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 363,
+      "title": "docs: apps/kustomization.yaml のアプリ一覧をCLAUDE.md/apps/README.mdへ反映 (T-0156)",
+      "url": "https://github.com/hikuohiku/homelab/pull/363",
+      "isDraft": false,
+      "createdAt": "2026-08-06T13:20:47Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "IN_PROGRESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "IN_PROGRESS"
+        },
+        {
+          "conclusion": "IN_PROGRESS"
+        }
+      ],
+      "headRefName": "autopilot/T-0156-app-list-doc-drift",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
     {
       "number": 362,

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,61 +1,41 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
+    {
+      "number": 362,
+      "title": "docs(ops): CHARTER.md の check_feedback.py CI記述を実態に合わせる (T-0155)",
+      "url": "https://github.com/hikuohiku/homelab/pull/362",
+      "mergedAt": "2026-08-06T13:13:59Z",
+      "headRefName": "autopilot/T-0155-charter-check-feedback-ci"
+    },
+    {
+      "number": 361,
+      "title": "ops(run #161): T-0155/T-0156 を起票（計画役の記録）",
+      "url": "https://github.com/hikuohiku/homelab/pull/361",
+      "mergedAt": "2026-08-06T13:07:07Z",
+      "headRefName": "autopilot/T-0155-T-0156-planning-record"
+    },
+    {
+      "number": 360,
+      "title": "feat(ops): 人間の書き置きを issue 経由から台帳に移す",
+      "url": "https://github.com/hikuohiku/homelab/pull/360",
+      "mergedAt": "2026-08-06T12:54:49Z",
+      "headRefName": "autopilot/feedback-ledger"
+    },
+    {
+      "number": 359,
+      "title": "feat(ops): review-log.md と backlog の R-NNN 参照食い違いを機械検証する",
+      "url": "https://github.com/hikuohiku/homelab/pull/359",
+      "mergedAt": "2026-08-06T12:54:35Z",
+      "headRefName": "autopilot/T-0154-review-log-validate-check"
+    },
     {
       "number": 358,
       "title": "fix(ops): 実ブラウザで見つかった描画の破綻を直す",
       "url": "https://github.com/hikuohiku/homelab/pull/358",
-      "isDraft": false,
-      "createdAt": "2026-08-06T12:51:46Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "QUEUED"
-        },
-        {
-          "conclusion": "QUEUED"
-        },
-        {
-          "conclusion": "IN_PROGRESS"
-        },
-        {
-          "conclusion": "IN_PROGRESS"
-        },
-        {
-          "conclusion": "IN_PROGRESS"
-        },
-        {
-          "conclusion": "IN_PROGRESS"
-        }
-      ],
-      "headRefName": "autopilot/dashboard-render-fixes",
-      "autoMergeRequest": {
-        "enabled_by": {
-          "login": "hikuohiku",
-          "id": 105905033,
-          "node_id": "U_kgDOBk_7iQ",
-          "avatar_url": "https://avatars.githubusercontent.com/u/105905033?v=4",
-          "gravatar_id": "",
-          "url": "https://api.github.com/users/hikuohiku",
-          "html_url": "https://github.com/hikuohiku",
-          "followers_url": "https://api.github.com/users/hikuohiku/followers",
-          "following_url": "https://api.github.com/users/hikuohiku/following{/other_user}",
-          "gists_url": "https://api.github.com/users/hikuohiku/gists{/gist_id}",
-          "starred_url": "https://api.github.com/users/hikuohiku/starred{/owner}{/repo}",
-          "subscriptions_url": "https://api.github.com/users/hikuohiku/subscriptions",
-          "organizations_url": "https://api.github.com/users/hikuohiku/orgs",
-          "repos_url": "https://api.github.com/users/hikuohiku/repos",
-          "events_url": "https://api.github.com/users/hikuohiku/events{/privacy}",
-          "received_events_url": "https://api.github.com/users/hikuohiku/received_events",
-          "type": "User",
-          "user_view_type": "public",
-          "site_admin": false
-        },
-        "merge_method": "merge",
-        "commit_title": null,
-        "commit_message": null
-      }
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-06T12:52:26Z",
+      "headRefName": "autopilot/dashboard-render-fixes"
+    },
     {
       "number": 356,
       "title": "ci(autopilot): images/autopilot 変更時の digest 更新漏れ検出スクリプトを追加",
@@ -440,41 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/302",
       "mergedAt": "2026-08-06T05:48:35Z",
       "headRefName": "autopilot/T-0132-vision-stage-mismatch"
-    },
-    {
-      "number": 301,
-      "title": "fix(ops): dashboard の定期実行間隔表示をクラスタ内常駐の実態に合わせる (T-0131)",
-      "url": "https://github.com/hikuohiku/homelab/pull/301",
-      "mergedAt": "2026-08-06T05:36:58Z",
-      "headRefName": "autopilot/T-0131-routines-cadence-drift"
-    },
-    {
-      "number": 300,
-      "title": "docs(ops): run #109 記録更新（計画役、T-0130/T-0131/T-0132 起票）",
-      "url": "https://github.com/hikuohiku/homelab/pull/300",
-      "mergedAt": "2026-08-06T05:28:24Z",
-      "headRefName": "autopilot/run109-plan-T-0130-T-0131-T-0132"
-    },
-    {
-      "number": 299,
-      "title": "docs(ops): run #108 記録更新（着手可能タスクなし）",
-      "url": "https://github.com/hikuohiku/homelab/pull/299",
-      "mergedAt": "2026-08-06T05:21:03Z",
-      "headRefName": "autopilot/run108-nothing-actionable"
-    },
-    {
-      "number": 298,
-      "title": "docs(ops): run #107 記録更新（着手可能タスクなし）",
-      "url": "https://github.com/hikuohiku/homelab/pull/298",
-      "mergedAt": "2026-08-06T05:10:51Z",
-      "headRefName": "autopilot/run107-nothing-actionable"
-    },
-    {
-      "number": 297,
-      "title": "docs(ops): run #106 記録更新（着手可能タスクなし）",
-      "url": "https://github.com/hikuohiku/homelab/pull/297",
-      "mergedAt": "2026-08-06T05:03:23Z",
-      "headRefName": "autopilot/run106-nothing-actionable"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4639,3 +4639,23 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   書かれたままだった）を修正。該当の 3 行を「既に検証されている」旨の 1 文に置き換えた
 - 次の起動へ: この PR の CI green・merge を見届けること。backlog の todo は T-0156
   （priority 46）と T-0117（`not_before` 2026-08-07T03:30 JST 未到来）が残る
+
+## 2026-08-06 22:17 JST — run #163（実行役）
+
+- 取り込んだフィードバック: なし（issue #56 は cutoff 以降新規無し、2ページ目も確認済み。
+  `ops-feedback` ブランチはまだ存在しない）
+- 前回の中断: オープン PR 0 件、`autopilot/*` 残骸ブランチ無し。中断拾いは無し
+- やったこと: T-0156（`CLAUDE.md`/`apps/README.md` のアプリ一覧が `apps/kustomization.yaml`
+  の実態からずれ続ける、5回目の再発）に着手。`CLAUDE.md` の Apps 一覧・Directory Structure
+  と `apps/README.md` のディレクトリ構造ツリー・`kubectl get application` サンプル出力に
+  `agent-rbac`/`ops-dashboard`/`syncthing` を反映。`ops/check_doc_commands.py` を手本に
+  `ops/check_app_list_sync.py` を新規実装（`apps/kustomization.yaml` の resources から app 名を
+  抽出し、ドキュメント中に一度も出現しないものを検出）。1件抜いた diff で実際に検出することを
+  手元で確認済み
+- `.github/workflows/ci.yml` の `ops` job への配線は見送り: この起動の `AUTOPILOT_GITHUB_TOKEN`
+  に `workflow` scope が無く `.github/workflows/**` への push が GitHub 側で拒否される
+  （T-0153 と同型、CHARTER §5.5）。T-0156 は `needs-human` に変更し、追記すべき YAML の具体的な
+  2行を `needs_human_reason` に書いた
+- `python3 ops/validate.py` / `python3 ops/check_app_list_sync.py` とも green を確認
+- 次の起動へ: この PR の CI green・merge を見届けること。backlog の todo は T-0117
+  （`not_before` 2026-08-07T03:30 JST 未到来）のみで、着手可能なタスクは無い

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T13:11:00Z",
+  "updated": "2026-08-06T13:17:00Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
@@ -1451,7 +1451,9 @@
       "kind": "in_cluster_loop",
       "by": "autopilot pod (実行役)",
       "summary": "実行役（journal run #159）。T-0153（autopilot 自身のイメージ digest pin 未検証）に着手し ops/check_autopilot_image_pin.py を新設・動作確認。CI (ci.yml) への配線は AUTOPILOT_GITHUB_TOKEN に workflow scope が無く push 拒否されると判明（CHARTER §5.5 に追記）、配線を差し戻しスクリプト単体を PR #356 として提出。T-0153 は配線待ちの needs-human に変更。",
-      "prs": [356]
+      "prs": [
+        356
+      ]
     },
     {
       "n": 160,
@@ -1475,7 +1477,17 @@
       "kind": "in_cluster_loop",
       "by": "autopilot pod (実行役)",
       "summary": "実行役（journal run #162）。T-0155（CHARTER §6 の自己矛盾: check_feedback.py は既にCI配線済みなのに「まだ」と記述していた）を修正。",
-      "prs": [362]
+      "prs": [
+        362
+      ]
+    },
+    {
+      "n": 163,
+      "at": "2026-08-06T13:17:00Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (実行役)",
+      "summary": "実行役（journal run #163）。T-0156（アプリ一覧drift5回目）: CLAUDE.md/apps/README.md を apps/kustomization.yaml の実態（agent-rbac/ops-dashboard/syncthing含む12件）に合わせて修正し、ops/check_app_list_sync.py を新規実装・動作確認済み。ci.yml への配線は workflow scope 不足で needs-human に切り出した（T-0153と同型）。",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`CLAUDE.md`（Apps 一覧・Directory Structure）と `apps/README.md`（ディレクトリ構造ツリー・`kubectl get application` サンプル出力）が `apps/kustomization.yaml` の実態（12 アプリ）からずれていました（`agent-rbac`/`ops-dashboard`/`syncthing` の記載漏れ）。同型の drift は T-0057/T-0089/T-0094/T-0134 で計4回起票・修正しており、今回で5回目の再発です。

- ドキュメント側を実態に合わせて修正
- 再発を防ぐため `ops/check_app_list_sync.py` を新規実装。`apps/kustomization.yaml` の `resources` から app 名を機械抽出し、`CLAUDE.md`/`apps/README.md` 内に一度も出現しないものを検出する

## 検証したこと

- `python3 ops/check_app_list_sync.py` が green
- 手元で1アプリ（`syncthing`）への言及を意図的に消した diff を作り、上記スクリプトが drift を検出することを確認（確認後に復元）
- `python3 ops/validate.py` が 0 error / 0 warning

## 残った作業（needs-human）

`ops/check_app_list_sync.py` を CI (`.github/workflows/ci.yml` の `ops` job) に配線する追記はこの PR に含めていません。この実行環境の `AUTOPILOT_GITHUB_TOKEN` に `workflow` scope が無く、`.github/workflows/**` への push が GitHub 側で拒否されるためです（T-0153 と同型）。

`workflow` scope を持つ credential で、`ops` job の「check docs reference only existing just recipes」ステップの直後に以下を追記して push してください:

```yaml
      - name: check app list in docs matches apps/kustomization.yaml
        run: python3 ops/check_app_list_sync.py
```

backlog の `T-0156` を `needs-human` にして上記を `needs_human_reason` にも記録しています。

## ロールバック手順

このコミットを revert すれば `CLAUDE.md`/`apps/README.md` は元の記載漏れがある状態に戻り、`ops/check_app_list_sync.py` も削除されます。スキーマやクラスタ状態を変更する変更ではないため、revert によるデータ不整合はありません。

## backlog task id

T-0156
