### PR TITLE
ops(run #166): PR #366 merge・フィードバック取り込み・heartbeat異常の記録

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,13 @@
   "open": [],
   "merged": [
     {
+      "number": 366,
+      "title": "ops(run #165): T-0157 を needs-human に切り出し（実行役の記録）",
+      "url": "https://github.com/hikuohiku/homelab/pull/366",
+      "mergedAt": "2026-08-06T14:12:36Z",
+      "headRefName": "autopilot/T-0157-ci-ops-job-glob"
+    },
+    {
       "number": 365,
       "title": "ops(run #164): T-0157 を起票（計画役の記録）",
       "url": "https://github.com/hikuohiku/homelab/pull/365",
@@ -413,13 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/306",
       "mergedAt": "2026-08-06T06:14:01Z",
       "headRefName": "autopilot/T-0112-post-pending-ask"
-    },
-    {
-      "number": 305,
-      "title": "docs(ops): run #114 記録更新（着手可能タスクなし）",
-      "url": "https://github.com/hikuohiku/homelab/pull/305",
-      "mergedAt": "2026-08-06T06:09:49Z",
-      "headRefName": "autopilot/run114-nothing-actionable"
     }
   ]
 }

--- a/ops/feedback.json
+++ b/ops/feedback.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T12:11:00Z",
+  "updated": "2026-08-06T14:20:00Z",
   "_comment": "人間からのフィードバックの台帳（正）。手順は ops/CHARTER.md §6。status: new（取り込んだ。扱いは未決）| accepted（起票した。task に T-XXXX）| done（片付いた）| declined（やらないと決めた）。done/declined には resolution（人間が読む一行）が必須で、これがダッシュボードに顛末として出る。accepted/done には task が必須。id は書かれた時点で確定し付け替えない。ops-dashboard から来たものは ops-feedback ブランチの ops/feedback/inbox/<id>.json が原本、issue から来たものは ref にコメント URL を置く。done/declined になって 90 日を過ぎたエントリは消してよい（review-log.md と同じ）",
   "inbox": {
     "branch": "ops-feedback",
@@ -13,5 +13,14 @@
     "cutoff": "2026-08-06T12:11:00Z",
     "_comment": "外から書ける経路として残す issue。cutoff は台帳に移行した時点（それ以前のコメントは ops/CHARTER.md 本文に反映済みで、原本は issue に残っている）。cutoff より新しいコメントで、その comment id が items の ref に無いものを取り込む。この値は動かさない"
   },
-  "items": []
+  "items": [
+    {
+      "id": "F-20260806T134136Z-c5205413264",
+      "source": "issue#56",
+      "received": "2026-08-06T13:41:36Z",
+      "ref": "https://github.com/hikuohiku/homelab/issues/56#issuecomment-5205413264",
+      "body": "## T-0107 の前提を実測で検証しました（記録が 2 点間違っています）\n\n構築セッションから実機に当たりました。結論を先に書きます。\n\n### 1. `1 to add` は誤検知です。ファイルは存在します\n\nPVE の CA を取り出し、証明書の SAN に載っている名前（`hikuo-homeserver`）で TLS 検証を通したうえで API に問い合わせた結果:\n\n```\nlocal:import/nixos-proxmox-cloud-v0.2.5.qcow2   997720064 bytes\n```\n\n`NIXOS_IMAGE_VERSION` が期待する `v0.2.5` そのものです。\n\n`terraform plan` を実際に走らせると、原因がはっきり出ます:\n\n```\nWarning: The file does not exist in datastore and resource must be recreated.\n  unexpected error when listing datastore files:\n  tls: failed to verify certificate\nPlan: 1 to add, 0 to change, 0 to destroy.\n```\n\n**provider は TLS 失敗を warning に握り潰し、「ファイルが存在しない」と結論しています。** つまり `1 to add` は TLS が直れば消えるはずのもので、node01 が再作成されるという恐れは前提から成り立っていません（ただし **TLS が直るまで apply しない判断は正しい**。いま apply すれば実際に再ダウンロードが走り、`replace_triggered_by` が発火しうる）。\n\n### 2. 「PVE 管理コンソールでの手作業」は誤りです\n\n`needs_human_reason` にそう書いてありますが、**`PROXMOX_API_TOKEN` は `/nodes` に `Sys.Modify` を持っています**（実測。47 権限）。証明書は `PUT /nodes/{node}/certificates/custom` で API から差し替えられます。コンソールは要りません。\n\n### 3. ただし本当の問題は SAN ではなく「CA を誰も信頼していない」ことです\n\n証明書の SAN はこうなっています:\n\n```\nIP:127.0.0.1, IP:::1, IP:192.168.1.2, DNS:hikuo-homeserver, DNS:hikuo-homeserver.local\n```\n\n実 IP の `192.168.0.2` は確かに入っていません（ネットワーク番号が変わった名残）。**しかし名前で繋いでも今度は「signed by unknown authority」で落ちます。** 発行者が PVE クラスタ CA で、クライアント側が信頼していないからです。**SAN を足すだけでは直りません。**\n\n### 提案する直し方\n\n`PROXMOX_ENDPOINT` は既に `https://hikuo-homeserver.tailae6c2.ts.net` です。**Tailscale は `*.ts.net` に対して Let's Encrypt の証明書を発行できます**（`tailscale cert`）。これを Proxmox に custom cert として入れれば:\n\n- 公的に信頼された CA なので、クライアント側に CA を配る必要が無い\n- SAN が endpoint と一致する\n- 更新も Tailscale 側の仕組みに乗る\n\n`tailscale cert` は Proxmox ホスト上で実行する必要があるので、**そこだけは人間の作業が残ります**（アップロード自体は API でできます）。SAN 追加や自己署名の作り直しより筋が良いはずですが、実行前に検証してください。\n\n### 記録の直し方（計画役へ）\n\nT-0107 の `why` と `needs_human_reason` を上の実測に合わせて書き直してください。特に:\n\n- 「ファイルが本当に無いのか TLS の副産物か未確定」→ **TLS の副産物と確定**\n- 「PVE コンソールでの手作業。autopilot にも構築セッションにも実行できない」→ **誤り。API で可能**\n- 残る人間の作業は `tailscale cert` の実行だけ（この方式を採るなら）\n\n### 構造の問題として\n\nこの `needs_human_reason` は一度書かれてから誰も検証していません。**「できない理由」を書いた時点でそれが事実として固定され、以後は読まれるだけになっています。** blocked / needs-human の理由は、書いた時点の観測でしかありません。アーキテクチャ・レビュー役の対象に「止まっている理由が今も成り立つか」を加えることを検討してください。",
+      "status": "new"
+    }
+  ]
 }

--- a/ops/inbox.md
+++ b/ops/inbox.md
@@ -11,3 +11,13 @@
 [`ops/CHARTER.md`](CHARTER.md) の §3「書く権利」。
 
 ---
+
+- run #166（実行役）: `ops-health-report`（`generated_at: 2026-08-06T14:00:04Z`）の
+  `autopilot.heartbeat.last_end` が iteration 13, exit_code **1**, elapsed 6 秒。history
+  （`ops/health/history/2026-08-06.jsonl`）を遡ると同日の直近 19 サンプルは全て exit_code 0 で、
+  今回が初めての非 0。elapsed 6 秒は通常の 1 iteration（実測 約9分）よりも著しく短く、起動直後に
+  落ちた可能性が高い。Pod 自体は `restartCount: 0` で正常稼働中（`kubectl get pods -n autopilot`）
+  なので loop.sh のシェルは生きており、1 回だけ中の `claude -p` 呼び出しが失敗した形。原因はログが
+  要る（autopilot ClusterRole に `pods/log` が無く自分では読めない）。単発かつ以降のイテレーション
+  （run #166 = このイテレーション自身）が通常どおり進行しているため即座に止まる判断はしなかったが、
+  再発するようなら構築セッションにログ調査を issue #56 経由で頼む調査タスクを起票してほしい

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4733,3 +4733,37 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - 次の起動へ: backlog の todo は 0 件（T-0117 は `not_before` 2026-08-06T18:30:00Z
   未到来のまま）。次の計画回は調査タスクの起票が必要になる見込み。T-0157/T-0156 とも
   workflow scope 付き credential での適用待ちで揃っている
+
+## 2026-08-06 23:15 JST — run #166（実行役）
+
+- 前回の中断を拾う: オープン PR は #366（T-0157 needs-human への記録更新、CI 6件 green・
+  `mergeable_state: clean`）の 1 件。低リスク（`ops/` 記録のみ）のため CI green を確認して
+  そのまま `merge_method: merge` で merge。ブランチは GitHub 側で自動削除済み
+  （手動 DELETE は「Reference does not exist」で no-op、想定どおり）。ローカル `main` を
+  `origin/main`（`42e58a6`）に同期。他に `autopilot/*` ブランチは残っていない
+- 取り込んだフィードバック: **F-20260806T134136Z-c5205413264**（issue #56,
+  2026-08-06T13:41:36Z）。T-0107（Proxmox pveproxy 証明書 SAN 不一致）について構築セッションが
+  実機検証した結果、(1) `1 to add` は TLS 検証失敗の副作用で実ファイルは存在する、
+  (2) 証明書差し替えは `PROXMOX_API_TOKEN` の `Sys.Modify` で API から可能（PVE コンソール手作業は
+  誤り）、(3) 真因は SAN 不一致ではなく CA 不信任で、`tailscale cert` を使った差し替えを提案。
+  `ops/feedback.json` に `status: new` で追記した（扱いの判断は計画役）。今回進めていた作業内容
+  とは矛盾しない（T-0117 は not_before 未到来で着手していない）ため作業方針の変更はなし
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T14:00:04Z`）で ArgoCD は
+  coder/immich/vaultwarden が引き続き Degraded（既知の T-0106 由来 `SecretSyncedError` のみ、
+  新規異常なし）。`pod_issues` の restarts:19 常連も変化なし。**autopilot 自身の heartbeat に
+  異常あり**: `last_end` が iteration 13, exit_code **1**, elapsed 6 秒。history
+  （`ops/health/history/2026-08-06.jsonl`）で同日の直近 19 サンプルは全て exit_code 0 で、
+  今回が初の非 0。elapsed 6 秒は通常（実測 約9分/iteration）より著しく短く、`claude -p` 起動直後に
+  落ちた可能性が高い。Pod は `restartCount: 0` で稼働中（`kubectl get pods -n autopilot`）、
+  events は保持期限切れで空、ログは autopilot の ClusterRole に `pods/log` が無く自分では読めない。
+  単発でありこのイテレーション自身が正常に進行していることから新規タスクへの着手を止める判断は
+  しなかったが、`ops/inbox.md` に事実を記録した（再発したら構築セッションへのログ調査依頼を検討
+  してほしい）
+- backlog: `T-0117` は `not_before` 2026-08-06T18:30:00Z 未到来で唯一の todo が引き続き
+  着手不能。他は前回棚卸し（run #164）から実質的な時間経過が無いため個別の再確認はしていない
+- やったこと: 上記のフィードバック取り込みと inbox 記録のみ。実装タスクの着手は無し
+  （実行役は起票できないため、着手可能なタスクが無いときの唯一の選択）
+- `python3 ops/validate.py` / `python3 ops/check_feedback.py` とも 0 error を確認
+- 次の起動へ: T-0117 は 2026-08-06T18:30:00Z 以降に actionable になる。それまでは
+  todo が空。F-20260806T134136Z-c5205413264 の扱い（T-0107 の `needs_human_reason` 訂正）は
+  計画役の判断待ち。autopilot heartbeat exit_code=1 の再発有無を次回も確認すること

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T13:38:28Z",
+  "updated": "2026-08-06T14:15:33Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
@@ -1503,6 +1503,16 @@
       "kind": "scheduled",
       "by": "in-cluster loop",
       "summary": "実行役（journal run #165）。フィードバック新規無し（ops-feedback ブランチ未作成、issue #56 last_read 以降新規コメント無し）。オープン PR・autopilot ブランチとも無く中断なし。T-0117 は not_before 未到来のため、唯一の todo だった T-0157（ci.yml ops job の glob 化）に着手。5対象スクリプトの個別実行・glob ループ実行（fail-fast含む）を手元検証済みだが、ci.yml への実 push は想定どおり workflow scope 不足で拒否されたため diff を needs_human_reason に切り出し needs-human とした（コード変更なし、backlog.json のみ）。",
+      "prs": [
+        366
+      ]
+    },
+    {
+      "n": 166,
+      "at": "2026-08-06T14:15:33Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (実行役)",
+      "summary": "実行役（journal run #166）。オープン PR #366（T-0157 needs-human 記録）を CI green 確認のうえ merge。フィードバック F-20260806T134136Z-c5205413264（T-0107 の実測訂正、issue #56）を台帳に new で追記。autopilot heartbeat の exit_code=1（iteration 13、直近19サンプル初の非0）を検知し inbox に記録。todo は T-0117（not_before 未到来）のみで着手可能なタスク無し。",
       "prs": [
         366
       ]


### PR DESCRIPTION
## 変更点

今回（run #166、実行役）の作業記録のみです。コード・マニフェストの変更はありません。

- 前回の中断（オープン PR #366、T-0157 を needs-human に切り出す記録更新）を CI green
  （6件成功）を確認したうえで `merge_method: merge` で merge しました
- issue #56 に届いていた新しいフィードバック（T-0107 の Proxmox 証明書問題について構築セッションが
  実機検証した結果の訂正提案）を `ops/feedback.json` に `status: new` で取り込みました。
  扱い（backlog への反映）は次の計画役の判断です
- `ops-health-report` を確認したところ、`applications` の Degraded 3件（coder/immich/vaultwarden）は
  既知（T-0106）の範囲内で新規異常はありませんでしたが、**autopilot 自身の heartbeat に
  `exit_code: 1`（iteration 13）を検知**しました。同日の直近19サンプルは全て exit_code 0 で今回が
  初の非0、elapsed も 6 秒と通常（約9分/iteration）より著しく短いことから、起動直後に落ちた
  可能性が高いです。ログを見る権限が無いため原因は特定できておらず、`ops/inbox.md` に記録して
  次の計画回の判断材料としました。Pod 自体は `restartCount: 0` で正常稼働中で、このイテレーション
  自身も正常に進行しています
- backlog の todo は T-0117（`not_before` 2026-08-06T18:30:00Z 未到来）のみで、着手可能な
  タスクはありませんでした（実行役は新規起票ができないため）

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/check_feedback.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 生成成功、`ops-dashboard` ブランチへ publish 成功

## ロールバック手順

`ops/` 配下の記録ファイル（journal・state.json・feedback.json・inbox.md・dashboard/prs.json）
のみの変更です。コード・マニフェストへの変更は含まれないため、revert すれば記録が巻き戻るだけで
実インフラやスキーマへの影響はありません。

## backlog task id

なし（記録のみ。関連: T-0157 は #366 で merge 済み、T-0107 は F-20260806T134136Z-c5205413264 の
取り込みのみで計画役の判断待ち）
