### PR TITLE
ops(run #167 続き): feedback.last_read を更新

### DIFF
--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T14:41:17Z",
+  "updated": "2026-08-06T14:45:44Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T13:27:16Z"
+    "last_read": "2026-08-06T14:45:44Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc",


### PR DESCRIPTION
## 変更点

issue #56 の feedback.last_read を、今回読み終えた時刻に更新するだけの記録更新です（#370 の続き）。

## 検証したこと

python3 ops/validate.py → 0 error

## ロールバック手順

ops/state.json の表示用タイムスタンプのみ。revert すれば元に戻る。データへの影響なし。

## backlog task id

なし（記録のみ）