### PR TITLE
ops(run #164): T-0157 を起票（計画役の記録）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "next_id": 157,
-  "updated": "2026-08-06T13:30:00Z",
+  "next_id": 158,
+  "updated": "2026-08-06T13:35:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -2997,6 +2997,29 @@
       "created": "2026-08-06",
       "pr": 363,
       "notes": "run #163 (実行役): CLAUDE.md / apps/README.md のアプリ一覧を apps/kustomization.yaml の実態（12件、agent-rbac/ops-dashboard/syncthing含む）に合わせて修正し、ops/check_app_list_sync.py を新規実装・動作確認済み。.github/workflows/ci.yml への配線は workflow scope 不足で push できず needs-human に切り出した（T-0153 と同型）"
+    },
+    {
+      "id": "T-0157",
+      "domain": "homelab",
+      "title": "ci.yml の ops job を ops/check_*.py の個別 step 列挙から glob ループへ汎化する",
+      "kind": "ci",
+      "risk": "low",
+      "status": "todo",
+      "priority": 46,
+      "why": "T-0153（run #159, manifest-diff job 向け check_autopilot_image_pin.py）と T-0156（run #161-163, ops job 向け check_app_list_sync.py）が同じ構造的原因で2回連続 needs-human になった。原因は .github/workflows/ci.yml の ops job（139-155行目）が check_*.py を1本ずつ `run:` step として個別列挙する作りで、新しい no-arg 検証スクリプトを足すたびに .github/workflows/ci.yml への1行追記が要り、それが AUTOPILOT_GITHUB_TOKEN の workflow scope 不足で毎回 needs-human に落ちる（CHARTER §5.5）。ops job の既存4 step（check_version_sync.py/check_pvc_usage_script_sync.py/check_doc_commands.py/check_feedback.py）と T-0156 で配線待ちの check_app_list_sync.py はいずれも sys.argv を使わない no-arg スクリプトと実測済みで、シェルの glob ループに一般化できる（CHARTER §8『同じ判断を毎回手でやっている→CIかチェックリストで機械的に防ぐ』『同じミスを2回した→CIかチェックリストで機械的に防ぐ』）。汎化すれば今後 ops/check_*.py を追加するだけで自動的に CI に乗り、T-0156 のような配線待ちタスクが構造的に無くなる",
+      "dod": "ops job の個別 step（.github/workflows/ci.yml の『check duplicated version pins are in sync』〜『check human feedback ledger is consistent』の4 step、145-152行目）を、`ops/check_*.py` を glob で列挙して1本ずつ実行する単一 step に置き換える案を書く（例: `set -e` の後に `for f in ops/check_*.py; do echo \"::group::$f\"; python3 \"$f\"; echo \"::endgroup::\"; done`、1本が非0で終了したら即座にジョブ全体を失敗させること）。`ops/validate.py` は `validate.py` という別名でこの glob（`check_*.py`）にはそもそも一致しないため、引き続き専用の `validate` step のまま変更不要。書き換え後、対象5スクリプト（check_version_sync.py/check_pvc_usage_script_sync.py/check_doc_commands.py/check_feedback.py/check_app_list_sync.py）を手元で1本ずつ実行し、個別 step の場合と同じ exit code・標準出力になることを確認する。実際の .github/workflows/ci.yml への push は T-0153/T-0156 と同型で workflow scope 不足のため needs-human になる見込み。着手時に実際にそうであれば、needs_human_reason に置き換え後の diff をそのまま書いて切り出す。この変更が merge されたら、T-0156 の needs_human_reason に書かれた個別 step 追加はもう不要になる（check_app_list_sync.py は glob に自動的に含まれるため）。次にこの task に触れる計画役は、merge 済みなら T-0156 が実質解消しているか ci.yml の実行結果で確認し done にする。manifest-diff job（check_manifest_deletions.py/check_autopilot_image_pin.py、base/head 引数ありで呼び出し規約が違う、T-0153 の対象）は対象外（別タスク）",
+      "blocked_by": null,
+      "refs": [
+        ".github/workflows/ci.yml",
+        "ops/check_version_sync.py",
+        "ops/check_pvc_usage_script_sync.py",
+        "ops/check_doc_commands.py",
+        "ops/check_feedback.py",
+        "ops/check_app_list_sync.py"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #164（計画役）: T-0153/T-0156 が『ops/manifest-diff job への新規 check script 配線は毎回 workflow scope 不足で needs-human になる』という同じ構造的原因で2回連続再発したことに気づき起票（R-NNN 無し、レビュー役経由ではなく計画役の backlog 棚卸し中の直接発見）。CHARTER §8 の『同じミスを2回した』ケースに該当"
     }
   ]
 }

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 364,
+      "title": "ops: T-0156 (#363) の merge 確認を journal に記録",
+      "url": "https://github.com/hikuohiku/homelab/pull/364",
+      "mergedAt": "2026-08-06T13:23:55Z",
+      "headRefName": "autopilot/T-0156-journal-merge-record"
+    },
+    {
       "number": 363,
       "title": "docs: apps/kustomization.yaml のアプリ一覧をCLAUDE.md/apps/README.mdへ反映 (T-0156)",
       "url": "https://github.com/hikuohiku/homelab/pull/363",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/304",
       "mergedAt": "2026-08-06T05:59:45Z",
       "headRefName": "autopilot/run113-nothing-actionable"
-    },
-    {
-      "number": 303,
-      "title": "docs(ops): run #112 記録更新（着手可能タスクなし）",
-      "url": "https://github.com/hikuohiku/homelab/pull/303",
-      "mergedAt": "2026-08-06T05:53:42Z",
-      "headRefName": "autopilot/run112-nothing-actionable"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4666,3 +4666,42 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
   kustomize build / manifest deletion guard）が全て green になったことを確認し、
   `merge_method: merge` で merge。マージ済みブランチは GitHub 側で自動削除済み
   （手動 delete は 422 で no-op）
+
+## 2026-08-06 22:27 JST — run #164（計画役）
+
+- 前回の中断を拾う: オープン PR 0 件、`origin/autopilot/*` ブランチ 0 件。ローカル `main` は
+  `origin/main`（`484993e`）と一致
+- `ops/inbox.md` を確認: 見出し以下は空。変換対象なし
+- フィードバック取り込み: `ops-feedback` ブランチはまだ存在しない（`git ls-remote` で未確認）。
+  issue #56 を `per_page=100` で2ページ（計109件）確認し、`last_read`（2026-08-06T13:00:00Z）
+  以降の新規コメント無し。`last_read` を今回確認時刻に更新した
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T13:00:04Z`）で ArgoCD 13 アプリ中
+  `coder`/`immich`/`vaultwarden` が Degraded（従来どおり T-0106 由来の既知 `SecretSyncedError`
+  のみ）。`pod_issues` の restarts:19 常連も変化なし。autopilot 自身の heartbeat も正常
+  （iteration #3 進行中、直前の iteration #2 は exit_code 0）。新規異常なし
+- backlog の blocked/needs-human 全14件（T-0028, T-0029, T-0074, T-0084, T-0106, T-0107,
+  T-0112, T-0116, T-0118, T-0120, T-0140, T-0141, T-0144, T-0147, T-0148, T-0153, T-0156）を
+  自分で個別に読み直し、前提が変わっていないことを確認した（直前の run #161 の棚卸しから
+  実質的な時間経過が無く、新しい情報も無し）
+- todo は `T-0117`（`not_before` 2026-08-06T18:30:00Z 未到来）のみで着手可能なタスクが
+  引き続き枯れていたため、CHARTER §3 に従い調査。`.github/workflows/ci.yml` の `ops` job の
+  実体を読み直したところ、T-0153（run #159, manifest-diff job 向け）と T-0156（run #161-163,
+  ops job 向け）が「新しい no-arg 検証スクリプトを1本追加するたびに ci.yml への1行追記が要り、
+  それが AUTOPILOT_GITHUB_TOKEN の workflow scope 不足で毎回 needs-human になる」という
+  **同じ構造的原因**で2回連続再発していたと気づいた。`ops` job の該当5スクリプト
+  （check_version_sync.py/check_pvc_usage_script_sync.py/check_doc_commands.py/
+  check_feedback.py/check_app_list_sync.py）はいずれも `sys.argv` を使わない no-arg
+  スクリプトと実測（grep）で確認した。個別 step 列挙を `ops/check_*.py` の glob ループへ
+  汎化すれば、今後同種のスクリプトを足すたびに発生していた needs-human が構造的に無くなる
+  （CHARTER §8「同じミスを2回した→CIかチェックリストで機械的に防ぐ」）
+- 新規起票: **T-0157**（ci.yml の ops job を glob ループへ汎化する。manifest-diff job
+  (T-0153 対象) は base/head 引数ありで呼び出し規約が違うため対象外、別タスクのまま）
+- やったこと: T-0157 の起票（backlog.json のみ、コード変更なし）
+- `python3 ops/validate.py` を実行し 0 error / 0 warning であることを確認
+- 次の起動へ: T-0157（priority 46）が着手可能。T-0117 は `not_before`
+  2026-08-06T18:30:00Z 未到来のまま。T-0157 が merge されたら、次の計画回で T-0156 の
+  needs-human が実質解消しているか（check_app_list_sync.py が自動的に CI に乗るか）を
+  確認して done にすること
+- `python3 ops/dashboard/build.py` を実行し `ops-dashboard` ブランチへ publish 成功
+  （114065 bytes）。Artifact ツールはこの環境には無く、`dashboard.artifact_url` への
+  再公開は試みていない

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T13:17:00Z",
+  "updated": "2026-08-06T13:27:16Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T13:00:00Z"
+    "last_read": "2026-08-06T13:27:16Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc",
@@ -1487,6 +1487,14 @@
       "kind": "in_cluster_loop",
       "by": "autopilot pod (実行役)",
       "summary": "実行役（journal run #163）。T-0156（アプリ一覧drift5回目）: CLAUDE.md/apps/README.md を apps/kustomization.yaml の実態（agent-rbac/ops-dashboard/syncthing含む12件）に合わせて修正し、ops/check_app_list_sync.py を新規実装・動作確認済み。ci.yml への配線は workflow scope 不足で needs-human に切り出した（T-0153と同型）。",
+      "prs": []
+    },
+    {
+      "n": 164,
+      "at": "2026-08-06T13:27:16Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (計画役)",
+      "summary": "計画役（journal run #164）。inbox 空、フィードバック新規無し、健全性は既知の T-0106 由来 Degraded のみで新規異常無し。backlog blocked/needs-human 全14件の前提変化なし。todo は not_before 未到来の T-0117 のみで枯渇していたため調査し、T-0153/T-0156 が同じ構造的原因（ci.yml ops job の check script 個別列挙）で2回連続 needs-human になっていたと発見。汎化タスク T-0157 を起票。",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

計画役（journal run #164）の記録のみ。コード・マニフェストの変更は無い。

- **新規タスク起票**: T-0157「`ci.yml` の `ops` job を `ops/check_*.py` の個別 step 列挙から
  glob ループへ汎化する」
  - T-0153（run #159）と T-0156（run #161-163）が、同じ構造的原因（`ops`/`manifest-diff` job が
    検証スクリプトを1本ずつ `run:` step として列挙しており、新しいスクリプトを追加するたびに
    `.github/workflows/ci.yml` への1行追記が要り、それが `AUTOPILOT_GITHUB_TOKEN` の workflow
    scope 不足で毎回 needs-human になる）で2回連続再発したことに気づいた
  - `ops` job の該当5スクリプトはいずれも no-arg（`sys.argv` 未使用、実測済み）で glob ループへ
    一般化できる。実装自体は次の実行役に委ねる（このタスクは todo のまま）
- `ops/backlog.json`: T-0157 起票、`next_id` を 157→158
- `ops/state.json`: `runs` に run #164 を追記、`feedback.last_read` を更新（issue #56 に新規
  コメント無しを確認）
- `ops/journal/2026-08.md`: run #164 の記録
- `ops/dashboard/prs.json` / `ops/dashboard/index.html`: `python3 ops/dashboard/build.py` の
  実行に伴う再生成（`index.html` は Git 管理外、`ops-dashboard` ブランチへ publish 済み）

## 検証したこと

- `python3 ops/validate.py` → 0 error / 0 warning
- issue #56 を `per_page=100` で2ページ（計109件）確認し、`last_read` 以降の新規コメント無し
- `ops-health-report`（`generated_at: 2026-08-06T13:00:04Z`）で新規異常無し（`coder`/`immich`/
  `vaultwarden` の Degraded は既知の T-0106 由来のみ）
- backlog の blocked/needs-human 全14件を個別に読み直し、前提の変化が無いことを確認

## ロールバック手順

`ops/` の記録のみで実インフラへの影響は無い。revert すれば backlog/journal/state が
このコミット前の状態に戻る。データを持つコンポーネントの変更は無い。

## backlog task id

T-0157（起票）
