### PR TITLE
feat(ops-health-reporter): 落ちた理由を消える前に残す

### DIFF
--- a/apps/autopilot/deployment.yaml
+++ b/apps/autopilot/deployment.yaml
@@ -48,6 +48,7 @@ spec:
           # 終わったのを待ってこの行のダイジェストも合わせて更新する
           # （ghcr の package が private の場合は imagePullSecrets が別途要る）
           image: ghcr.io/hikuohiku/homelab-autopilot@sha256:1ef41f711651af72fea996ba95c0e0a6e9171f4e6f5579325f54fed1605938a8
+          terminationMessagePolicy: FallbackToLogsOnError
           command: ["bash", "/config/loop.sh"]
           securityContext:
             allowPrivilegeEscalation: false

--- a/apps/coder/deployment.yaml
+++ b/apps/coder/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       containers:
         - name: coder
           image: ghcr.io/coder/coder:v2.35.3
+          terminationMessagePolicy: FallbackToLogsOnError
           command: ["/opt/coder"]
           args: ["server"]
           securityContext:

--- a/apps/coder/postgres.yaml
+++ b/apps/coder/postgres.yaml
@@ -35,6 +35,7 @@ spec:
       initContainers:
         - name: init-permissions
           image: busybox:1.38.0
+          terminationMessagePolicy: FallbackToLogsOnError
           command: ["sh", "-c", "chown -R 999:999 /var/lib/postgresql/data"]
           securityContext:
             runAsUser: 0
@@ -44,6 +45,7 @@ spec:
       containers:
         - name: postgres
           image: postgres:17.10
+          terminationMessagePolicy: FallbackToLogsOnError
           # 公式 postgres イメージは UID/GID 999 で postgres ユーザーを作成する
           # (docker-library/postgres Dockerfile: groupadd -r postgres --gid=999,
           # useradd -r -g postgres --uid=999)。init-permissions の chown 999:999 と揃える。

--- a/apps/coder/pvc-usage-cronjob.yaml
+++ b/apps/coder/pvc-usage-cronjob.yaml
@@ -197,6 +197,7 @@ spec:
           containers:
             - name: pvc-usage
               image: python:3.14-alpine
+              terminationMessagePolicy: FallbackToLogsOnError
               command: ["python", "/scripts/pvc_usage.py"]
               env:
                 - name: PVC_MOUNTS

--- a/apps/coder/restic-backup-cronjob.yaml
+++ b/apps/coder/restic-backup-cronjob.yaml
@@ -29,6 +29,7 @@ spec:
           initContainers:
             - name: pg-dump
               image: postgres:17.10
+              terminationMessagePolicy: FallbackToLogsOnError
               command:
                 - sh
                 - -c
@@ -64,6 +65,7 @@ spec:
           containers:
             - name: restic-backup
               image: restic/restic:0.19.1
+              terminationMessagePolicy: FallbackToLogsOnError
               command:
                 - sh
                 - -c
@@ -136,6 +138,7 @@ spec:
           containers:
             - name: restic-forget
               image: restic/restic:0.19.1
+              terminationMessagePolicy: FallbackToLogsOnError
               command:
                 - sh
                 - -c

--- a/apps/coder/workspace-home-backup-cronjob.yaml
+++ b/apps/coder/workspace-home-backup-cronjob.yaml
@@ -300,6 +300,7 @@ spec:
           containers:
             - name: spawn-backup-jobs
               image: python:3.14-alpine
+              terminationMessagePolicy: FallbackToLogsOnError
               command: ["python", "/scripts/spawn_backup_jobs.py"]
               env:
                 - name: PYTHONDONTWRITEBYTECODE
@@ -352,6 +353,7 @@ spec:
           containers:
             - name: restic-forget
               image: restic/restic:0.19.1
+              terminationMessagePolicy: FallbackToLogsOnError
               command:
                 - sh
                 - -c

--- a/apps/immich/postgres.yaml
+++ b/apps/immich/postgres.yaml
@@ -38,6 +38,7 @@ spec:
       initContainers:
         - name: init-permissions
           image: busybox:1.38.0
+          terminationMessagePolicy: FallbackToLogsOnError
           command: ["sh", "-c", "chown -R 26:999 /var/lib/postgresql/data"]
           securityContext:
             runAsUser: 0
@@ -47,6 +48,7 @@ spec:
       containers:
         - name: postgres
           image: ghcr.io/tensorchord/cloudnative-vectorchord:16.9-0.4.3
+          terminationMessagePolicy: FallbackToLogsOnError
           # このイメージは CloudNativePG operand イメージ (postgres-containers)
           # を継承しており、ベースの Debian postgres ユーザー (UID/GID 999) に
           # usermod -u 26 postgres で UID のみ 26 に変更している (GID は 999 のまま)。

--- a/apps/immich/pvc-usage-cronjob.yaml
+++ b/apps/immich/pvc-usage-cronjob.yaml
@@ -197,6 +197,7 @@ spec:
           containers:
             - name: pvc-usage
               image: python:3.14-alpine
+              terminationMessagePolicy: FallbackToLogsOnError
               command: ["python", "/scripts/pvc_usage.py"]
               env:
                 - name: PVC_MOUNTS

--- a/apps/immich/restic-backup-cronjob.yaml
+++ b/apps/immich/restic-backup-cronjob.yaml
@@ -34,6 +34,7 @@ spec:
           containers:
             - name: restic-backup
               image: restic/restic:0.19.1
+              terminationMessagePolicy: FallbackToLogsOnError
               command:
                 - sh
                 - -c
@@ -114,6 +115,7 @@ spec:
           containers:
             - name: restic-forget
               image: restic/restic:0.19.1
+              terminationMessagePolicy: FallbackToLogsOnError
               command:
                 - sh
                 - -c

--- a/apps/ops-dashboard/deployment.yaml
+++ b/apps/ops-dashboard/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       initContainers:
         - name: fetch-init
           image: alpine:3.22.5
+          terminationMessagePolicy: FallbackToLogsOnError
           command:
             - sh
             - -c
@@ -54,6 +55,7 @@ spec:
         # 認証不要で raw.githubusercontent.com から読める）を定期取得して共有 volume に置く。
         - name: fetcher
           image: alpine:3.22.5
+          terminationMessagePolicy: FallbackToLogsOnError
           command:
             - sh
             - -c
@@ -97,6 +99,7 @@ spec:
         # ops/feedback.json へ取り込んで状態を進める
         - name: httpd
           image: python:3.14-alpine
+          terminationMessagePolicy: FallbackToLogsOnError
           command: ["python3", "/config/server.py"]
           env:
             - name: WWW_ROOT

--- a/apps/ops-health-reporter/cronjob.yaml
+++ b/apps/ops-health-reporter/cronjob.yaml
@@ -27,6 +27,7 @@ spec:
           containers:
             - name: report
               image: python:3.14-alpine
+              terminationMessagePolicy: FallbackToLogsOnError
               command: ["python", "/scripts/report.py"]
               env:
                 - name: GITHUB_TOKEN

--- a/apps/ops-health-reporter/report.py
+++ b/apps/ops-health-reporter/report.py
@@ -65,9 +65,51 @@ def collect_applications():
     return out
 
 
+# 異常時に残す証拠の大きさ。terminationMessage は kubelet 側で 4096 バイトに
+# 切られるが、履歴（history/*.jsonl）は 1 行 1 レポートで無限に伸びるので
+# こちら側でも切る。FATAL の 1 行が読めれば足りるので 1200 文字にした。
+TERMINATION_MESSAGE_LIMIT = 1200
+# 1 レポートに載せる証拠の上限。全 Pod が同時に壊れてもファイルが破裂しない。
+MAX_EVIDENCE_PER_REPORT = 8
+
+
+def _terminated_evidence(cs):
+    """直前に終了したコンテナの証拠を取り出す。
+
+    「落ちた」ことだけを記録して「なぜ落ちたか」を捨てていたため、後から調べた
+    ときには必ず手遅れになっていた（T-0112: immich-postgres の CrashLoopBackOff の
+    FATAL が、events もログも保持期間切れで誰にも分からなくなった）。
+
+    lastState.terminated は `pods` の read 権限だけで読める。ログ本文を取るには
+    pods/log が要るが、それは autopilot namespace に閉じる判断を既にしている
+    （T-0110、rbac.yaml のコメント参照）。その判断を覆さずに原因を残すため、
+    ワークロード側を terminationMessagePolicy: FallbackToLogsOnError にして
+    kubelet に異常終了時のログ末尾を message へ入れさせている。
+    """
+    term = (cs.get("lastState") or {}).get("terminated")
+    if not term:
+        return None
+    message = (term.get("message") or "").strip()
+    truncated = len(message) > TERMINATION_MESSAGE_LIMIT
+    return {
+        "container": cs.get("name"),
+        # restart_count 込みで「どの落下か」が一意になる。同じ値なら同じ事象なので
+        # 読む側で重複を捨てられる（レポートは 30 分毎に出るため）
+        "signature": "{}:{}".format(cs.get("name"), cs.get("restartCount", 0)),
+        "exit_code": term.get("exitCode"),
+        "reason": term.get("reason"),
+        "finished_at": term.get("finishedAt"),
+        "message": message[:TERMINATION_MESSAGE_LIMIT] if message else None,
+        "message_truncated": truncated,
+        # message が空なら、そのワークロードが FallbackToLogsOnError になっていない
+        "message_available": bool(message),
+    }
+
+
 def collect_pod_issues():
     data = k8s_get("/api/v1/pods")
     issues = []
+    evidence_budget = MAX_EVIDENCE_PER_REPORT
     for item in data.get("items", []):
         meta = item.get("metadata", {})
         status = item.get("status", {})
@@ -80,15 +122,20 @@ def collect_pod_issues():
             if "waiting" in cs.get("state", {})
         ]
         if phase not in ("Running", "Succeeded") or restarts > 3 or waiting_reasons:
-            issues.append(
-                {
-                    "name": meta.get("name"),
-                    "namespace": meta.get("namespace"),
-                    "phase": phase,
-                    "restarts": restarts,
-                    "waiting_reasons": waiting_reasons,
-                }
-            )
+            issue = {
+                "name": meta.get("name"),
+                "namespace": meta.get("namespace"),
+                "phase": phase,
+                "restarts": restarts,
+                "waiting_reasons": waiting_reasons,
+            }
+            evidence = [e for e in (_terminated_evidence(cs) for cs in cs_list) if e]
+            if evidence and evidence_budget > 0:
+                issue["terminated"] = evidence[:evidence_budget]
+                evidence_budget -= len(issue["terminated"])
+            elif evidence:
+                issue["terminated_omitted"] = len(evidence)
+            issues.append(issue)
     return issues
 
 

--- a/apps/syncthing/deployment.yaml
+++ b/apps/syncthing/deployment.yaml
@@ -24,6 +24,7 @@ spec:
           # （GitHub Releases で breaking change の記載なしを確認済み、DB は SQLite で新規インストールは
           # マイグレーション対象外）
           image: syncthing/syncthing:2.1.3
+          terminationMessagePolicy: FallbackToLogsOnError
           # 公式イメージの entrypoint (script/docker-entrypoint.sh) は root で起動し、$HOME
           # (=/var/syncthing) を PUID:PGID へ chown した上で su-exec により非 root (既定 1000:1000)
           # へ権限を落として実行する（GitHub syncthing/syncthing 実測、2026-08-06）。vaultwarden と

--- a/apps/vaultwarden/deployment.yaml
+++ b/apps/vaultwarden/deployment.yaml
@@ -26,6 +26,7 @@ spec:
         # local-path の PVC は root:root で作成されるため、非 root 実行に備えて所有権を調整
         - name: init-permissions
           image: busybox:1.38.0
+          terminationMessagePolicy: FallbackToLogsOnError
           command: ["sh", "-c", "chown -R 1000:1000 /data"]
           securityContext:
             runAsUser: 0
@@ -38,6 +39,7 @@ spec:
           # 1.37.0 が Bitwarden クライアント 2026.7.0+ の対応に必須。
           # 1.37.1 は alpine イメージのビルド不具合 (OpenSSL) 修正を含むため alpine では 1.37.1 を採る。
           image: vaultwarden/server:1.37.1-alpine
+          terminationMessagePolicy: FallbackToLogsOnError
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/apps/vaultwarden/pvc-usage-cronjob.yaml
+++ b/apps/vaultwarden/pvc-usage-cronjob.yaml
@@ -197,6 +197,7 @@ spec:
           containers:
             - name: pvc-usage
               image: python:3.14-alpine
+              terminationMessagePolicy: FallbackToLogsOnError
               command: ["python", "/scripts/pvc_usage.py"]
               env:
                 - name: PVC_MOUNTS

--- a/apps/vaultwarden/restic-backup-cronjob.yaml
+++ b/apps/vaultwarden/restic-backup-cronjob.yaml
@@ -76,6 +76,7 @@ spec:
           initContainers:
             - name: sqlite-snapshot
               image: python:3.14-alpine
+              terminationMessagePolicy: FallbackToLogsOnError
               command: ["python", "/scripts/sqlite_backup.py"]
               env:
                 - name: SRC_DB
@@ -115,6 +116,7 @@ spec:
           containers:
             - name: restic-backup
               image: restic/restic:0.19.1
+              terminationMessagePolicy: FallbackToLogsOnError
               command:
                 - sh
                 - -c
@@ -202,6 +204,7 @@ spec:
           containers:
             - name: restic-forget
               image: restic/restic:0.19.1
+              terminationMessagePolicy: FallbackToLogsOnError
               command:
                 - sh
                 - -c


### PR DESCRIPTION
T-0112（immich-postgres の CrashLoopBackOff の FATAL を確認する）を調べようとして、**証拠が完全に消えていた**。

- 現行 Pod は 14 時間 Running・再起動 0（旧イメージに戻されている）。`--previous` は not found
- `kubectl get events` に該当なし（保持期間切れ）
- 検証用だった `immich-postgres-bootstrap-verify` の Pod も残っていない

唯一残っていたのが `ops-health-report` ブランチの履歴で、内容はこれだけだった:

```json
{"name":"immich-postgres-596b8c498d-lm4p2","namespace":"immich",
 "restarts":6,"waiting_reasons":["CrashLoopBackOff"]}
```

**「落ちた」ことは記録され、「なぜ落ちたか」は捨てられている。** 30 分ごとに巡回して異常を見つけているのに、その瞬間にしか取れない情報を残していない。だから調べようとしたときには毎回手遅れで、「人間に見てもらう」以外の道が残らない。T-0112 が `needs-human` なのは権限の問題ではなく、これが理由だった。

## 変更

`pod_issues` の各エントリに `lastState.terminated` を載せる。`exit_code` / `reason` / `finished_at` / `message`。

**これは `pods` の read 権限だけで読める。** ログ本文を取るには `pods/log` が要るが、**それは autopilot namespace に閉じるという判断を T-0110 で既にしている**（`rbac.yaml` のコメント: 「他 namespace のワークロードのログを読む経路を一切新設したくない」）。その判断は今も妥当なので覆さない。

代わりにワークロード側を **`terminationMessagePolicy: FallbackToLogsOnError`** にした。異常終了時に kubelet がログ末尾を `terminated.message` に入れてくれるので、**権限を広げずに原因が残る**。自前マニフェストの 26 コンテナに入れた。

## 量の上限

- `message` は 1200 文字で切る（kubelet 側でも 4096 バイトに切られるが、履歴は 1 行 1 レポートで無限に伸びるのでこちらでも切る。FATAL の 1 行が読めれば足りる）
- 1 レポートあたり証拠 8 件まで。溢れたら `terminated_omitted` に件数だけ残す
- `signature`（コンテナ名 + restartCount）を付ける。同じ値なら同じ落下なので、読む側で重複を捨てられる

## 未設定の箇所が自己申告される

`message_available: false` は「そのワークロードがまだ `FallbackToLogsOnError` になっていない」を意味する。immich の Helm chart 側 3 コンテナ（server / machine-learning / valkey）が該当する。**vendored chart なので今回は触っていない。** レポートを読めばどこが未設定か分かるので、必要になった時点で values.yaml に入れればよい。

## 検証

実クラスタの Pod status（`kubectl get pods -A -o json`）を食わせて動作を確認した。異常 Pod 7 件を検知し、うち argocd の 4 コンテナで `exit=255 / reason=Unknown / message_available=False` を抽出できている（この 4 つは policy 適用前なので `message` が空になるのが正しい）。

**クラスタでの実動作は未実測**（kubectl が read-only のため CronJob を走らせられない）。次の巡回で `latest.json` に `terminated` が載ることで確認できる。