### PR TITLE
chore(ops): T-0162 マージ後の帳簿圧縮 (ops/ledger.py)

### DIFF
--- a/ops/archive/backlog-done.json
+++ b/ops/archive/backlog-done.json
@@ -2682,6 +2682,24 @@
       "notes": "run #187（計画役）: ops/review-log.md R-002 を起票。R-002 の状態を『起票済 T-0161』に更新した。T-0153（CI検出の仕組み自体）とは別論点として分離。 run #201（実行役）: PR #376 merge後の直列化ルールに従い着手。commit 8eacc31 (chromium/font追加) が main へ入った push (merge commit 72eaec33ced3847c8b9030354d04261318b675fc、workflow run 31102707031, success) が実際にghcr.ioへ push したイメージのindex digestを ghcr.io/v2/.../manifests/72eaec33... へGET（ghcr.io/tokenで取得した匿名pullトークン使用）して実測: sha256:6d0cf8b13d602f189d75b48ef654cb0cfd0fe999740782928199097b7451bf75（現行pin同様OCI image index）。deployment.yamlのdigestをこれに更新。"
     },
     {
+      "id": "T-0162",
+      "domain": "homelab",
+      "title": "ダッシュボードの健全性サマリに coder/immich/vaultwarden Degraded が T-0106 由来の既知事象である旨を注記する（レビュー役 R-003）",
+      "kind": "feature",
+      "risk": "low",
+      "status": "done",
+      "priority": 55,
+      "why": "レビュー役 run #172（利用者視点、R-003, PR #377）の発見。ダッシュボード先頭の健全性サマリが『落ちている: coder、immich、vaultwarden』とだけ赤字表示し、これが T-0106（Doppler キー未登録による ExternalSecret の SecretSyncedError、Pod 自体は全て Running/Ready で実サービスへの影響なし）由来の無害な既知状態であることの注記が無い。初見の人間は『3 サービスが落ちている』と誤読する。事情を辿るには優先度順19件の待ち行列を14番目（T-0106）までスクロールし、さらに完了扱いの T-0122 まで辿る必要があり、VISION が名指しで求める『(a) いまシステムは健康か』にダッシュボード単体では正しく・素早く答えられない",
+      "dod": "`ops/dashboard/build.py` の健全性サマリ生成部分で、Degraded な Application が T-0106 由来（`SecretSyncedError` かつ対象が `<app>-restic-backup-credentials` のみ）と機械的に判定できる場合に、サマリ内に一言の注記（例: 『既知の原因あり (T-0106)、実サービスへの影響なし』）を添える。機械判定が難しければ、少なくとも静的な注記（『Degraded の詳細は T-0106 を参照』等、対象アプリ名を明示）を追加する。生成した HTML を目視確認し、初見でも『実害なし』と分かる文言になっているか確認する",
+      "blocked_by": null,
+      "refs": [
+        "ops/dashboard/build.py"
+      ],
+      "created": "2026-08-06",
+      "pr": 388,
+      "notes": "run #187（計画役）: ops/review-log.md R-003 を起票。R-003 の状態を『起票済 T-0162』に更新した。 | run #210（実行役）: 健全性レポートが externalsecret 詳細を持たず機械判定できないため、DoD のフォールバック方針どおり静的な注記にした。bad apps が {coder, immich, vaultwarden} の既知集合に収まる場合と一部混在する場合の両方をローカルで検証（後者は既知分のみ注記し他は『要確認』と表示）。done。"
+    },
+    {
       "id": "T-0165",
       "domain": "homelab",
       "title": "REVIEW_EVERY の根拠数値が CHARTER.md 2箇所と loop.sh に三重化しているのを一本化する（R-005）",

--- a/ops/archive/runs.json
+++ b/ops/archive/runs.json
@@ -1660,6 +1660,14 @@
       "by": "autopilot pod (計画役)",
       "summary": "計画役（journal run #187）。PR #376/#377 は GitHub Actions incident（qcvjkzcs7j74）が引き続き investigating（update は 21:30:42Z 版へ進んだが webhook throttle 継続）のためリトライ見送り。2つの open PR が #172 の分岐以降15回以上の起動にわたって独立に ops/ ファイルを編集し続けコンフリクト確実だったため、autopilot/run-172-review-user を autopilot/run-172-records へ手動 merge で1本化（journal/state.json は at タイムスタンプで正しい時系列に挿入）。レビュー役が取り込んだ feedback 新着3件は autopilot 自身の自己投稿（issue #56 author が hikuohiku PAT と同一のため区別不能）と判明し declined、構造的原因を T-0159 として起票。inbox の R-001/R-002/R-003 を T-0160/T-0161/T-0162 として起票し review-log.md の状態を更新、T-0117 の GC調査メモは同タスクの notes へ折り込みinbox を空にした。backlog 20→24件。健全性・issue #56 とも新規異常なし。",
       "prs": []
+    },
+    {
+      "n": 190,
+      "at": "2026-08-06T21:38:00Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (実行役)",
+      "summary": "実行役（journal run #190）。PR #377 は close・ブランチ削除済みを確認、残る中断は PR #376 のみ。GitHub Actions incident（qcvjkzcs7j74）は run #189 が見た 21:30:42Z 版から変化なし、actions/runs?head_sha= も total_count:0 のままのためリトライ見送り。feedback/健全性とも新規変化なし、T-0117/T-0158/T-0159〜T-0162 とも直列化ルールに従い今回も着手せず。",
+      "prs": []
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -542,24 +542,6 @@
       "notes": "run #181（計画役）: ops/inbox.md（run #174 実行役の記録、autopilot/run-172-records ブランチ上で発見・処理。GitHub Actions major_outage で PR #376/#377 が blocked のため main にはまだ無い引き継ぎだった）から起票。緊急性なし（自己回復済み、データ破壊・誤動作は無い）"
     },
     {
-      "id": "T-0162",
-      "domain": "homelab",
-      "title": "ダッシュボードの健全性サマリに coder/immich/vaultwarden Degraded が T-0106 由来の既知事象である旨を注記する（レビュー役 R-003）",
-      "kind": "feature",
-      "risk": "low",
-      "status": "done",
-      "priority": 55,
-      "why": "レビュー役 run #172（利用者視点、R-003, PR #377）の発見。ダッシュボード先頭の健全性サマリが『落ちている: coder、immich、vaultwarden』とだけ赤字表示し、これが T-0106（Doppler キー未登録による ExternalSecret の SecretSyncedError、Pod 自体は全て Running/Ready で実サービスへの影響なし）由来の無害な既知状態であることの注記が無い。初見の人間は『3 サービスが落ちている』と誤読する。事情を辿るには優先度順19件の待ち行列を14番目（T-0106）までスクロールし、さらに完了扱いの T-0122 まで辿る必要があり、VISION が名指しで求める『(a) いまシステムは健康か』にダッシュボード単体では正しく・素早く答えられない",
-      "dod": "`ops/dashboard/build.py` の健全性サマリ生成部分で、Degraded な Application が T-0106 由来（`SecretSyncedError` かつ対象が `<app>-restic-backup-credentials` のみ）と機械的に判定できる場合に、サマリ内に一言の注記（例: 『既知の原因あり (T-0106)、実サービスへの影響なし』）を添える。機械判定が難しければ、少なくとも静的な注記（『Degraded の詳細は T-0106 を参照』等、対象アプリ名を明示）を追加する。生成した HTML を目視確認し、初見でも『実害なし』と分かる文言になっているか確認する",
-      "blocked_by": null,
-      "refs": [
-        "ops/dashboard/build.py"
-      ],
-      "created": "2026-08-06",
-      "pr": 388,
-      "notes": "run #187（計画役）: ops/review-log.md R-003 を起票。R-003 の状態を『起票済 T-0162』に更新した。 | run #210（実行役）: 健全性レポートが externalsecret 詳細を持たず機械判定できないため、DoD のフォールバック方針どおり静的な注記にした。bad apps が {coder, immich, vaultwarden} の既知集合に収まる場合と一部混在する場合の両方をローカルで検証（後者は既知分のみ注記し他は『要確認』と表示）。done。"
-    },
-    {
       "id": "T-0163",
       "domain": "homelab",
       "title": "既知の外部障害でリトライ不能と判明した後、確認間隔を伸ばす backoff の仕組みを作る",

--- a/ops/state.json
+++ b/ops/state.json
@@ -35,14 +35,6 @@
   },
   "runs": [
     {
-      "n": 190,
-      "at": "2026-08-06T21:38:00Z",
-      "kind": "in_cluster_loop",
-      "by": "autopilot pod (実行役)",
-      "summary": "実行役（journal run #190）。PR #377 は close・ブランチ削除済みを確認、残る中断は PR #376 のみ。GitHub Actions incident（qcvjkzcs7j74）は run #189 が見た 21:30:42Z 版から変化なし、actions/runs?head_sha= も total_count:0 のままのためリトライ見送り。feedback/健全性とも新規変化なし、T-0117/T-0158/T-0159〜T-0162 とも直列化ルールに従い今回も着手せず。",
-      "prs": []
-    },
-    {
       "n": 191,
       "at": "2026-08-06T21:46:00Z",
       "kind": "in_cluster_loop",


### PR DESCRIPTION
## 変更点

T-0162（PR #388）を done にした回に `python3 ops/ledger.py` を実行し忘れていたため、別 PR で補います。
`ops/backlog.json` の done エントリ1件を `ops/archive/backlog-done.json` へ、`ops/state.json` の
起動記録1件を `ops/archive/runs.json` へ移しました（内容の変更なし、置き場所の移動のみ）。

## 検証したこと

- `python3 ops/ledger.py` を実行（backlog 1件・state 1件を archive へ移動、サイズ上限内に収まることを確認）
- `python3 ops/validate.py` → 0 error, 0 warning

## ロールバック手順

archive への移動は参照の付け替えのみで、この PR を revert すればエントリは元の
`ops/backlog.json`/`ops/state.json` に戻ります。データの意味的な変更は含みません。

## backlog task id

T-0162（記録の後始末、リポジトリ内で完結する low risk の変更）
