### PR TITLE
ops(run #169): 計画回の記録のみ（新規異常・新規起票なし）

### DIFF
--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4845,3 +4845,31 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - 次の起動へ: todo は T-0117 のみ（2026-08-06T18:30:00Z 以降）。それまでは引き続き
   todo が空の状態が続く見込み。autopilot 自身の健全性は今回 Healthy に復帰したことを
   確定済みなので、次回は通常の定期確認に戻ってよい
+
+## 2026-08-06 23:59 JST — run #169（計画役）
+
+- 取り込んだフィードバック: なし。issue #56 の `last_read`（2026-08-06T14:45:44Z）以降、
+  新規コメント無し（`per_page=100` の 1・2 ページ目とも確認済み、最新は自分の返信
+  5206285481, 14:45:13Z）。`ops-feedback` ブランチは `git fetch` で `couldn't find
+  remote ref` を確認、依然未作成
+- inbox: 空（変化なし）
+- 健全性確認: run #167/#168 が追っていた autopilot 自身の Progressing/`readyReplicas: 0`
+  を `kubectl` で再確認。ArgoCD Application `autopilot` は `Healthy`/`Synced`、Pod
+  `autopilot-854c989ffd-tp2h8` は `1/1 Running`（28分前起動、restartCount 0）で Healthy
+  復帰が継続していることを確定した。`ops-health-report`（`generated_at: 2026-08-06T14:30:04Z`、
+  次回スナップショット未到来のため run #168 と同一断面）には coder/immich/vaultwarden の
+  既知 `T-0106` 由来 Degraded 以外の新規異常無し、pod restarts の `19` 常連も変化なし
+- backlog 棚卸し: blocked/needs-human 14件は run #167/#168 で直近棚卸し済みのため前提の
+  再確認のみ行い、変化は無かった。todo は `T-0117` のみで `not_before`
+  （2026-08-06T18:30:00Z）まで残り約3時間半、依然未到来
+- 新規起票: なし。3 回連続（run #167/#168/本回）で計画回が新規の着手可能タスクを
+  見つけられていない状態が続いているが、直前2回で inventory.json の `policy: auto` 全対象・
+  ドキュメントdrift・backlog 全件の stale-premise 確認をすでに終えており、この短時間
+  （前回から約8分）で同じ調査を繰り返しても新しい発見は見込めないと判断し、busywork の
+  ための起票はしなかった。`review-log.md` は依然 `R-NNN` エントリ無し（レビュー役が
+  まだ一度も回っていない）ため、次にレビュー役が回るまでは計画役の観測範囲がこれ以上
+  広がらない可能性がある
+- `python3 ops/validate.py` → 0 error, 0 warning
+- 次の起動へ: todo は `T-0117` のみ（2026-08-06T18:30:00Z 以降に actionable）。それまでは
+  引き続き todo が空の見込み。次に計画役が回る際、`T-0117` の時刻ゲートが解けていれば
+  それを最優先で拾うこと

--- a/ops/state.json
+++ b/ops/state.json
@@ -229,6 +229,14 @@
       "by": "autopilot pod (計画役)",
       "summary": "計画役（journal run #168）。フィードバック・inbox とも新規無し。run #167 が引き継いだ autopilot 自身の Progressing/readyReplicas:0 を kubectl で直接確認し、14:30:17Z 時点で Synced/Healthy・1/1 に復帰済みと確定（PR #368 ロールアウトの一時的な状態だった、インシデントではない）。coder/immich/vaultwarden の Degraded は T-0106 由来の SecretSyncedError のみで変化なし、pod restarts の19常連・immich backup_listing・node_metrics も異常無し。backlog blocked/needs-human 14件の前提に変化なし、todo は T-0117（not_before 未到来）のみ。新規起票価値のあるギャップは見つからず、busywork のための起票はしなかった。",
       "prs": []
+    },
+    {
+      "n": 169,
+      "at": "2026-08-06T14:59:18Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (計画役)",
+      "summary": "計画役（journal run #169）。フィードバック・inbox とも新規無し（issue #56 last_read 以降新規コメント無し、ops-feedback ブランチ未作成）。autopilot 自身の Healthy/1/1 復帰継続を kubectl で再確認、他アプリ健全性も変化なし。backlog blocked/needs-human 14件は run #167/#168 で直近棚卸し済みのため前提のみ再確認、変化なし。todo は T-0117（not_before 未到来、残り約3.5時間）のみ。直近2回で inventory/ドキュメントdrift/backlog stale-premise の調査を終えたばかりで短時間の再調査は見込み薄と判断し、新規起票はしなかった。",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

計画回（run #169）の記録のみ。`ops/journal/2026-08.md` と `ops/state.json` の `runs` に
1件追記した。コード・マニフェストの変更なし。

## 検証したこと

- issue #56 の新着コメント無し（`per_page=100` で全ページ確認、last_read 以降ゼロ件）
- `ops-feedback` ブランチは未作成（`git fetch` で `couldn't find remote ref`）
- `kubectl` で autopilot 自身が `Healthy`/`Synced`・Pod `1/1 Running` であることを再確認
  （run #167/#168 が追っていた一時的な Progressing は解消済み）
- `ops-health-report`（`generated_at: 2026-08-06T14:30:04Z`）に新規異常無し（既知の T-0106
  由来 Degraded のみ）
- backlog の blocked/needs-human 14件は直近2回（run #167/#168）で棚卸し済みのため前提のみ
  再確認、変化なし。todo は T-0117（`not_before` 未到来）のみ
- `python3 ops/validate.py` / `python3 ops/check_feedback.py` とも 0 error

## ロールバック手順

`ops/` の記録追記のみ（journal・state.json の `runs`）。revert すれば元に戻る。
スキーマ変更・実データへの影響は無い。

## backlog task id

なし（新規起票なし）
