### PR TITLE
ops(run #208): 計画役 — 棚卸しの結果、新規起票なし・記録のみ

### DIFF
--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -6025,3 +6025,31 @@ GitHub Actions incident で blocked のまま run #172〜#193 を独立に積み
 - 見つけたこと: なし
 - 次の起動へ: この回の PR の CI green を確認して merge。T-0116 は構築セッション/人間からの
   返信待ち。返信が来ていなければ todo の次（`T-0163` 優先度50）へ進む
+
+## 2026-08-07 09:36 JST — run #208
+
+- 取り込んだフィードバック: なし。`ops-feedback` ブランチは引き続き不在（ダッシュボードからの
+  書き置きゼロ件）。issue #56 を `per_page=100` で全2ページ（114件）確認し、`feedback.json` の
+  最新エントリ（15:20:02Z）より新しい非自己投稿コメントは無し（直近の新規コメントは autopilot
+  自身が投稿した T-0116 確認依頼で、`<!-- autopilot:self-posted -->` マーカーにより取り込み対象外）
+- 前回の中断: なし。オープン PR 0件、`autopilot/*` の残りブランチ 0件（PR #383 は merge 済み）
+- 健全性: `ops-health-report`（generated_at 2026-08-07T00:30:04Z、新鮮）を確認。
+  `coder`/`immich`/`vaultwarden` の `Degraded` は既知事象 T-0106 由来（`SecretSyncedError` のみ、
+  Pod は全て Running/Ready）で新規異常なし。`pod_issues` の restartCount 19 系はいずれも
+  2026-08-03 の古い terminated イベントで変化なし。immich の `backup_listing` 最新 mtime は
+  2026-08-06T02:00:05Z（24時間以内）で健全。autopilot 自身の heartbeat は iteration #4 まで
+  exit_code 0 で正常
+- inbox: `ops/inbox.md` は空。変換対象なし
+- backlog 棚卸し: blocked/needs-human 13件を一つずつ確認した。T-0153/T-0156/T-0157
+  （`.github/workflows/ci.yml` への配線待ち）は該当箇所が依然として個別 step 列挙のままで
+  未変更、workflow scope 不足の前提は継続。T-0112（構築セッションへの postgres FATAL ログ
+  確認依頼）・T-0144（issue #35 の2点確認依頼）とも issue 側に返信なし。T-0116（PBS 上の
+  backup ジョブ確認依頼）は run #207 が本日 00:29:20Z に投稿したばかりで応答を待つには早すぎる。
+  T-0084 は `next_review: 2026-08-08` 未到来。前提が古びている blocked/needs-human は
+  見つからなかった
+- todo: T-0158/T-0162/T-0163/T-0164/T-0165 の5件が着手可能で足りている。新規起票なし
+- やったこと: なし（記録のみ）
+- 見つけたこと: なし
+- `python3 ops/validate.py` → 0 error, 0 warning
+- 次の起動へ: この回の PR の CI green を確認して merge。実行役は todo 先頭（`T-0158`）から
+  直列に着手

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-07T00:35:00Z",
+  "updated": "2026-08-07T00:36:54Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-07T00:35:00Z"
+    "last_read": "2026-08-07T00:36:54Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc",
@@ -219,6 +219,14 @@
       "kind": "in-cluster-loop",
       "by": "autopilot pod (実行役)",
       "summary": "実行役（journal run #207）。前回中断なし(PR #383 merge済み)、フィードバック新規なし。backlog todoの先頭T-0116（PBS VM退役）に着手。DoD(3)（停止・削除手順）をpbs.tf.ignore/docs/backup.mdに明記。DoD(2)（PBS上の依存ジョブ・データ確認）はautopilotにProxmox credentialが無く確認不能なため issue #56 で構築セッションに確認を依頼し needs-human に変更した。",
+      "prs": []
+    },
+    {
+      "n": 208,
+      "at": "2026-08-07T00:36:54Z",
+      "kind": "in-cluster-loop",
+      "by": "autopilot pod (計画役)",
+      "summary": "計画役（journal run #208）。前回の中断なし、フィードバック新規なし（ops-feedback ブランチ不在、issue #56 に非自己投稿の新着なし）、健全性は既知事象(T-0106)のみで異常なし。inbox 空。blocked/needs-human 13件を棚卸ししたが、いずれも前提は現在も成り立っており更新不要と判断（T-0153/T-0156/T-0157 の workflow scope 待ち・T-0112/T-0144 の返信待ち・T-0116 の依頼直後・T-0084 の next_review 未到来）。todo は T-0158/T-0162〜T-0165 の5件で足りており新規起票なし。",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

計画役の1イテレーション分の記録のみ（`ops/journal/`・`ops/state.json`）。コード・マニフェストの変更なし。

## やったこと

1. `ops/inbox.md` を確認 — 空。変換対象なし
2. 人間からのフィードバック取り込み — `ops-feedback` ブランチは引き続き不在（ダッシュボード経由の書き置き0件）。issue #56 を `per_page=100` で全2ページ取得し、`ops/feedback.json` の最新エントリより新しい非自己投稿コメントが無いことを確認（新着1件は autopilot 自身の自己投稿マーカー付きコメントのため取り込み対象外）
3. `ops-health-report` ブランチの健全性レポートを確認 — `coder`/`immich`/`vaultwarden` の `Degraded` は既知事象 T-0106（`SecretSyncedError` のみ、Pod は Running/Ready）で新規異常なし。immich バックアップ listing も直近24時間以内で健全
4. `ops/backlog.json` の blocked/needs-human 13件を一つずつ棚卸し — いずれも前提は現在も成り立っており、ステータス変更・記述更新の必要なし（T-0153/T-0156/T-0157 は `.github/workflows/ci.yml` 未変更のまま、T-0112/T-0144 は issue に返信なし、T-0116 は依頼直後、T-0084 は `next_review` 未到来）
5. `todo` は T-0158/T-0162〜T-0165 の5件で着手可能量として足りているため、新規起票なし

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning

## ロールバック手順

`ops/journal/`・`ops/state.json` の追記のみで実インフラへの影響は無い。revert すれば記録が1エントリ分減るだけ。

## backlog task id

なし（記録のみの回）
