### PR TITLE
docs(pbs): PBS VM 退役手順を明記し、依存確認を構築セッションへ依頼する (T-0116)

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -412,6 +412,17 @@ T-0116 として別途起票した（`blocked_by: T-0078`）。PBS VM 自体の�
 管理コンソールでの操作が要り、autopilot の Proxmox credential は PVEAuditor（読み取り専用）
 のため実行できない。人間の物理操作が要る点は T-0116 側で明記する。
 
+**2026-08-07 追記（T-0117 完了、T-0116 再開）**: workspace home の初回 backup 成功
+（`lastSuccessfulTime` 一致）と復元試験（`restore_rc=0`, 31秒, 3156ファイル, 925MiB）が
+完了し、5対象すべてが restic backup + 復元試験でカバーされた。PBS の VM 単位バックアップは
+理屈のうえでは冗長になったが、**PBS 自身が実際に何のジョブを持っているか（node01 を含む
+VM 単位バックアップとして機能していたか）は依然未確認のまま**（上記「わからないこと」節、
+方針転換で確認自体を打ち切っていた）。停止・削除の実行手順は
+`terraform/proxmox/pbs.tf.ignore` に記載した。手順の最初のステップ（PBS 上の backup ジョブ
+実在確認）は autopilot・構築セッションいずれも実行環境から PBS/Proxmox に到達できない
+（autopilot にはこの実行環境に Proxmox credential が無い）ため、issue #56 で構築セッションに
+確認を依頼した。
+
 ## これに依存しているタスク
 
 - T-0029（immich postgres/vchord のメジャー更新、データを失いうる変更）・T-0023（coder

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 166,
-  "updated": "2026-08-07T00:22:00Z",
+  "updated": "2026-08-07T00:35:00Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -190,18 +190,34 @@
       "title": "PBS VM (qemu/112) を退役する",
       "kind": "chore",
       "risk": "medium",
-      "status": "todo",
+      "status": "needs-human",
       "priority": 43,
       "why": "T-0072（run #82）の判断: T-0065 が挙げた実データ5対象のうち、restic backup + 復元試験まで完了しているのは immich/vaultwarden/coder-postgres 系の4対象のみで、`coder-<workspace-id>-home`（T-0078）が未実装の間は PBS の VM 単位バックアップが唯一の（未確認だが）保険になっている。T-0078 が完了し、workspace home も復元試験まで確認できたら、node01 の全実データがアプリレベルの restic backup でカバーされ、PBS の VM 単位バックアップは完全に冗長になる（node01 VM 自体は Terraform+NixOS で宣言的に再現可能なため）",
       "dod": "T-0078 が done になった後、(1) workspace home の restic backup が実際に成功し復元試験も通ることを確認する、(2) PBS 上に他に依存しているジョブ・データが無いか最終確認する、(3) `terraform/proxmox/pbs.tf.ignore` にこの記録を残しつつ PBS VM (qemu/112) の停止・削除手順を明記する。実際の VM 停止・削除は Proxmox 管理コンソールでの操作が要り、autopilot の Proxmox credential（PVEAuditor、読み取り専用）では実行できないため、この最終手順は needs-human として人間に引き継ぐ",
       "blocked_by": null,
+      "needs_human_reason": "DoD(1)(3) は完了（T-0117 で復元試験成功、pbs.tf.ignore に停止・削除手順を明記済み）。残る DoD(2)（PBS 上に backup ジョブ・データが実在するか）は PBS/Proxmox VE への到達性が要り、この in-cluster autopilot 実行環境には Proxmox credential が無いため確認できない。issue #56 で構築セッションに確認を依頼済み（返信待ち）。確認が取れ次第、実際の VM 停止・削除（`qm shutdown 112` / `qm destroy 112`、物理/管理コンソール操作）を人間にお願いする",
+      "human_action": {
+        "summary": "PBS (qemu/112) 上に backup ジョブ・データが実在するかの確認結果を issue #56 で待っています。確認が取れたら、terraform/proxmox/pbs.tf.ignore の手順どおり PBS VM の停止・削除をお願いします",
+        "why": "PBS の VM 単位バックアップは restic 側の復元試験完了により理屈のうえでは冗長になったが、PBS 自身が実際に何を保護していたかを一度も確認しないまま止めると、確認していない前提で『無かった』とみなす安全でない判断になる（CHARTER §4）",
+        "steps": [
+          "issue #56 の依頼コメント（下記リンク）への構築セッションの回答を待つ、または人間が直接 Proxmox で Datacenter > Backup（`pvesh get /cluster/backup`）を確認する",
+          "PBS を対象にした backup ジョブが無い、または削除可能と判断できたら、terraform/proxmox/pbs.tf.ignore に記載した手順（shutdown → 1〜2週間観察 → destroy）で PBS VM (qemu/112) を停止・削除する",
+          "削除後、pbs.tf.ignore / CLAUDE.md / README.md / Plans.md の pbs 関連記述を past tense に更新する PR を出すよう autopilot に issue #56 で伝えるか、次の起動が自動で拾えるよう state に一言残してください"
+        ],
+        "links": [
+          {
+            "label": "issue #56 の確認依頼コメント",
+            "url": "https://github.com/hikuohiku/homelab/issues/56#issuecomment-5210344855"
+          }
+        ]
+      },
       "refs": [
         "docs/backup.md",
         "terraform/proxmox/pbs.tf.ignore"
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "run #82: T-0072（PBS 退役判断）から実行タスクとして分離起票 | run #102 (計画役): blocked_by が T-0078 のままだったが、T-0078 は run #84 で done・PR #264 merge 済み（実装は完了済み）。実際に残っているのは復元試験（分離済みの T-0117、CronJob 初回実行が 2026-08-07 03:30 JST まで到来しないため未実施）で、blocked_by を T-0117 に訂正した（CHARTER §2 計画役の作業『blocked/needs-human の理由が古い前提のままになっていないか確かめる』）。 | run #206: T-0117 の DoD(1)(2) が完了（restore_rc=0, docs/backup.md 記録済み）したため blocked_by を解消し todo に戻した。DoD(2)『PBS 上に他に依存しているジョブ・データが無いか最終確認する』・DoD(3)『停止・削除手順を明記する』は未着手のまま残っている。"
+      "notes": "run #82: T-0072（PBS 退役判断）から実行タスクとして分離起票 | run #102 (計画役): blocked_by が T-0078 のままだったが、T-0078 は run #84 で done・PR #264 merge 済み（実装は完了済み）。実際に残っているのは復元試験（分離済みの T-0117、CronJob 初回実行が 2026-08-07 03:30 JST まで到来しないため未実施）で、blocked_by を T-0117 に訂正した（CHARTER §2 計画役の作業『blocked/needs-human の理由が古い前提のままになっていないか確かめる』）。 | run #206: T-0117 の DoD(1)(2) が完了（restore_rc=0, docs/backup.md 記録済み）したため blocked_by を解消し todo に戻した。DoD(2)『PBS 上に他に依存しているジョブ・データが無いか最終確認する』・DoD(3)『停止・削除手順を明記する』は未着手のまま残っている。 | run #207（実行役）: DoD(3) を terraform/proxmox/pbs.tf.ignore に追記（停止・削除手順、docs/backup.md にも追記）。DoD(2) は autopilot 自身に Proxmox credential が無く確認不能なため、issue #56 で構築セッションに確認を依頼し needs-human に変更した（CHARTER §3『needs-human に落とす前に構築セッションで確認できないか考える』）。"
     },
     {
       "id": "T-0118",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,27 @@
   "open": [],
   "merged": [
     {
+      "number": 383,
+      "title": "docs(backup): coder workspace home の復元試験の成功を記録し、検証用リソースを削除する (T-0117)",
+      "url": "https://github.com/hikuohiku/homelab/pull/383",
+      "mergedAt": "2026-08-07T00:23:11Z",
+      "headRefName": "autopilot/T-0117-restore-verify-cleanup"
+    },
+    {
+      "number": 382,
+      "title": "feat(coder): workspace home backup の復元試験用 Job を追加する (T-0117)",
+      "url": "https://github.com/hikuohiku/homelab/pull/382",
+      "mergedAt": "2026-08-07T00:11:51Z",
+      "headRefName": "autopilot/T-0117-workspace-home-restore-verify"
+    },
+    {
+      "number": 381,
+      "title": "fix(autopilot): issue #56 への自己投稿コメントの取り込みループバックを防ぐ",
+      "url": "https://github.com/hikuohiku/homelab/pull/381",
+      "mergedAt": "2026-08-07T00:01:22Z",
+      "headRefName": "autopilot/T-0159-self-posted-comment-marker"
+    },
+    {
       "number": 380,
       "title": "fix(autopilot): autopilot-reader ClusterRole に services の get/list を追加",
       "url": "https://github.com/hikuohiku/homelab/pull/380",
@@ -399,27 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/321",
       "mergedAt": "2026-08-06T08:06:17Z",
       "headRefName": "autopilot/run130-plan-no-new-findings"
-    },
-    {
-      "number": 320,
-      "title": "docs(ops): run #129（計画役）記録更新、T-0135起票",
-      "url": "https://github.com/hikuohiku/homelab/pull/320",
-      "mergedAt": "2026-08-06T07:59:26Z",
-      "headRefName": "autopilot/T-0135-run129-plan-record"
-    },
-    {
-      "number": 319,
-      "title": "docs(ops): run #128（計画役）記録更新、新規起票なし",
-      "url": "https://github.com/hikuohiku/homelab/pull/319",
-      "mergedAt": "2026-08-06T07:51:49Z",
-      "headRefName": "autopilot/run128-plan-no-new-findings"
-    },
-    {
-      "number": 318,
-      "title": "docs(ops): run #127（計画役）記録更新、新規起票なし",
-      "url": "https://github.com/hikuohiku/homelab/pull/318",
-      "mergedAt": "2026-08-06T07:44:48Z",
-      "headRefName": "autopilot/run127-plan-no-new-findings"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -6008,3 +6008,20 @@ GitHub Actions incident で blocked のまま run #172〜#193 を独立に積み
 - 次の起動へ: この回の PR の CI green を確認して merge。merge 後は todo の
   `T-0116`/`T-0158`/`T-0162`〜`T-0165`（6件）の着手を CHARTER §2 の直列化ルールに従い
   1 件ずつ進める
+
+## 2026-08-07 09:35 JST — run #207
+
+- 取り込んだフィードバック: なし。issue #56 を `per_page=100` で全件確認し新規なし。
+  `ops-feedback` ブランチは引き続き不在
+- 前回の中断: なし。オープン PR 0件、`autopilot/*` の残りブランチ 0件（PR #383 は merge 済み）
+- 健全性: 直接の再確認はせず run #206 の確認（既知事象 T-0106 のみ、異常なし）を踏襲
+- やったこと: todo（priority 昇順）の先頭 `T-0116`（PBS VM 退役）に着手。DoD(3)
+  （停止・削除手順の明記）を `terraform/proxmox/pbs.tf.ignore` と `docs/backup.md` に追記。
+  DoD(2)（PBS 上に依存しているジョブ・データが無いか）は autopilot 自身にこの実行環境で
+  Proxmox credential が無く確認不能なため、issue #56 で構築セッションに確認を依頼
+  （https://github.com/hikuohiku/homelab/issues/56#issuecomment-5210344855）し、
+  T-0116 を needs-human に変更した（CHARTER §3「needs-human に落とす前に構築セッションで
+  確認できないか考える」）
+- 見つけたこと: なし
+- 次の起動へ: この回の PR の CI green を確認して merge。T-0116 は構築セッション/人間からの
+  返信待ち。返信が来ていなければ todo の次（`T-0163` 優先度50）へ進む

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-07T00:22:00Z",
+  "updated": "2026-08-07T00:35:00Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-06T23:31:00Z"
+    "last_read": "2026-08-07T00:35:00Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc",
@@ -212,6 +212,14 @@
       "prs": [
         383
       ]
+    },
+    {
+      "n": 207,
+      "at": "2026-08-07T00:35:00Z",
+      "kind": "in-cluster-loop",
+      "by": "autopilot pod (実行役)",
+      "summary": "実行役（journal run #207）。前回中断なし(PR #383 merge済み)、フィードバック新規なし。backlog todoの先頭T-0116（PBS VM退役）に着手。DoD(3)（停止・削除手順）をpbs.tf.ignore/docs/backup.mdに明記。DoD(2)（PBS上の依存ジョブ・データ確認）はautopilotにProxmox credentialが無く確認不能なため issue #56 で構築セッションに確認を依頼し needs-human に変更した。",
+      "prs": []
     }
   ]
 }

--- a/terraform/proxmox/pbs.tf.ignore
+++ b/terraform/proxmox/pbs.tf.ignore
@@ -11,6 +11,37 @@
 #       既に稼働中だった pbs を Terraform に巻き込んで誤って再作成/破壊しないよう
 #       pbs.tf → pbs.tf.ignore にリネームして無効化した。
 #       2026-06-21 に「pbs は手動管理（Terraform 管理対象外）」として方針を確定。
+#
+# 退役判断 (T-0072, 2026-08-06): node01 の実データ5対象（immich-library/immich-postgres-data/
+# vaultwarden-data/coder-postgres-data/coder-<workspace-id>-home）全てが restic ベースの backup
+# CronJob で復元試験まで完了した（T-0071/T-0117, docs/backup.md 参照）。node01 VM 自体は
+# Terraform + NixOS image で完全に宣言的なため VM 単位の復元は IaC の再適用で代替でき、PBS の
+# VM 単位バックアップは冗長になった。退役タスクは T-0116（ops/backlog.json）。
+#
+# PBS VM (qemu/112) 停止・削除手順（実行未着手。物理/管理コンソール操作のため人間専有）:
+#
+#   1. Proxmox WebUI または `pvesh` で、pbs (qemu/112) を対象にした backup ジョブ
+#      （Datacenter > Backup、vzdump が PBS storage を指すもの）が実在しないか確認する。
+#      無ければそのまま 2 へ。あれば先にそのジョブを削除する（後述「確認できていないこと」参照）
+#   2. Proxmox WebUI で pbs (qemu/112) をシャットダウン（`qm shutdown 112`）する
+#   3. 一定期間（目安 1〜2 週間）稼働させたまま観察し、参照している設定・ジョブが無いことを
+#      再確認する
+#   4. 問題なければ pbs (qemu/112) を削除する（`qm destroy 112`）。ディスク（local-lvm 上の
+#      64GB）も同時に解放される
+#   5. このファイル（pbs.tf.ignore）と CLAUDE.md / README.md / Plans.md の pbs 関連記述を、
+#      「過去に運用していた」past tense に更新する PR を別途出す（削除はしない。経緯の記録として
+#      残す）
+#
+# autopilot の Proxmox credential（PVEAuditor、読み取り専用）ではこの手順を実行できない
+# （書き込み・削除権限が無い）。この in-cluster 実行環境自体に Proxmox credential が無いため
+# （2026-08-07 実測、環境変数に PROXMOX_* 系が存在しない）、手順1の確認も autopilot 単独では
+# できない。人間または構築セッション（Coder ワークスペース、T-0107 で PROXMOX_API_TOKEN の
+# Sys.Modify 権限を実測済み）が実行する。
+#
+# 確認できていないこと（手順1で埋める）: PBS 自身が保持している backup job 設定・保存済み
+# バックアップの一覧。autopilot はこの in-cluster 実行環境から PBS/Proxmox のどちらにも到達
+# できないため確認できない。issue #56 で構築セッションに確認を依頼した
+# （https://github.com/hikuohiku/homelab/issues/56, T-0116 参照）。
 
 resource "proxmox_virtual_environment_vm" "pbs" {
   name        = "pbs"


### PR DESCRIPTION
## 変更点

PBS VM (qemu/112) 退役タスク（T-0116）の残り DoD を進めました。実装（コード変更）は無く、記録・手順のドキュメント化のみです。

- `terraform/proxmox/pbs.tf.ignore` に PBS VM の停止・削除手順（Datacenter > Backup の確認 → shutdown → 観察期間 → destroy）を追記（DoD 3）
- `docs/backup.md` の「PBS 退役判断」節に、T-0117（workspace home backup 復元試験）完了を受けた現状を追記
- DoD(2)「PBS 上に他に依存しているジョブ・データが無いか最終確認する」は、この in-cluster autopilot 実行環境に Proxmox credential が無く確認できないため、issue #56 で構築セッションに確認を依頼しました（https://github.com/hikuohiku/homelab/issues/56#issuecomment-5210344855）
- `ops/backlog.json`: T-0116 を `todo` → `needs-human` に変更（残る作業は上記確認待ち＋人間による物理的な VM 停止・削除操作）
- journal / state.json / dashboard を更新

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `ops/check_*.py`（no-arg スクリプト全て）→ 全て ok
- `python3 ops/dashboard/build.py` → 例外なく生成・publish

## ロールバック手順

ドキュメント・backlog の変更のみで、実インフラには一切触れていません。この PR を revert すれば元の記述に戻ります（PBS VM 自体は今回も停止・削除していないため、revert してもインフラ側の状態変化はありません）。

## backlog task id

T-0116
