### PR TITLE
ops: T-0156 (#363) の merge 確認を journal に記録

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,33 +1,13 @@
 {
-  "open": [
+  "open": [],
+  "merged": [
     {
       "number": 363,
       "title": "docs: apps/kustomization.yaml のアプリ一覧をCLAUDE.md/apps/README.mdへ反映 (T-0156)",
       "url": "https://github.com/hikuohiku/homelab/pull/363",
-      "isDraft": false,
-      "createdAt": "2026-08-06T13:20:47Z",
-      "statusCheckRollup": [
-        {
-          "conclusion": "IN_PROGRESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "SUCCESS"
-        },
-        {
-          "conclusion": "IN_PROGRESS"
-        },
-        {
-          "conclusion": "IN_PROGRESS"
-        }
-      ],
-      "headRefName": "autopilot/T-0156-app-list-doc-drift",
-      "autoMergeRequest": null
-    }
-  ],
-  "merged": [
+      "mergedAt": "2026-08-06T13:22:25Z",
+      "headRefName": "autopilot/T-0156-app-list-doc-drift"
+    },
     {
       "number": 362,
       "title": "docs(ops): CHARTER.md の check_feedback.py CI記述を実態に合わせる (T-0155)",
@@ -440,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/303",
       "mergedAt": "2026-08-06T05:53:42Z",
       "headRefName": "autopilot/run112-nothing-actionable"
-    },
-    {
-      "number": 302,
-      "title": "fix(ops): VISION の段階表・state.json・CHARTER の自己申告を一致させる (T-0132)",
-      "url": "https://github.com/hikuohiku/homelab/pull/302",
-      "mergedAt": "2026-08-06T05:48:35Z",
-      "headRefName": "autopilot/T-0132-vision-stage-mismatch"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4659,3 +4659,10 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py` / `python3 ops/check_app_list_sync.py` とも green を確認
 - 次の起動へ: この PR の CI green・merge を見届けること。backlog の todo は T-0117
   （`not_before` 2026-08-07T03:30 JST 未到来）のみで、着手可能なタスクは無い
+
+## 2026-08-06 22:27 JST — run #163 追記（実行役, merge 確認）
+
+- PR #363 の CI 5 件（ops state validate / terraform validate / nix flake check /
+  kustomize build / manifest deletion guard）が全て green になったことを確認し、
+  `merge_method: merge` で merge。マージ済みブランチは GitHub 側で自動削除済み
+  （手動 delete は 422 で no-op）


### PR DESCRIPTION
ops/ の運用記録のみ（journal 追記・dashboard の PR キャッシュ再生成）。CHARTER §4 の相乗り例外に該当する記録専用の低リスク変更で、CI green を確認次第 merge する。

## backlog task id

T-0156（本体は #363 で merge 済み。この PR は journal への merge 確認記録のみ）