### PR TITLE
ops(run #168): 計画回の記録のみ（新規異常・新規起票なし）

### DIFF
--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4811,3 +4811,37 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py` / `python3 ops/check_feedback.py` とも 0 error を確認
 - 次の起動へ: backlog の todo は引き続き 0 件（T-0117 は 2026-08-06T18:30:00Z 以降）。
   autopilot 自身の Progressing/0-replica が次スナップショットでも続いていれば最優先で調査すること
+
+## 2026-08-06 23:51 JST — run #168（計画役）
+
+- 取り込んだフィードバック: なし。issue #56 の `last_read`（2026-08-06T14:45:44Z）以降、
+  新規コメント無し（`per_page=100` の 1・2 ページ目とも確認、罠は踏んでいない）。
+  `ops-feedback` ブランチは存在せず（`git branch -r` で不在確認）、ダッシュボード経由の
+  書き置きも無い
+- inbox: 空（run #167 が処理済みのまま変化なし）
+- 健全性確認: run #167 が「次のスナップショット（15:00 台）で確認すること」と引き継いだ
+  autopilot 自身の `Progressing`/`readyReplicas: 0` を、この起動は in-cluster pod のため
+  `kubectl` で直接確認した（30分毎の health snapshot 到来を待たずに済んだ）。ArgoCD
+  Application `autopilot` は `sync: Synced` / `health: Healthy`（`lastTransitionTime`
+  14:30:17Z）、Deployment は `readyReplicas: 1/1`（`MinimumReplicasAvailable`、同時刻から）。
+  PR #368（`terminationMessagePolicy` 追加）のロールアウトによる一時的な Progressing
+  だったと確定した。インシデントではない。他: `kubectl get externalsecret -A` で
+  coder/immich/vaultwarden の `Degraded` が引き続き `<app>-restic-backup-credentials` の
+  `SecretSyncedError` のみ（他の ExternalSecret は全て `SecretSynced`）であることを確認、
+  T-0106 の既知事象で変化なし。pod restarts の `19` 常連（argocd 系4件・coredns・
+  local-path-provisioner・metrics-server）も `kubectl get pods -A` で変化なしを確認。
+  immich の `backup_listing` 最新ファイルは `2026-08-06T02:00:05Z`（24時間以内）で健全。
+  `node_metrics`（cpu 約0.41 core, memory 約6.24GiB）に異常兆候なし
+- backlog 棚卸し: blocked/needs-human 14件の前提を再確認したが、run #167 から実質的な
+  時間経過が無く（約10分）新たな変化は無し。todo は T-0117 のみで `not_before`
+  （2026-08-06T18:30:00Z）未到来
+- 新規起票: なし。まだ観測していないものを探したが（`review-log.md` は `R-NNN` エントリ
+  無し＝レビュー役未実施、`inventory.json` は run #167 が直前に全 `policy: auto` 対象を
+  upstream と突き合わせ済み、health history の蓄積は T-0084 の再確認にはまだ早い）、
+  着手価値のある新しいギャップは見つからなかった。busywork のための起票はしない判断
+- やったこと: 上記の確認と journal/state の記録のみ。`ops/` の記録のみの変更のため
+  PR は risk: low
+- `python3 ops/validate.py` / `python3 ops/check_feedback.py` とも 0 error を確認
+- 次の起動へ: todo は T-0117 のみ（2026-08-06T18:30:00Z 以降）。それまでは引き続き
+  todo が空の状態が続く見込み。autopilot 自身の健全性は今回 Healthy に復帰したことを
+  確定済みなので、次回は通常の定期確認に戻ってよい

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T14:45:44Z",
+  "updated": "2026-08-06T14:51:21Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
@@ -220,6 +220,14 @@
       "kind": "in_cluster_loop",
       "by": "autopilot pod (計画役)",
       "summary": "計画役（journal run #167）。フィードバック F-20260806T134136Z-c5205413264（T-0107 実測訂正）を accepted にし、T-0107 の why/dod/needs_human_reason/human_action を実測どおりに書き直した（真因は CA 不信任、証明書差し替えは API 可能、残る人間作業は tailscale cert 実行のみ）。issue #56 に14:24:40Z 付けで「反映済み」という別コメントがあったが main には未反映だったと判明、実際に反映したのはこの回。needs-human 7件（T-0106/T-0140/T-0141/T-0144/T-0148/T-0153/T-0156/T-0157）に欠けていた human_action を追記。ops/inventory.json の policy:auto 全対象を upstream と突き合わせ actionable な差分無しと確認。inbox の heartbeat 単発異常は CHARTER §2 の標準手順でカバーされるため起票せず削除。",
+      "prs": []
+    },
+    {
+      "n": 168,
+      "at": "2026-08-06T14:51:21Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (計画役)",
+      "summary": "計画役（journal run #168）。フィードバック・inbox とも新規無し。run #167 が引き継いだ autopilot 自身の Progressing/readyReplicas:0 を kubectl で直接確認し、14:30:17Z 時点で Synced/Healthy・1/1 に復帰済みと確定（PR #368 ロールアウトの一時的な状態だった、インシデントではない）。coder/immich/vaultwarden の Degraded は T-0106 由来の SecretSyncedError のみで変化なし、pod restarts の19常連・immich backup_listing・node_metrics も異常無し。backlog blocked/needs-human 14件の前提に変化なし、todo は T-0117（not_before 未到来）のみ。新規起票価値のあるギャップは見つからず、busywork のための起票はしなかった。",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

計画回（run #168）の記録のみ。コード・マニフェストの変更は無し。

- `ops/journal/2026-08.md`: run #168 のエントリを追記
- `ops/state.json`: `runs` に run #168 を追記、`updated` を更新

## 今回確認したこと

- **run #167 が引き継いだ懸念（autopilot 自身の ArgoCD Application が `Progressing`、
  Deployment が `readyReplicas: 0`）を解消。** この起動は in-cluster pod のため `kubectl` で
  直接確認したところ、`sync: Synced` / `health: Healthy`、Deployment は `readyReplicas: 1/1`
  （`14:30:17Z` 以降）だった。直前にマージされた PR #368 のロールアウトによる一時的な状態と
  確定し、インシデントではない
- coder/immich/vaultwarden の `Degraded` は引き続き T-0106 由来の `SecretSyncedError`
  （`<app>-restic-backup-credentials`）のみで、他の ExternalSecret には波及していない
- pod restarts の `19` 常連（ノード再起動由来、既知）、immich の DB バックアップ
  （最新ファイル `2026-08-06T02:00:05Z`、24時間以内）、node のリソース使用量とも異常無し
- issue #56 に新規フィードバックなし（`per_page=100` の1・2ページとも確認）、`ops-feedback`
  ブランチも存在せず未取り込みの書き置きなし
- backlog の blocked/needs-human 14件の前提を再確認したが、run #167 から実質的な時間経過が
  無く変化なし。todo は T-0117（`not_before` 未到来）のみで、着手可能な新規タスクは見つからなかった

## 検証したこと

- `python3 ops/validate.py` → 0 error
- `python3 ops/check_feedback.py` → 0 error

## ロールバック手順

`ops/journal/2026-08.md` と `ops/state.json` のみの変更。revert すれば記録が消えるだけで、
インフラ・スキーマへの影響は無い。

## backlog task id

無し（記録のみ、CHARTER §4 の相乗り例外に該当）
