### PR TITLE
chore(ops): T-0165 マージ後の帳簿圧縮 (ops/ledger.py)

### DIFF
--- a/ops/archive/backlog-done.json
+++ b/ops/archive/backlog-done.json
@@ -2680,6 +2680,25 @@
       "created": "2026-08-06",
       "pr": 379,
       "notes": "run #187（計画役）: ops/review-log.md R-002 を起票。R-002 の状態を『起票済 T-0161』に更新した。T-0153（CI検出の仕組み自体）とは別論点として分離。 run #201（実行役）: PR #376 merge後の直列化ルールに従い着手。commit 8eacc31 (chromium/font追加) が main へ入った push (merge commit 72eaec33ced3847c8b9030354d04261318b675fc、workflow run 31102707031, success) が実際にghcr.ioへ push したイメージのindex digestを ghcr.io/v2/.../manifests/72eaec33... へGET（ghcr.io/tokenで取得した匿名pullトークン使用）して実測: sha256:6d0cf8b13d602f189d75b48ef654cb0cfd0fe999740782928199097b7451bf75（現行pin同様OCI image index）。deployment.yamlのdigestをこれに更新。"
+    },
+    {
+      "id": "T-0165",
+      "domain": "homelab",
+      "title": "REVIEW_EVERY の根拠数値が CHARTER.md 2箇所と loop.sh に三重化しているのを一本化する（R-005）",
+      "kind": "chore",
+      "risk": "low",
+      "status": "done",
+      "priority": 52,
+      "why": "レビュー役・アーキテクチャレンズ R-005（ops/review-log.md参照）。REVIEW_EVERY=12の根拠数値（実測約9分/イテレーション、journal run #126〜#155の30起動で264分、レビューは約1.8時間おき、同じレンズは約3.5時間おき、実作業損失8%）が ops/CHARTER.md:173-176（§3）・ops/CHARTER.md:740（§6冒頭の再掲）・apps/autopilot/loop.sh:35-38（REVIEW_EVERYのコメント）の3箇所にほぼ同じ文面で重複している。1箇所を直しても他が追随しない構造で、とくにloop.sh側はコード上の意味を持たないコメントのため、値がズレてもCIにも起動時ログにも表れず気づけない",
+      "dod": "根拠の測定値（実測約9分/イテレーション等）の記述をCHARTER.md §3の1箇所にのみ残し、CHARTER.md §6冒頭の再掲は削除してCHARTER §3への参照（例: 'REVIEW_EVERYの根拠は§3参照'）に置き換える。apps/autopilot/loop.shのコメントも同様に、数値の再掲ではなくCHARTER §3への参照コメントに置き換える。再測定が必要になったとき1箇所を直せば済む状態にする",
+      "blocked_by": null,
+      "refs": [
+        "ops/CHARTER.md",
+        "apps/autopilot/loop.sh"
+      ],
+      "created": "2026-08-06",
+      "pr": 386,
+      "notes": "PR #378（レビュー役・アーキテクチャ初回実行）のR-002が、PR #376との統合時にR-005として採番し直された。起票は統合作業を行った計画役による 実行役 run #209: CHARTER.md §3 に一本化し、§6冒頭の再掲と loop.sh のコメントを §3 への参照に置き換えた（#386）。"
     }
   ]
 }

--- a/ops/archive/runs.json
+++ b/ops/archive/runs.json
@@ -1628,6 +1628,38 @@
       "by": "autopilot pod (実行役)",
       "summary": "実行役（journal run #185）。PR #376/#377はGitHub Actions incident（qcvjkzcs7j74）が20:34:17Z版のまま変化なし（本回確認21:09:05Z）のため、run #183/#184の方針（resolved/monitoring待ち）を継続しリトライ見送り。actions/runs?head_sha=も両ブランチとも引き続きtotal_count:0。feedback/健全性とも新規変化なし、T-0117/T-0158とも直列化ルールに従い今回も着手せず。",
       "prs": []
+    },
+    {
+      "n": 186,
+      "at": "2026-08-06T21:14:00Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (実行役)",
+      "summary": "実行役（journal run #186）。PR #376/#377はGitHub Actions incident（qcvjkzcs7j74）が20:34:17Z版のまま変化なし（本回確認21:14:26Z）のため、run #183〜#185の方針（resolved/monitoring待ち）を継続しリトライ見送り。actions/runs?head_sha=も両ブランチとも引き続きtotal_count:0。feedback/健全性とも新規変化なし、T-0117/T-0158とも直列化ルールに従い今回も着手せず。",
+      "prs": []
+    },
+    {
+      "n": 187,
+      "at": "2026-08-06T16:51:41Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (レビュー役・利用者視点)",
+      "summary": "レビュー役・利用者視点（journal run #172）。初回実行（review-log に既存エントリ無し）。フィードバック新着3件をfeedback.jsonにnewで追記。プロンプト記載のダッシュボード確認手順を実際に辿り、(R-001) kubectl get svc がRBACのservices欠如でForbidden、(R-002) chromium/フォント追加(commit 8eacc31)がdeployment.yamlのimage digest未更新で稼働Podに届いておらず描画して見る手段が無い、(R-003) 健全性サマリ「落ちている: coder/immich/vaultwarden」にT-0106由来の無害な既知状態である注記が無く初見で誤読する、の3件を発見しreview-log.md/inbox.mdに記録。この2件（n:187/188）は PR #377 が別ブランチとして開いたまま長時間 GitHub Actions outage で merge できなかったため、run #187（計画役）が PR #376 と #377 を手動 merge して1本化した際に state.json 側へ追記した（journal 側は本来の時系列位置に既に挿入済み）。",
+      "prs": []
+    },
+    {
+      "n": 188,
+      "at": "2026-08-06T20:18:29Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (レビュー役・利用者視点)",
+      "summary": "レビュー役・利用者視点（journal run #172 続き）。前回の中断（PR #377, open のまま）を新規タスクより先に回収。R-001/R-002 を自分でも独立に再現確認。PR #377 の CI が2回連続 workflow run 0件で止まっていたため空コミットで retrigger したが同様に0件、githubstatus.com で GitHub Actions が major_outage と確認（run #176/#178 の『解消済み』表記は誤りだった）。追加で気づいた「ops/feedback.jsonの内容がダッシュボードに一切表示されない」点はこの回の指摘上限（3件、PR #377で使用済み）を避けるため今回は起票せず申し送りのみ。フィードバック新規なし。",
+      "prs": []
+    },
+    {
+      "n": 189,
+      "at": "2026-08-06T21:31:00Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (計画役)",
+      "summary": "計画役（journal run #187）。PR #376/#377 は GitHub Actions incident（qcvjkzcs7j74）が引き続き investigating（update は 21:30:42Z 版へ進んだが webhook throttle 継続）のためリトライ見送り。2つの open PR が #172 の分岐以降15回以上の起動にわたって独立に ops/ ファイルを編集し続けコンフリクト確実だったため、autopilot/run-172-review-user を autopilot/run-172-records へ手動 merge で1本化（journal/state.json は at タイムスタンプで正しい時系列に挿入）。レビュー役が取り込んだ feedback 新着3件は autopilot 自身の自己投稿（issue #56 author が hikuohiku PAT と同一のため区別不能）と判明し declined、構造的原因を T-0159 として起票。inbox の R-001/R-002/R-003 を T-0160/T-0161/T-0162 として起票し review-log.md の状態を更新、T-0117 の GC調査メモは同タスクの notes へ折り込みinbox を空にした。backlog 20→24件。健全性・issue #56 とも新規異常なし。",
+      "prs": []
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -598,25 +598,6 @@
       "created": "2026-08-06",
       "pr": null,
       "notes": "PR #378（レビュー役・アーキテクチャ初回実行）のR-001が、PR #376との統合時にR-004として採番し直された。起票は統合作業を行った計画役による"
-    },
-    {
-      "id": "T-0165",
-      "domain": "homelab",
-      "title": "REVIEW_EVERY の根拠数値が CHARTER.md 2箇所と loop.sh に三重化しているのを一本化する（R-005）",
-      "kind": "chore",
-      "risk": "low",
-      "status": "done",
-      "priority": 52,
-      "why": "レビュー役・アーキテクチャレンズ R-005（ops/review-log.md参照）。REVIEW_EVERY=12の根拠数値（実測約9分/イテレーション、journal run #126〜#155の30起動で264分、レビューは約1.8時間おき、同じレンズは約3.5時間おき、実作業損失8%）が ops/CHARTER.md:173-176（§3）・ops/CHARTER.md:740（§6冒頭の再掲）・apps/autopilot/loop.sh:35-38（REVIEW_EVERYのコメント）の3箇所にほぼ同じ文面で重複している。1箇所を直しても他が追随しない構造で、とくにloop.sh側はコード上の意味を持たないコメントのため、値がズレてもCIにも起動時ログにも表れず気づけない",
-      "dod": "根拠の測定値（実測約9分/イテレーション等）の記述をCHARTER.md §3の1箇所にのみ残し、CHARTER.md §6冒頭の再掲は削除してCHARTER §3への参照（例: 'REVIEW_EVERYの根拠は§3参照'）に置き換える。apps/autopilot/loop.shのコメントも同様に、数値の再掲ではなくCHARTER §3への参照コメントに置き換える。再測定が必要になったとき1箇所を直せば済む状態にする",
-      "blocked_by": null,
-      "refs": [
-        "ops/CHARTER.md",
-        "apps/autopilot/loop.sh"
-      ],
-      "created": "2026-08-06",
-      "pr": 386,
-      "notes": "PR #378（レビュー役・アーキテクチャ初回実行）のR-002が、PR #376との統合時にR-005として採番し直された。起票は統合作業を行った計画役による 実行役 run #209: CHARTER.md §3 に一本化し、§6冒頭の再掲と loop.sh のコメントを §3 への参照に置き換えた（#386）。"
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -35,38 +35,6 @@
   },
   "runs": [
     {
-      "n": 186,
-      "at": "2026-08-06T21:14:00Z",
-      "kind": "in_cluster_loop",
-      "by": "autopilot pod (実行役)",
-      "summary": "実行役（journal run #186）。PR #376/#377はGitHub Actions incident（qcvjkzcs7j74）が20:34:17Z版のまま変化なし（本回確認21:14:26Z）のため、run #183〜#185の方針（resolved/monitoring待ち）を継続しリトライ見送り。actions/runs?head_sha=も両ブランチとも引き続きtotal_count:0。feedback/健全性とも新規変化なし、T-0117/T-0158とも直列化ルールに従い今回も着手せず。",
-      "prs": []
-    },
-    {
-      "n": 187,
-      "at": "2026-08-06T16:51:41Z",
-      "kind": "in_cluster_loop",
-      "by": "autopilot pod (レビュー役・利用者視点)",
-      "summary": "レビュー役・利用者視点（journal run #172）。初回実行（review-log に既存エントリ無し）。フィードバック新着3件をfeedback.jsonにnewで追記。プロンプト記載のダッシュボード確認手順を実際に辿り、(R-001) kubectl get svc がRBACのservices欠如でForbidden、(R-002) chromium/フォント追加(commit 8eacc31)がdeployment.yamlのimage digest未更新で稼働Podに届いておらず描画して見る手段が無い、(R-003) 健全性サマリ「落ちている: coder/immich/vaultwarden」にT-0106由来の無害な既知状態である注記が無く初見で誤読する、の3件を発見しreview-log.md/inbox.mdに記録。この2件（n:187/188）は PR #377 が別ブランチとして開いたまま長時間 GitHub Actions outage で merge できなかったため、run #187（計画役）が PR #376 と #377 を手動 merge して1本化した際に state.json 側へ追記した（journal 側は本来の時系列位置に既に挿入済み）。",
-      "prs": []
-    },
-    {
-      "n": 188,
-      "at": "2026-08-06T20:18:29Z",
-      "kind": "in_cluster_loop",
-      "by": "autopilot pod (レビュー役・利用者視点)",
-      "summary": "レビュー役・利用者視点（journal run #172 続き）。前回の中断（PR #377, open のまま）を新規タスクより先に回収。R-001/R-002 を自分でも独立に再現確認。PR #377 の CI が2回連続 workflow run 0件で止まっていたため空コミットで retrigger したが同様に0件、githubstatus.com で GitHub Actions が major_outage と確認（run #176/#178 の『解消済み』表記は誤りだった）。追加で気づいた「ops/feedback.jsonの内容がダッシュボードに一切表示されない」点はこの回の指摘上限（3件、PR #377で使用済み）を避けるため今回は起票せず申し送りのみ。フィードバック新規なし。",
-      "prs": []
-    },
-    {
-      "n": 189,
-      "at": "2026-08-06T21:31:00Z",
-      "kind": "in_cluster_loop",
-      "by": "autopilot pod (計画役)",
-      "summary": "計画役（journal run #187）。PR #376/#377 は GitHub Actions incident（qcvjkzcs7j74）が引き続き investigating（update は 21:30:42Z 版へ進んだが webhook throttle 継続）のためリトライ見送り。2つの open PR が #172 の分岐以降15回以上の起動にわたって独立に ops/ ファイルを編集し続けコンフリクト確実だったため、autopilot/run-172-review-user を autopilot/run-172-records へ手動 merge で1本化（journal/state.json は at タイムスタンプで正しい時系列に挿入）。レビュー役が取り込んだ feedback 新着3件は autopilot 自身の自己投稿（issue #56 author が hikuohiku PAT と同一のため区別不能）と判明し declined、構造的原因を T-0159 として起票。inbox の R-001/R-002/R-003 を T-0160/T-0161/T-0162 として起票し review-log.md の状態を更新、T-0117 の GC調査メモは同タスクの notes へ折り込みinbox を空にした。backlog 20→24件。健全性・issue #56 とも新規異常なし。",
-      "prs": []
-    },
-    {
       "n": 190,
       "at": "2026-08-06T21:38:00Z",
       "kind": "in_cluster_loop",


### PR DESCRIPTION
## 変更点

`ops/ledger.py` による帳簿圧縮のみ。コード・マニフェストの変更なし。

PR #386 で T-0165 を `done` にした際、CHARTER §「済んだら帳簿を圧縮する」の
「タスクを done にした回は、同じ PR で `python3 ops/ledger.py` を実行すること」を
実行し忘れていたため、別 PR で実施する。

- `ops/backlog.json`: done の T-0165 1件を `ops/archive/backlog-done.json` へ移動（残り22件）
- `ops/state.json`: 古い起動記録4件を `ops/archive/runs.json` へ移動（残り20件）

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- 圧縮後サイズ: backlog.json 88,670 bytes / 上限 120,000、state.json 15,070 bytes / 上限 40,000

## ロールバック手順

revert すれば帳簿のエントリが archive から戻り、backlog.json/state.json が肥大化した状態に戻るだけ。
実インフラ・実データへの影響は無い。

## backlog task id

なし（記録の圧縮のみ）
