### PR TITLE
ops(run #172): レビュー役（利用者視点）初回実行・R-001〜R-003

### DIFF
--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,6 +1,43 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 376,
+      "title": "ops(run #172): 前回中断PR #375のCI一時障害を回収・新規異常なし",
+      "url": "https://github.com/hikuohiku/homelab/pull/376",
+      "isDraft": false,
+      "createdAt": "2026-08-06T15:36:09Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "QUEUED"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "QUEUED"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "QUEUED"
+        },
+        {
+          "conclusion": "SUCCESS"
+        }
+      ],
+      "headRefName": "autopilot/run-172-records",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
+    {
+      "number": 375,
+      "title": "ops(run #171): 前回中断の回収・needs-human未依頼6件をissue #56へ依頼・T-0074記述訂正",
+      "url": "https://github.com/hikuohiku/homelab/pull/375",
+      "mergedAt": "2026-08-06T15:33:04Z",
+      "headRefName": "autopilot/T-0074-note-fix"
+    },
     {
       "number": 374,
       "title": "ops(run #170): 計画回の記録のみ（新規異常・新規起票なし）",
@@ -413,13 +450,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/315",
       "mergedAt": "2026-08-06T07:17:14Z",
       "headRefName": "autopilot/run124-record-only"
-    },
-    {
-      "number": 314,
-      "title": "docs(ops): run #123 記録更新（PR #313 拾い、着手可能タスクなし）",
-      "url": "https://github.com/hikuohiku/homelab/pull/314",
-      "mergedAt": "2026-08-06T07:13:23Z",
-      "headRefName": "autopilot/run123-record-only"
     }
   ]
 }

--- a/ops/feedback.json
+++ b/ops/feedback.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-06T14:41:17Z",
+  "updated": "2026-08-06T16:50:14Z",
   "_comment": "人間からのフィードバックの台帳（正）。手順は ops/CHARTER.md §6。status: new（取り込んだ。扱いは未決）| accepted（起票した。task に T-XXXX）| done（片付いた）| declined（やらないと決めた）。done/declined には resolution（人間が読む一行）が必須で、これがダッシュボードに顛末として出る。accepted/done には task が必須。id は書かれた時点で確定し付け替えない。ops-dashboard から来たものは ops-feedback ブランチの ops/feedback/inbox/<id>.json が原本、issue から来たものは ref にコメント URL を置く。done/declined になって 90 日を過ぎたエントリは消してよい（review-log.md と同じ）",
   "inbox": {
     "branch": "ops-feedback",
@@ -22,6 +22,30 @@
       "body": "## T-0107 の前提を実測で検証しました（記録が 2 点間違っています）\n\n構築セッションから実機に当たりました。結論を先に書きます。\n\n### 1. `1 to add` は誤検知です。ファイルは存在します\n\nPVE の CA を取り出し、証明書の SAN に載っている名前（`hikuo-homeserver`）で TLS 検証を通したうえで API に問い合わせた結果:\n\n```\nlocal:import/nixos-proxmox-cloud-v0.2.5.qcow2   997720064 bytes\n```\n\n`NIXOS_IMAGE_VERSION` が期待する `v0.2.5` そのものです。\n\n`terraform plan` を実際に走らせると、原因がはっきり出ます:\n\n```\nWarning: The file does not exist in datastore and resource must be recreated.\n  unexpected error when listing datastore files:\n  tls: failed to verify certificate\nPlan: 1 to add, 0 to change, 0 to destroy.\n```\n\n**provider は TLS 失敗を warning に握り潰し、「ファイルが存在しない」と結論しています。** つまり `1 to add` は TLS が直れば消えるはずのもので、node01 が再作成されるという恐れは前提から成り立っていません（ただし **TLS が直るまで apply しない判断は正しい**。いま apply すれば実際に再ダウンロードが走り、`replace_triggered_by` が発火しうる）。\n\n### 2. 「PVE 管理コンソールでの手作業」は誤りです\n\n`needs_human_reason` にそう書いてありますが、**`PROXMOX_API_TOKEN` は `/nodes` に `Sys.Modify` を持っています**（実測。47 権限）。証明書は `PUT /nodes/{node}/certificates/custom` で API から差し替えられます。コンソールは要りません。\n\n### 3. ただし本当の問題は SAN ではなく「CA を誰も信頼していない」ことです\n\n証明書の SAN はこうなっています:\n\n```\nIP:127.0.0.1, IP:::1, IP:192.168.1.2, DNS:hikuo-homeserver, DNS:hikuo-homeserver.local\n```\n\n実 IP の `192.168.0.2` は確かに入っていません（ネットワーク番号が変わった名残）。**しかし名前で繋いでも今度は「signed by unknown authority」で落ちます。** 発行者が PVE クラスタ CA で、クライアント側が信頼していないからです。**SAN を足すだけでは直りません。**\n\n### 提案する直し方\n\n`PROXMOX_ENDPOINT` は既に `https://hikuo-homeserver.tailae6c2.ts.net` です。**Tailscale は `*.ts.net` に対して Let's Encrypt の証明書を発行できます**（`tailscale cert`）。これを Proxmox に custom cert として入れれば:\n\n- 公的に信頼された CA なので、クライアント側に CA を配る必要が無い\n- SAN が endpoint と一致する\n- 更新も Tailscale 側の仕組みに乗る\n\n`tailscale cert` は Proxmox ホスト上で実行する必要があるので、**そこだけは人間の作業が残ります**（アップロード自体は API でできます）。SAN 追加や自己署名の作り直しより筋が良いはずですが、実行前に検証してください。\n\n### 記録の直し方（計画役へ）\n\nT-0107 の `why` と `needs_human_reason` を上の実測に合わせて書き直してください。特に:\n\n- 「ファイルが本当に無いのか TLS の副産物か未確定」→ **TLS の副産物と確定**\n- 「PVE コンソールでの手作業。autopilot にも構築セッションにも実行できない」→ **誤り。API で可能**\n- 残る人間の作業は `tailscale cert` の実行だけ（この方式を採るなら）\n\n### 構造の問題として\n\nこの `needs_human_reason` は一度書かれてから誰も検証していません。**「できない理由」を書いた時点でそれが事実として固定され、以後は読まれるだけになっています。** blocked / needs-human の理由は、書いた時点の観測でしかありません。アーキテクチャ・レビュー役の対象に「止まっている理由が今も成り立つか」を加えることを検討してください。",
       "status": "accepted",
       "task": "T-0107"
+    },
+    {
+      "id": "F-20260806T142440Z-c5205985558",
+      "source": "issue#56",
+      "received": "2026-08-06T14:24:40Z",
+      "ref": "https://github.com/hikuohiku/homelab/issues/56#issuecomment-5205985558",
+      "body": "T-0107 を実測どおりに書き直しました。「1 to add」は TLS 検証失敗の副産物、根本原因は CA 不信、証明書差し替え自体は API 可能、の3点を反映済みです。残る人間作業は tailscale cert を node01 ホスト OS 上で実行する部分のみです（採用可否は未検証、実行前にご確認ください）。",
+      "status": "new"
+    },
+    {
+      "id": "F-20260806T144513Z-c5206285481",
+      "source": "issue#56",
+      "received": "2026-08-06T14:45:13Z",
+      "ref": "https://github.com/hikuohiku/homelab/issues/56#issuecomment-5206285481",
+      "body": "T-0107 を実測どおりに反映しました（#370, merged）。14:24:40Z のコメントは実は反映されておらず main は旧内容のままでしたが、今回の起動で実際に書き直しました。\n\n残る人間作業は `tailscale cert` 方式の採用可否確認と、OKならホスト OS 上での実行のみです（詳細は T-0107 の `human_action` 参照）。",
+      "status": "new"
+    },
+    {
+      "id": "F-20260806T152002Z-c5206837844",
+      "source": "issue#56",
+      "received": "2026-08-06T15:20:02Z",
+      "ref": "https://github.com/hikuohiku/homelab/issues/56#issuecomment-5206837844",
+      "body": "計画役（人間の対話セッション経由、run #170 の中断回収に続けて棚卸し）からです。\n\n**needs-human の棚卸し中に、backlog 上は依頼内容が書かれているのに issue #56 へ実際には\n一度も投稿されていないタスクが 6 件見つかりました。** CHARTER §3/§4 の「依頼が実際に issue #56\nに存在するかを確かめる」を辿ったところ、`T-0141`/`.envrc`/`workflow scope`/`LXC 101`/\n`ブラウザで` のいずれのキーワードでもこのタスクたちへの直接の依頼コメントが見つからず、\n`T-0112`（run #77 起票、run #115 で発覚するまで約38回投稿漏れ）と同型の「対応待ちのつもり\nだが実際には誰にも届いていない」状態でした。以下、まとめて依頼します。\n\n## T-0140 — 旧 LXC 101 (syncthing) の config 移行\n`cert.pem`/`key.pem`/`config.xml` を含む config ディレクトリ一式（想定パス\n`/var/lib/syncthing`、実際のパスは要確認）を取り出し、新 PVC（T-0138 で作成済み）へ配置できる\n形で渡してください。device ID/証明書を移さずに新 syncthing を既存ピアへ接続すると別デバイスと\n再認識され、同期方向次第でデータ削除が伝播しうるため、これが済むまで新旧を接続しないでください。\n\n## T-0141 — Tailscale OAuth credential の重複調査（issue #37）\n対話セッション（このセッションのようなローカル環境）で `.envrc` の中身と、Tailscale MCP が\n実際にどの credential（`TAILSCALE_AGENT_CLIENT_ID/SECRET` / `TAILSCALE_OAUTH_CLIENT_ID/SECRET` /\n`TAILSCALE_CLIENT_ID/SECRET`）を使っているか確認してください。CLAUDE.md の記述どおり解消済みなら\nissue #37 にその旨をコメントして close できます。\n\n## T-0148 — ops-dashboard の外部到達性確認\ntailnet に接続した端末のブラウザで `https://ops-dashboard.tailae6c2.ts.net/` を開けるか確認して\nください。構築セッションによる内部 Service 到達（HTTP 200）は確認済みですが、tailnet 経由の\n実際の外部到達（MagicDNS + L7 Ingress）はまだ誰も確認していません。\n\n## T-0153 / T-0156 / T-0157 — `.github/workflows/ci.yml` への配線追加（3件共通の原因）\n検証スクリプト自体は実装・動作確認済みですが、`AUTOPILOT_GITHUB_TOKEN` に `workflow` scope が\n無く `.github/workflows/**` への push が GitHub 側で拒否されるため、ワークフローファイルへの\n配線だけが残っています。**T-0157 を先に適用すると T-0156 の配線は不要になります**（ops job が\nglob ループ化され `check_*.py` を自動で拾うため）。workflow scope 付きの credential で以下を\nお願いします。\n\n1. **T-0157**（ops job の glob ループ化。backlog.json の `T-0157.why` に完全な diff あり）\n   を先に適用\n2. T-0157 適用後に T-0156 の状況を再確認 — 対象の `check_app_list_sync.py` が glob で\n   自動的に拾われていれば T-0156 の追記は不要\n3. **T-0153**（manifest-diff job への1ステップ追加）は独立しているので別途:\n   ```\n         - name: Check autopilot image digest pin is updated alongside its Dockerfile\n           run: python3 head/ops/check_autopilot_image_pin.py base head\n   ```\n   を「Check for unexplained object deletions」ステップの直後に追記\n\nいずれも backlog.json の該当タスクの `human_action.steps` に詳細な手順があります。",
+      "status": "new"
     }
   ]
 }

--- a/ops/inbox.md
+++ b/ops/inbox.md
@@ -11,3 +11,7 @@
 [`ops/CHARTER.md`](CHARTER.md) の §3「書く権利」。
 
 ---
+
+- [R-001] レビュー役プロンプトが指示する `kubectl -n ops-dashboard get svc` が RBAC の `services` 欠如で Forbidden になる
+- [R-002] `apps/autopilot/deployment.yaml` の image digest が commit 8eacc31（chromium/フォント追加）以降更新されておらず、稼働中 Pod に chromium が無い
+- [R-003] ダッシュボードの健全性サマリ「落ちている: coder、immich、vaultwarden」が T-0106 由来の無害な既知状態であることの注記が無く、初見では実障害と誤読する

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4974,3 +4974,40 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - `python3 ops/validate.py` → 0 error, 0 warning
 - 次の起動へ: 計画役は `ops/inbox.md` の R-001〜R-003 と `ops/feedback.json` の新着3件
   （`new`）を処理すること
+
+
+## 2026-08-07 05:18 JST — run #172 続き（レビュー役・利用者視点、PR #377 の中断回収）
+
+- 前回の中断を拾った: `git branch -r` で `autopilot/run-172-review-user`（PR #377,
+  「レビュー役（利用者視点）初回実行・R-001〜R-003」）が open のまま残っていた。中身
+  （feedback.json 新着3件の取り込み、review-log.md/inbox.md の R-001〜R-003）を読み、
+  「レビュー役として今この起動で新たにやるべきこと」と実質同一と判断。**新しい PR は作らず、
+  この中断の回収に専念した**（CHARTER §2「新規タスクより先に片付ける」）
+- R-001（`kubectl get svc` が RBAC で Forbidden）・R-002（chromium 未搭載で描画不能）を
+  自分でも独立に再現して確認した（`kubectl -n ops-dashboard get svc` → Forbidden、
+  `which chromium`/`apk info -e chromium`/`find / -iname '*chromium*'` すべて該当無し、
+  Pod は `autopilot-854c989ffd-tp2h8`）。R-001 の回避として使われていたクラスタ内 DNS
+  ではなく、素の Pod IP（`kubectl get pods -o wide` で取得、`autopilot-reader` ClusterRole
+  は pods の get/list を許可）への直 curl でも HTML 取得は可能だった（IP は再作成のたび
+  変わるため恒久策ではない）
+- 加えて、`ops/dashboard/build.py` が `ops/feedback.json` を一切読み込んでおらず、書き置き
+  の `resolution`（CHARTER §6 が「ダッシュボードに出る」と明記する顛末）を表示する場所が
+  ダッシュボード上に無いことに気づいたが、**新規の R-NNN としては追記しなかった**。
+  理由: R-001〜R-003 は既に PR #377 に記録済みで「1 回につき最大 3 件」を使い切っており、
+  同じ回に 4 件目を積み増すと計画役側の「この回の指摘」の数え方が曖昧になる。次のレビュー
+  回（アーキテクチャ視点の後、利用者視点が再度回ってきたとき）に、台帳の状態を確認した
+  うえで改めて指摘する
+  （この段落自体は次のレビュー役への申し送りであり、今回はここに書くだけで留める）
+- PR #377 は CI が2回連続で workflow run 0件のまま止まっていた（`head_sha` 指定の
+  `GET /actions/runs` が `total_count: 0`）。空コミットで3回目の retrigger を push
+  （`9721078`）したが同様に 0件のままだったため、`https://www.githubstatus.com/api/v2/summary.json`
+  で確認したところ **GitHub Actions が `major_outage`**（Webhooks は `operational`）と判明。
+  run #176/#178 の retrigger コミットメッセージは「recovering」「解消確認」としていたが、
+  実際には解消していなかった
+- フィードバック: issue #56 を `per_page=100` で全件確認したが、`ops/feedback.json` の
+  `updated`（PR #377 内、16:50:14Z）より新しいコメントは無し。`ops-feedback` ブランチも
+  引き続き未作成
+- 次の起動へ: **PR #377 は GitHub Actions の `major_outage` が解消してから retrigger する
+  こと**（`githubstatus.com` の Actions component を先に確認する。`operational` に戻って
+  いない限り retrigger しても無駄になる）。解消後は CI green を確認して merge し、
+  `ops/inbox.md` の R-001〜R-003 と `feedback.json` の新着3件（`new`）を計画役が処理する

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -4949,3 +4949,28 @@ kubectl で直接確認した。**障害発生から復旧確認まで約 25 分
 - 次の起動へ: todo は `T-0117` のみ（2026-08-06T18:30:00Z 以降）。issue #56 に依頼した
   6件（T-0140/T-0141/T-0148/T-0153/T-0156/T-0157）は今回で「未依頼」状態を解消したので、
   次の計画回はこれらを「対応待ち」として扱ってよい（新たに催促する必要はない）
+
+
+## 2026-08-07 01:51 JST — run #172（レビュー役・利用者視点）
+
+- 取り込んだフィードバック: issue #56 に新着3件（14:24:40Z T-0107再訂正の経緯共有、14:45:13Z
+  T-0107実反映報告、15:20:02Z 計画役から未依頼6件の一括依頼）。全て `ops/feedback.json` に
+  `status: new` で追記済み（扱いの判断は次の計画役）。`ops-feedback` ブランチは依然未作成
+- レビュー役として初回実行（`ops/review-log.md` にこれまで `R-NNN` エントリ無し）。「人間に
+  見せている画面」のレンズで、プロンプト記載の手順をそのまま辿った
+- 見つけたこと（`ops/review-log.md` R-001〜R-003、`ops/inbox.md` に転記済み）:
+  - R-001: プロンプトが指示する `kubectl -n ops-dashboard get svc` が `autopilot-reader`
+    ClusterRole に `services` が無く Forbidden。代替に cluster 内 DNS 直 curl で回避
+  - R-002: `images/autopilot/Dockerfile`（commit 8eacc31, 2026-08-06T12:43:53Z）で追加した
+    chromium/font-noto-cjk が、`apps/autopilot/deployment.yaml` の image digest 未更新のため
+    稼働中 Pod（`autopilot-854c989ffd-tp2h8`）に届いておらず、ダッシュボードを実際に描画して
+    見る手段が今も無い。T-0153（digest ズレの CI 検出）はこの"再発防止"を扱うが、"今まさに
+    ズレている"現在の事実は誰も指摘していなかった
+  - R-003: ダッシュボード先頭の健全性サマリ「落ちている: coder、immich、vaultwarden」が
+    赤表示のみで、T-0106由来の無害な SecretSyncedError だと分かる注記が無い。VISION の
+    「(a) いまシステムは健康か」に単体では正しく答えられない
+  - R-001/R-002 により「実際に描画して見る」ことはできず、HTML テキストの読み取りで代替した
+- `python3 ops/check_feedback.py` → 0 error, 0 warning
+- `python3 ops/validate.py` → 0 error, 0 warning
+- 次の起動へ: 計画役は `ops/inbox.md` の R-001〜R-003 と `ops/feedback.json` の新着3件
+  （`new`）を処理すること

--- a/ops/review-log.md
+++ b/ops/review-log.md
@@ -25,3 +25,53 @@
 「採らなかった」のか「採ったが記録し忘れた」のかが後から区別できない。
 
 ---
+
+## R-001 — レビュー役に指示されたダッシュボード確認手順の1行目が RBAC で失敗する
+- レンズ: user / 2026-08-06
+- 見たもの: `apps/autopilot/prompt-review-user.md`（このプロンプト自身）に書かれた手順をそのまま実行。
+  `kubectl -n ops-dashboard get svc ops-dashboard -o jsonpath='{.spec.clusterIP}'`
+- 詰まり: `Error from server (Forbidden): services is forbidden: User
+  "system:serviceaccount:autopilot:autopilot" cannot get resource "services"`。
+  `kubectl auth can-i --list` で確認したところ、`autopilot-reader` ClusterRole
+  （`apps/autopilot/rbac.yaml`）が読める resource 一覧に `services` がそもそも含まれていない
+  （CHARTER §5.5 の一覧とも一致：pods/PVC/nodes/namespaces/events/deployments 等はあるが
+  services が無い）。プロンプトが「実際に確認しろ」と名指しで渡してくるコマンドの、その
+  最初の一歩が今の権限では実行不能。代替として cluster 内 DNS 名
+  （`ops-dashboard.ops-dashboard.svc.cluster.local`）への直接 curl で IP 取得を回避し HTML
+  自体は取得できたが、これはプロンプトに書かれた手段ではなく、次にこのプロンプトを読む
+  自分（または別のレビュー役）が毎回同じ Forbidden に当たって同じ回避を再発見する必要がある
+- 状態: 未処理
+
+## R-002 — レビュー役に「実際に描画しろ」と指示した本人の変更が、まだ動いている Pod に届いていない
+- レンズ: user / 2026-08-06
+- 見たもの: R-001 の回避で取得した HTML を chromium で描画しようとした。`which chromium` /
+  `apk info -e chromium` / `find / -iname '*chromium*'`（すべて見つからず）。
+  `images/autopilot/Dockerfile` と `apps/autopilot/deployment.yaml` の git 履歴
+  （`git log --since` で 8eacc31 以降の変更を確認）
+- 詰まり: 稼働中の Pod（`autopilot-854c989ffd-tp2h8`、Alpine 3.24.1）に chromium も
+  font-noto-cjk も入っていない。`images/autopilot/Dockerfile` には commit `8eacc31`
+  （2026-08-06T12:43:53Z「レビュー役がダッシュボードを実際に見られるようにする」）で
+  chromium/font-noto/font-noto-cjk が追加されているが、`apps/autopilot/deployment.yaml`
+  の image digest はその commit 以降一度も更新されていない（同ファイルへの変更コミットは
+  `4de23b5` の1件のみで image 行には触れていない）。つまり「レビュー役が実際に見られる
+  ようにする」ための変更自体が、レビュー役が動く Pod にまだ配達されていない。想像で書くなの
+  原則を守ろうとした結果、今回もマークアップ（HTML テキスト）を読むところまでしかできなかった。
+  T-0153（digest ズレを CI で機械検出する仕組み）は「今後同じズレを繰り返さない」対策だが、
+  「今まさにこの Pod がズレている」という現在の具体的事実そのものは誰も指摘していない
+- 状態: 未処理
+
+## R-003 — ダッシュボードの健全性サマリだけでは「(a) いまシステムは健康か」に正しく答えられない
+- レンズ: user / 2026-08-06
+- 見たもの: R-001 の回避で取得した `ops/dashboard/index.html`（生成 2026-08-06 16:45 UTC）の
+  先頭 pulsebox。`homelab のアプリ` 欄が赤 (`dot--crit`) で「10 / 13 正常」
+  「落ちている: coder、immich、vaultwarden」
+- 詰まり: この表示だけを見た初見の人間は「3 サービスが落ちている」と読む。実際は
+  T-0106（Doppler キー未登録による ExternalSecret の SecretSyncedError）がこの3
+  Application の集約 health を Degraded に引き上げているだけで、Pod は全て
+  Running/Ready・実サービスへの影響は無い（CHARTER §2 に明記済みの既知の状態）。
+  ダッシュボード上にはこの注記が無く、同じ HTML 内で事情を辿るには優先度順 19 件の
+  待ち行列を 14 番目（T-0106、B2 キー発行の依頼文言で health への言及なし）まで
+  スクロールしたうえ、さらに「完了」扱いの T-0122（この因果関係を実際に説明している
+  唯一の記述）まで辿る必要がある。VISION が名指しで求める3つの問い
+  「(a) いまシステムは健康か」に、ダッシュボード単体では正しく・素早く答えられない
+- 状態: 未処理

--- a/ops/state.json
+++ b/ops/state.json
@@ -217,6 +217,14 @@
       "by": "autopilot pod (レビュー役・利用者視点)",
       "summary": "レビュー役・利用者視点（journal run #172）。初回実行（review-log に既存エントリ無し）。フィードバック新着3件をfeedback.jsonにnewで追記。プロンプト記載のダッシュボード確認手順を実際に辿り、(R-001) kubectl get svc がRBACのservices欠如でForbidden、(R-002) chromium/フォント追加(commit 8eacc31)がdeployment.yamlのimage digest未更新で稼働Podに届いておらず描画して見る手段が無い、(R-003) 健全性サマリ「落ちている: coder/immich/vaultwarden」にT-0106由来の無害な既知状態である注記が無く初見で誤読する、の3件を発見しreview-log.md/inbox.mdに記録。",
       "prs": []
+    },
+    {
+      "n": 173,
+      "at": "2026-08-06T20:18:29Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (レビュー役・利用者視点)",
+      "summary": "レビュー役・利用者視点（journal run #172 続き）。前回の中断（PR #377, open のまま）を新規タスクより先に回収。R-001/R-002 を自分でも独立に再現確認。PR #377 の CI が2回連続 workflow run 0件で止まっていたため空コミットで retrigger したが同様に0件、githubstatus.com で GitHub Actions が major_outage と確認（run #176/#178 の『解消済み』表記は誤りだった）。追加で気づいた「ops/feedback.jsonの内容がダッシュボードに一切表示されない」点はこの回の指摘上限（3件、PR #377で使用済み）を避けるため今回は起票せず申し送りのみ。フィードバック新規なし。",
+      "prs": []
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-06T15:30:00Z",
+  "updated": "2026-08-06T16:51:41Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T14:45:44Z"
+    "last_read": "2026-08-06T16:51:41Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc",
@@ -208,6 +208,14 @@
       "kind": "in_cluster_loop",
       "by": "autopilot pod (計画役)",
       "summary": "計画役（journal run #171）。前回の中断PR #374（run #170の記録のみ）が manifest deletion guard の一時的インフラ障害（Service Unavailable）でblockedだったため、空コミットでCI再実行しgreen確認後merge（ca4c577）。needs-humanタスクの棚卸しでissue #56への依頼が実際に投稿されていないもの6件（T-0140/T-0141/T-0148/T-0153/T-0156/T-0157）を発見し、まとめてissue #56へ投稿（issuecomment-5206837844）。T-0074のneeds_human_reason/whyがT-0107の旧い記述（PVE管理コンソール手作業）を引きずっていたのを現状に合わせて訂正。健全性・backlogとも新規異常なし、todoはT-0117（not_before未到来）のみ。ダッシュボードをbuild・publish。",
+      "prs": []
+    },
+    {
+      "n": 172,
+      "at": "2026-08-06T16:51:41Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (レビュー役・利用者視点)",
+      "summary": "レビュー役・利用者視点（journal run #172）。初回実行（review-log に既存エントリ無し）。フィードバック新着3件をfeedback.jsonにnewで追記。プロンプト記載のダッシュボード確認手順を実際に辿り、(R-001) kubectl get svc がRBACのservices欠如でForbidden、(R-002) chromium/フォント追加(commit 8eacc31)がdeployment.yamlのimage digest未更新で稼働Podに届いておらず描画して見る手段が無い、(R-003) 健全性サマリ「落ちている: coder/immich/vaultwarden」にT-0106由来の無害な既知状態である注記が無く初見で誤読する、の3件を発見しreview-log.md/inbox.mdに記録。",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

`ops/CHARTER.md` §3 の「レビュー役（利用者視点）」を初めて実際に実行した回です（`ops/review-log.md` にこれまで `R-NNN` エントリが無かったため）。実装は含まず、`ops/` の記録のみです。

- **フィードバック取り込み**: issue #56 の新着3件を `ops/feedback.json` に `status: new` で追記（扱いの判断は次の計画役）
- **利用者視点レビュー**: プロンプト記載の「ダッシュボードを実際に開く」手順をそのまま辿り、次の3点を発見（`ops/review-log.md` R-001〜R-003、`ops/inbox.md` に転記）
  1. **R-001**: 手順の1行目 `kubectl -n ops-dashboard get svc` が RBAC（`autopilot-reader` ClusterRole に `services` が無い）で Forbidden になる
  2. **R-002**: chromium/日本語フォント追加（commit `8eacc31`）が `apps/autopilot/deployment.yaml` の image digest 未更新のため稼働中 Pod に届いておらず、ダッシュボードを実際に描画して見る手段が今も無い
  3. **R-003**: ダッシュボード先頭の健全性サマリ「落ちている: coder、immich、vaultwarden」が、T-0106 由来の無害な既知状態であることの注記が無く、初見では実障害と誤読する

いずれも「見つけただけ」で、直し方は計画役の判断に委ねます（レビュー役は実装しません）。

**追記（後続の起動より）**: このPRは push 後2回連続で CI の workflow run が 0件のまま止まっていました。空コミットで retrigger しても解消せず、`githubstatus.com` で GitHub Actions の `major_outage` を確認しました（Webhooks は operational）。R-001/R-002 はこの後続の起動でも独立に再現確認済みで、内容は正確です。Actions 復旧後に retrigger して merge してください。

## 検証したこと

- `python3 ops/check_feedback.py` → 0 error, 0 warning
- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 生成・`ops-dashboard` ブランチへ publish 成功

## ロールバック手順

`ops/` の記録のみの変更（journal・review-log・inbox・feedback.json・state.json・dashboard cache）。revert すれば元に戻り、データ不整合は残らない。

## backlog task id

このタスクは backlog への起票を伴わない記録用 PR です（レビュー役は起票しない）。次の計画役が `ops/inbox.md` の R-001〜R-003 を見て起票するか判断します。