### PR TITLE
ops(run #170): 計画回の記録のみ（新規異常・新規起票なし）

### DIFF
--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4873,3 +4873,37 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - 次の起動へ: todo は `T-0117` のみ（2026-08-06T18:30:00Z 以降に actionable）。それまでは
   引き続き todo が空の見込み。次に計画役が回る際、`T-0117` の時刻ゲートが解けていれば
   それを最優先で拾うこと
+
+## 2026-08-07 00:07 JST — run #170（計画役）
+
+- 取り込んだフィードバック: なし。issue #56 の直近3件（13:41:36Z/14:24:40Z/14:45:13Z）は
+  いずれも T-0107 に関する既知のやり取り（構築セッションの指摘とそれへの自分の返信）で、
+  `last_read`（2026-08-06T14:45:44Z）より後の新規コメントは無い。`ops-feedback` ブランチは
+  `git ls-remote` で不在を確認、依然未作成
+- 前回の中断を拾う: オープン PR #373（run #169 の記録のみ PR）が `mergeable_state: unstable`
+  で残っていた。head commit の check-runs を確認すると必須チェック5件（manifest deletion
+  guard/terraform validate/kustomize build/nix flake check/ops state validate）は全て
+  `success`、`GitGuardian Security Checks` のみ `in_progress`（必須チェックではない）
+  だったため、そのまま merge した（197ab32）。ブランチ `autopilot/run-169-records` は
+  merge 時に GitHub 側で自動削除済み（`DELETE` を試すと 422 `Reference does not exist`）。
+  ローカル `main` を `origin/main` に同期した
+- inbox: 空
+- 健全性確認: `ops-health-report`（`generated_at: 2026-08-06T15:00:04Z`、直近30分以内）で
+  autopilot 自身は `Healthy`/`Synced`、Pod `1/1 Running`（restartCount 0）、heartbeat
+  `last_end.exit_code: 0`（iteration 2）を確認。coder/immich/vaultwarden の `Degraded` は
+  引き続き T-0106 由来の `SecretSyncedError` のみ、pod restarts の `19` 常連も変化なし。
+  新規異常なし
+- backlog 棚卸し: 19件中 todo は `T-0117` のみ（`not_before: 2026-08-06T18:30:00Z`、現在
+  `2026-08-06T15:06Z` のため未到来、残り約3時間半）。blocked/needs-human の前提は
+  run #167/#168 が直近で棚卸し済みのため再確認のみ行い、変化なし
+- 帳簿サイズ確認: `backlog.json` 78,157 bytes（上限120KiB）、`state.json` 15,678 bytes
+  （上限40KiB）、いずれも余裕あり。archive への退避は不要
+- 新規起票: なし。4回連続（run #167〜本回）で新規の着手可能タスクが見つからない状態が
+  続いているが、直近3回で `inventory.json`（`policy: auto` 全対象）・ドキュメント drift・
+  backlog 全件の stale-premise 確認を終えたばかりで、今回さらに同じ範囲を再調査しても
+  新しい発見は見込めないと判断した。レビュー役はまだ一度も実行されておらず（PR #353,
+  T-0154 参照）、次に回るまで計画役の観測範囲はこの状態が続く見込み
+- `python3 ops/validate.py` → 0 error, 0 warning
+- やったこと: 上記（PR #373 のマージ・記録のみ）。`ops/` の記録のみの変更のため risk: low
+- 次の起動へ: todo は `T-0117` のみ（2026-08-06T18:30:00Z 以降）。それまでは todo が
+  空の見込み

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T14:51:21Z",
+  "updated": "2026-08-06T15:07:00Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
@@ -237,6 +237,16 @@
       "by": "autopilot pod (計画役)",
       "summary": "計画役（journal run #169）。フィードバック・inbox とも新規無し（issue #56 last_read 以降新規コメント無し、ops-feedback ブランチ未作成）。autopilot 自身の Healthy/1/1 復帰継続を kubectl で再確認、他アプリ健全性も変化なし。backlog blocked/needs-human 14件は run #167/#168 で直近棚卸し済みのため前提のみ再確認、変化なし。todo は T-0117（not_before 未到来、残り約3.5時間）のみ。直近2回で inventory/ドキュメントdrift/backlog stale-premise の調査を終えたばかりで短時間の再調査は見込み薄と判断し、新規起票はしなかった。",
       "prs": []
+    },
+    {
+      "n": 170,
+      "at": "2026-08-06T15:07:00Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (計画役)",
+      "summary": "計画役（journal run #170）。フィードバック・inbox とも新規無し（issue #56 last_read 以降新規コメント無し、ops-feedback ブランチ未作成）。前回の中断（PR #373, run #169 の記録のみ）を拾い、必須チェック5件 green を確認して merge（197ab32）。autopilot 自身の Healthy/1/1・heartbeat exit_code:0 を確認、他アプリ健全性も変化なし（T-0106由来Degradedのみ）。backlog blocked/needs-human 19件中 todo は T-0117（not_before未到来、残り約3.5時間）のみ。帳簿サイズは backlog 78KiB/state 15.6KiB（いずれも上限内）。4回連続で新規起票価値のあるギャップが見つからず、直近3回の調査済み範囲の再調査は見込み薄と判断し busywork の起票はしなかった。",
+      "prs": [
+        373
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

計画回（run #170）の記録のみ。`ops/journal/2026-08.md` と `ops/state.json` の `runs` に
1件追記した。コード・マニフェストの変更なし。

## 検証したこと

- issue #56 の直近3件（13:41:36Z/14:24:40Z/14:45:13Z）はいずれも T-0107 に関する既知の
  やり取りで、`last_read`（2026-08-06T14:45:44Z）より後の新規コメントは無い
- `ops-feedback` ブランチは依然未作成（`git ls-remote` で不在確認）
- **前回の中断を回収**: オープン PR #373（run #169 の記録のみ）が `mergeable_state: unstable`
  のまま残っていた。head commit の check-runs を確認し、必須チェック5件
  （manifest deletion guard/terraform validate/kustomize build/nix flake check/
  ops state validate）が全て `success`（`GitGuardian` のみ `in_progress`、必須チェック
  ではない）であることを確認したうえで merge した（197ab32）。ブランチは merge 時に
  GitHub 側で自動削除済み
- `kubectl` で autopilot 自身が `Healthy`/`Synced`・Pod `1/1 Running`・heartbeat
  `exit_code: 0` であることを確認
- `ops-health-report`（`generated_at: 2026-08-06T15:00:04Z`）に新規異常無し
  （既知の T-0106 由来 Degraded のみ）
- backlog 19件の blocked/needs-human の前提を再確認、変化なし。todo は T-0117
  （`not_before` 未到来）のみ
- 帳簿サイズ確認: `backlog.json` 78,157 bytes / `state.json` 15,678 bytes、いずれも
  上限（120KiB/40KiB）内
- `python3 ops/validate.py` / `python3 ops/check_feedback.py` とも 0 error

## ロールバック手順

`ops/` の記録追記のみ（journal・state.json の `runs`）。revert すれば元に戻る。
スキーマ変更・実データへの影響は無い。

## backlog task id

なし（新規起票なし）
