### PR TITLE
feat(dashboard): coder/immich/vaultwarden の Degraded に T-0106 既知事象の注記を追加 (T-0162)

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 166,
-  "updated": "2026-08-07T00:55:00Z",
+  "updated": "2026-08-07T00:57:24Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -547,7 +547,7 @@
       "title": "ダッシュボードの健全性サマリに coder/immich/vaultwarden Degraded が T-0106 由来の既知事象である旨を注記する（レビュー役 R-003）",
       "kind": "feature",
       "risk": "low",
-      "status": "todo",
+      "status": "done",
       "priority": 55,
       "why": "レビュー役 run #172（利用者視点、R-003, PR #377）の発見。ダッシュボード先頭の健全性サマリが『落ちている: coder、immich、vaultwarden』とだけ赤字表示し、これが T-0106（Doppler キー未登録による ExternalSecret の SecretSyncedError、Pod 自体は全て Running/Ready で実サービスへの影響なし）由来の無害な既知状態であることの注記が無い。初見の人間は『3 サービスが落ちている』と誤読する。事情を辿るには優先度順19件の待ち行列を14番目（T-0106）までスクロールし、さらに完了扱いの T-0122 まで辿る必要があり、VISION が名指しで求める『(a) いまシステムは健康か』にダッシュボード単体では正しく・素早く答えられない",
       "dod": "`ops/dashboard/build.py` の健全性サマリ生成部分で、Degraded な Application が T-0106 由来（`SecretSyncedError` かつ対象が `<app>-restic-backup-credentials` のみ）と機械的に判定できる場合に、サマリ内に一言の注記（例: 『既知の原因あり (T-0106)、実サービスへの影響なし』）を添える。機械判定が難しければ、少なくとも静的な注記（『Degraded の詳細は T-0106 を参照』等、対象アプリ名を明示）を追加する。生成した HTML を目視確認し、初見でも『実害なし』と分かる文言になっているか確認する",
@@ -557,7 +557,7 @@
       ],
       "created": "2026-08-06",
       "pr": null,
-      "notes": "run #187（計画役）: ops/review-log.md R-003 を起票。R-003 の状態を『起票済 T-0162』に更新した。"
+      "notes": "run #187（計画役）: ops/review-log.md R-003 を起票。R-003 の状態を『起票済 T-0162』に更新した。 | run #210（実行役）: 健全性レポートが externalsecret 詳細を持たず機械判定できないため、DoD のフォールバック方針どおり静的な注記にした。bad apps が {coder, immich, vaultwarden} の既知集合に収まる場合と一部混在する場合の両方をローカルで検証（後者は既知分のみ注記し他は『要確認』と表示）。done。"
     },
     {
       "id": "T-0163",

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -556,7 +556,7 @@
         "ops/dashboard/build.py"
       ],
       "created": "2026-08-06",
-      "pr": null,
+      "pr": 388,
       "notes": "run #187（計画役）: ops/review-log.md R-003 を起票。R-003 の状態を『起票済 T-0162』に更新した。 | run #210（実行役）: 健全性レポートが externalsecret 詳細を持たず機械判定できないため、DoD のフォールバック方針どおり静的な注記にした。bad apps が {coder, immich, vaultwarden} の既知集合に収まる場合と一部混在する場合の両方をローカルで検証（後者は既知分のみ注記し他は『要確認』と表示）。done。"
     },
     {

--- a/ops/dashboard/build.py
+++ b/ops/dashboard/build.py
@@ -530,6 +530,16 @@ def render_pulse(state, health, prs, runs) -> str:
         atone = "crit" if bad else "ok"
         atext = f"{len(apps) - len(bad)} / {len(apps)} 正常"
         asub = ("落ちている: " + "、".join(E(str(a.get("name"))) for a in bad[:4])) if bad else fresh
+        # T-0162: coder/immich/vaultwarden の Degraded は Doppler 未登録の
+        # ExternalSecret（T-0106）由来と分かっている既知事象。健全性レポートは
+        # externalsecret の詳細まで持たないので機械判定はできず、静的な注記に留める。
+        bad_names = {str(a.get("name")) for a in bad}
+        known_t0106 = {"coder", "immich", "vaultwarden"}
+        if bad_names and bad_names <= known_t0106:
+            asub += "（既知の原因あり: T-0106、実サービスへの影響なし）"
+        elif bad_names & known_t0106:
+            asub += (f"（うち {'、'.join(sorted(bad_names & known_t0106))} は"
+                      "既知の原因あり: T-0106、実サービスへの影響なし。他は要確認）")
         if bad and ftone != "ok":
             asub += f"（{fresh}）"
     else:

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,34 @@
   "open": [],
   "merged": [
     {
+      "number": 387,
+      "title": "chore(ops): T-0165 マージ後の帳簿圧縮 (ops/ledger.py)",
+      "url": "https://github.com/hikuohiku/homelab/pull/387",
+      "mergedAt": "2026-08-07T00:50:43Z",
+      "headRefName": "autopilot/T-0165-ledger-followup"
+    },
+    {
+      "number": 386,
+      "title": "chore(ops): REVIEW_EVERY の根拠数値の三重化を解消する (T-0165)",
+      "url": "https://github.com/hikuohiku/homelab/pull/386",
+      "mergedAt": "2026-08-07T00:48:57Z",
+      "headRefName": "autopilot/T-0165-review-every-dedup"
+    },
+    {
+      "number": 385,
+      "title": "ops(run #208): 計画役 — 棚卸しの結果、新規起票なし・記録のみ",
+      "url": "https://github.com/hikuohiku/homelab/pull/385",
+      "mergedAt": "2026-08-07T00:42:03Z",
+      "headRefName": "autopilot/run208-planning-record"
+    },
+    {
+      "number": 384,
+      "title": "docs(pbs): PBS VM 退役手順を明記し、依存確認を構築セッションへ依頼する (T-0116)",
+      "url": "https://github.com/hikuohiku/homelab/pull/384",
+      "mergedAt": "2026-08-07T00:32:02Z",
+      "headRefName": "autopilot/T-0116-pbs-decommission-doc"
+    },
+    {
       "number": 383,
       "title": "docs(backup): coder workspace home の復元試験の成功を記録し、検証用リソースを削除する (T-0117)",
       "url": "https://github.com/hikuohiku/homelab/pull/383",
@@ -392,34 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/325",
       "mergedAt": "2026-08-06T08:45:11Z",
       "headRefName": "autopilot/T-0137-syncthing-k8s-feasibility"
-    },
-    {
-      "number": 324,
-      "title": "T-0136: Tailscale Services/ProxyGroup 調査 — 導入見送り",
-      "url": "https://github.com/hikuohiku/homelab/pull/324",
-      "mergedAt": "2026-08-06T08:33:06Z",
-      "headRefName": "autopilot/T-0136-tailscale-services-investigation"
-    },
-    {
-      "number": 323,
-      "title": "chore(ops): run #132（計画役）T-0136/T-0137 起票、記録更新",
-      "url": "https://github.com/hikuohiku/homelab/pull/323",
-      "mergedAt": "2026-08-06T08:23:52Z",
-      "headRefName": "autopilot/run132-plan-T-0136-T-0137"
-    },
-    {
-      "number": 322,
-      "title": "chore(ops): T-0135 孤児ブランチ2件を削除、記録更新",
-      "url": "https://github.com/hikuohiku/homelab/pull/322",
-      "mergedAt": "2026-08-06T08:13:01Z",
-      "headRefName": "autopilot/T-0135-cleanup-orphan-branches"
-    },
-    {
-      "number": 321,
-      "title": "docs(ops): run #130（計画役）記録更新、新規起票なし",
-      "url": "https://github.com/hikuohiku/homelab/pull/321",
-      "mergedAt": "2026-08-06T08:06:17Z",
-      "headRefName": "autopilot/run130-plan-no-new-findings"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -6073,3 +6073,27 @@ GitHub Actions incident で blocked のまま run #172〜#193 を独立に積み
   大きく、実行役の1回で確実に仕上げるには荷が重いと判断した。`ops/inbox.md` に計画役への
   分割提案を記録
 - 次の起動へ: この回の PR (#386) の CI green を確認して merge。T-0163/T-0164 は分割を検討
+
+## 2026-08-07 09:57 JST — run #210
+
+- 取り込んだフィードバック: なし。`ops-feedback` ブランチ引き続き不在（ダッシュボードからの
+  書き置きゼロ件）。issue #56 を `per_page=100` で全2ページ（114件）確認し、`feedback.json` の
+  最新エントリより新しい非自己投稿コメントは無し（直近の新着は autopilot 自身が投稿した
+  T-0116 の PBS backup ジョブ確認依頼で、`<!-- autopilot:self-posted -->` マーカーにより
+  取り込み対象外）
+- 前回の中断: なし。PR #386/#387（T-0165 本体・帳簿圧縮フォローアップ）はいずれも merge 済みを
+  確認。オープン PR 0件、`autopilot/*` の残りブランチ 0件
+- 健全性: `ops-health-report`（generated_at 2026-08-07T00:30:04Z）を確認。`coder`/`immich`/
+  `vaultwarden` の `Degraded` は既知事象 T-0106 由来のみで新規異常なし。autopilot 自身の
+  heartbeat も iteration #4 まで exit_code 0 で正常
+- やったこと: todo 優先度順（`T-0163`/`T-0164` は run #209 が分割見送り済み、inbox に分割提案を
+  記録済み）の次点 `T-0162`（priority 55、レビュー役 R-003、ダッシュボードの健全性サマリに
+  T-0106 既知事象の注記を追加）に着手。`ops/dashboard/build.py` の `render_pulse()` に、
+  Degraded な Application が `{coder, immich, vaultwarden}` の既知集合に収まる場合の静的注記を
+  追加した（健全性レポートは externalsecret の詳細を持たず機械判定できないため、DoD の
+  フォールバック方針どおり）。ローカルで3パターン（全て既知／一部既知混在／異常なし）を検証し、
+  想定どおりの文言になることを確認。`python3 ops/validate.py` → 0 error, 0 warning。T-0162 を
+  done にした
+- 見つけたこと: なし
+- 次の起動へ: この回の PR の CI green を確認して merge。todo 残りは `T-0158`（priority 92）と、
+  分割待ちの `T-0163`/`T-0164`

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-07T00:47:01Z",
+  "updated": "2026-08-07T00:57:24Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
@@ -206,6 +206,14 @@
       "prs": [
         386
       ]
+    },
+    {
+      "n": 210,
+      "at": "2026-08-07T00:57:24Z",
+      "kind": "in-cluster-loop",
+      "by": "autopilot pod (実行役)",
+      "summary": "実行役（journal run #210）。前回中断なし（PR #386/#387 とも merge済み）、フィードバック新規なし、健全性は既知事象(T-0106)のみで異常なし。T-0163/T-0164は分割待ちのため見送り、T-0162（priority 55、レビュー役R-003、ダッシュボードのDegradedにT-0106既知事象の注記）に着手。ops/dashboard/build.py の render_pulse() に静的注記を追加、3パターンをローカル検証しdoneにした。",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

ダッシュボードの健全性サマリ（`ops/dashboard/build.py` の `render_pulse()`）に、
`coder`/`immich`/`vaultwarden` の Degraded が T-0106（Doppler 未登録の ExternalSecret による
`SecretSyncedError`、Pod 自体は全て Running/Ready で実サービスへの影響なし）由来の既知事象で
あることを示す静的な注記を追加しました。これまでは「落ちている: coder、immich、vaultwarden」
とだけ表示され、初見の人間には3サービスが実際に落ちているように読めていました
（レビュー役 run #172 R-003 の指摘）。

健全性レポート（`ops-health-report` ブランチの `latest.json`）は ExternalSecret の詳細
（`SecretSyncedError` の対象等）まで持っていないため、「Degraded の原因が本当に T-0106 か」を
機械的に判定することはできません。DoD のフォールバック方針どおり、Degraded な Application 名が
`{coder, immich, vaultwarden}` の既知集合に収まる場合（全部一致／一部混在の両方）に静的な文言を
添える形にしました。

## 検証したこと

- ローカルで3パターン（全て既知集合に一致／一部が既知集合外と混在／異常なし）を
  `render_pulse()` に直接与えて出力を確認:
  - 全て既知: `落ちている: coder、immich、vaultwarden（既知の原因あり: T-0106、実サービスへの影響なし）`
  - 一部混在: `落ちている: coder、dex（うち coder は既知の原因あり: T-0106、実サービスへの影響なし。他は要確認）`
  - 異常なし: 通常の観測時刻表示のまま（注記なし）
- 実際の `ops-health-report`（generated_at 2026-08-07T00:30:04Z）を使って `python3 ops/dashboard/build.py` を実行し、生成された `index.html` に想定どおりの文言が出ることを確認
- `python3 ops/validate.py` → 0 error, 0 warning

## ロールバック手順

`ops/dashboard/build.py` のこの diff を revert すれば、追加した注記のロジックのみが消えて
元の表示（注記なし）に戻ります。DB・スキーマ・実データへの変更は含まないため、revert に伴う
不整合は発生しません。`ops/dashboard/index.html` は Git 管理していない生成物（T-0035）なので、
コード revert 後の次回 `build.py` 実行で自動的に反映されます。

## backlog task id

T-0162
