### PR TITLE
feat(autopilot): loop.sh の起動失敗理由を心拍ログに載せる (T-0158)

### DIFF
--- a/apps/autopilot/loop.sh
+++ b/apps/autopilot/loop.sh
@@ -87,21 +87,26 @@ setup_git() {
 }
 
 # 1 イテレーション: リポジトリを最新化 → claude -p を実行 → 終了コードを返す
+# 早期 return の理由は FAIL_REASON に書いて main() のログ行に載せる（T-0158）。
+# 「claude -p 自体の異常」と「repo 同期前段での早期return」を外形（heartbeat の
+# exit_code のみ）から区別できず、外から『止まっている』のと見分けがつかなかったため
 iterate() {
+  FAIL_REASON=""
+
   if [ ! -d "${REPO_DIR}/.git" ]; then
     log "cloning ${REPO_URL} into ${REPO_DIR}"
-    git clone --quiet "${REPO_URL}" "${REPO_DIR}" || return 1
+    git clone --quiet "${REPO_URL}" "${REPO_DIR}" || { FAIL_REASON="git clone failed"; return 1; }
   fi
 
-  cd "${REPO_DIR}" || return 1
+  cd "${REPO_DIR}" || { FAIL_REASON="cd to repo failed"; return 1; }
 
   # 前回のイテレーションの作業ブランチ・未コミットの残骸は捨てて main の最新から始める。
   # 中断の引き継ぎは origin 側（オープン PR と autopilot/* ブランチ）から拾う設計
   # なので、ローカルに残す意味が無い（CHARTER §2）
-  git fetch --prune --quiet origin || return 1
-  git checkout --quiet -B main origin/main || return 1
-  git reset --hard --quiet origin/main || return 1
-  git clean -fdq || return 1
+  git fetch --prune --quiet origin || { FAIL_REASON="git fetch failed"; return 1; }
+  git checkout --quiet -B main origin/main || { FAIL_REASON="git checkout failed"; return 1; }
+  git reset --hard --quiet origin/main || { FAIL_REASON="git reset failed"; return 1; }
+  git clean -fdq || { FAIL_REASON="git clean failed"; return 1; }
 
   # 役の選択。REVIEW_EVERY 回に 1 回はレビュー役、着手可能なタスクが無いか
   # PLAN_EVERY 回に 1 回は計画役、それ以外は実行役。
@@ -163,7 +168,7 @@ EOF
   fi
   log "role=${role}${lens:+ lens=${lens}} actionable=${actionable}"
 
-  PROMPT="$(cat "${PROMPT_FILE}")" || return 1
+  PROMPT="$(cat "${PROMPT_FILE}")" || { FAIL_REASON="failed to read prompt file"; return 1; }
 
   # timeout の -k は「猶予後に SIGKILL」。GNU coreutils と busybox の双方で使える書式。
   # 上限に達した場合の終了コードは 124
@@ -218,6 +223,8 @@ main() {
     elapsed=$(($(date -u '+%s') - started_at))
     if [ "${rc}" -eq 124 ]; then
       log "iteration #${i} end exit=124 (timed out after ${ITERATION_TIMEOUT_SECONDS}s) elapsed=${elapsed}s"
+    elif [ "${rc}" -ne 0 ] && [ -n "${FAIL_REASON:-}" ]; then
+      log "iteration #${i} end exit=${rc} (${FAIL_REASON}) elapsed=${elapsed}s"
     else
       log "iteration #${i} end exit=${rc} elapsed=${elapsed}s"
     fi

--- a/apps/ops-health-reporter/report.py
+++ b/apps/ops-health-reporter/report.py
@@ -236,13 +236,14 @@ def collect_nodes():
 
 
 # loop.sh (apps/autopilot/loop.sh) の log() が書く心拍行だけを抜き出す正規表現。
-# ここにマッチした行から取り出した値（timestamp/iteration/exit_code/elapsed_seconds）
+# ここにマッチした行から取り出した値（timestamp/iteration/exit_code/elapsed_seconds/reason）
 # だけを report に載せる。生ログはこの関数の外に一切出さない — claude の出力を
 # git 管理のブランチにそのまま持ち出す経路を作らないため（T-0110）。
-# exit=124 (timeout) の行は "exit=124 (timed out after Ns) elapsed=Ns" と exit code の後に
-# 括弧書きが挟まるので、その部分を任意にして両方の形式を通す
+# exit code の後に "exit=124 (timed out after Ns) elapsed=Ns" のような括弧書きの理由が
+# 挟まることがある（タイムアウト、または repo 同期前段での早期return, T-0158）ので、
+# その部分を任意で捕捉する
 HEARTBEAT_RE = re.compile(
-    r"^\[autopilot\] (\S+) iteration #(\d+) (?:start|end exit=(-?\d+)(?: \([^)]*\))? elapsed=(\d+)s)"
+    r"^\[autopilot\] (\S+) iteration #(\d+) (?:start|end exit=(-?\d+)(?: \(([^)]*)\))? elapsed=(\d+)s)"
 )
 
 
@@ -253,7 +254,7 @@ def parse_heartbeat(raw_log):
         m = HEARTBEAT_RE.match(line.strip())
         if not m:
             continue
-        ts, iteration, exit_code, elapsed = m.groups()
+        ts, iteration, exit_code, reason, elapsed = m.groups()
         if exit_code is None:
             last_start = {"timestamp": ts, "iteration": int(iteration)}
         else:
@@ -263,6 +264,8 @@ def parse_heartbeat(raw_log):
                 "exit_code": int(exit_code),
                 "elapsed_seconds": int(elapsed),
             }
+            if reason:
+                last_end["reason"] = reason
     return {"last_start": last_start, "last_end": last_end}
 
 

--- a/ops/archive/backlog-done.json
+++ b/ops/archive/backlog-done.json
@@ -2637,8 +2637,8 @@
         "apps/ops-health-reporter/report.py"
       ],
       "created": "2026-08-06",
-      "pr": null,
-      "notes": "run #181（計画役）: ops/inbox.md（run #174 実行役の記録、autopilot/run-172-records ブランチ上で発見・処理。GitHub Actions major_outage で PR #376/#377 が blocked のため main にはまだ無い引き継ぎだった）から起票。緊急性なし（自己回復済み、データ破壊・誤動作は無い） | run #211（実行役）: iterate() の各早期return（clone/cd/fetch/checkout/reset/clean・PROMPT_FILE 読み込み失敗）に FAIL_REASON を設定し、main() のログ行を `exit=1 (git fetch failed)` のように理由付きで出力するよう loop.sh を変更。report.py の HEARTBEAT_RE/parse_heartbeat() を括弧内テキストを last_end.reason として捕捉するよう更新。実際に存在しない remote への git clone/fetch を走らせてログ行を確認し、4パターンの心拍行で parse_heartbeat() の捕捉を確認した。done にした"
+      "pr": 390,
+      "notes": "run #181（計画役）: ops/inbox.md（run #174 実行役の記録、autopilot/run-172-records ブランチ上で発見・処理。GitHub Actions major_outage で PR #376/#377 が blocked のため main にはまだ無い引き継ぎだった）から起票。緊急性なし（自己回復済み、データ破壊・誤動作は無い） | run #211（実行役）: iterate() の各早期return（clone/cd/fetch/checkout/reset/clean・PROMPT_FILE 読み込み失敗）に FAIL_REASON を設定し、main() のログ行を `exit=1 (git fetch failed)` のように理由付きで出力するよう loop.sh を変更。report.py の HEARTBEAT_RE/parse_heartbeat() を括弧内テキストを last_end.reason として捕捉するよう更新。実際に存在しない remote への git clone/fetch を走らせてログ行を確認し、4パターンの心拍行で parse_heartbeat() の捕捉を確認した。PR #390。done にした"
     },
     {
       "id": "T-0159",

--- a/ops/archive/backlog-done.json
+++ b/ops/archive/backlog-done.json
@@ -2622,6 +2622,25 @@
       "notes": "run #162（実行役）: CHARTER.md §6 手順5 の該当箇所を修正し PR で反映。"
     },
     {
+      "id": "T-0158",
+      "domain": "homelab",
+      "title": "loop.sh 起動直後の git fetch 失敗を『止まっている』と区別できるようにする",
+      "kind": "observability",
+      "risk": "low",
+      "status": "done",
+      "priority": 92,
+      "why": "run #174（実行役、ops/inbox.md 経由の引き継ぎ）の発見。2026-08-06 の GitHub Actions major_outage 中、`iterate()`（apps/autopilot/loop.sh）冒頭の `git fetch --prune --quiet origin || return 1` が約2時間（17:00〜19:00 UTC 頃、iteration 13→70 の57回連続）失敗し続け、ログには `[autopilot] <ts> iteration #N end exit=1 elapsed=5〜6s` としか残らなかった。ops-health-reporter（apps/ops-health-reporter/report.py の `HEARTBEAT_RE`）はこの行から `exit_code`/`elapsed_seconds` だけを抽出して report に載せる設計（生ログは意図的に外に出さない、T-0110）のため、`exit_code!=0` が『claude -p 自体の異常』なのか『repo 同期前段の早期return』なのかをダッシュボード側から区別できず、外形的には『止まっている』のと見分けがつかなかった。実際は git 操作自体は本イテレーションでは正常に動いており、loop.sh の自己回復設計（Pod を落とさず同じ間隔で回り続ける）どおり実害なく復帰した",
+      "dod": "iterate() の各早期return（clone/fetch/checkout/reset/clean のいずれかの失敗、PROMPT_FILE 読み込み失敗）の理由を、`HEARTBEAT_RE` が既にサポートしている exit code 後の任意の括弧書き（`exit=124 (timed out after Ns) elapsed=Ns` と同型、現状は非捕捉群で読み捨てられている）に乗せて `iteration #N end exit=1 (git fetch failed) elapsed=Ns` のように出力する。あわせて report.py の `HEARTBEAT_RE`/`parse_heartbeat()` がこの括弧内テキストを捕捉し `last_end.reason` 相当のフィールドとして report に含めるようにする（生ログを外に出さない既存方針は維持し、載せるのはこの定型の理由文字列のみに限る）。ダッシュボード側の表示変更は必須ではない（report.py が値を持てば十分）。意図的に git fetch を失敗させて（例: 存在しない remote へ一時的に切り替える等、手元検証の範囲で）ログ行とパース結果を確認する",
+      "blocked_by": null,
+      "refs": [
+        "apps/autopilot/loop.sh",
+        "apps/ops-health-reporter/report.py"
+      ],
+      "created": "2026-08-06",
+      "pr": null,
+      "notes": "run #181（計画役）: ops/inbox.md（run #174 実行役の記録、autopilot/run-172-records ブランチ上で発見・処理。GitHub Actions major_outage で PR #376/#377 が blocked のため main にはまだ無い引き継ぎだった）から起票。緊急性なし（自己回復済み、データ破壊・誤動作は無い） | run #211（実行役）: iterate() の各早期return（clone/cd/fetch/checkout/reset/clean・PROMPT_FILE 読み込み失敗）に FAIL_REASON を設定し、main() のログ行を `exit=1 (git fetch failed)` のように理由付きで出力するよう loop.sh を変更。report.py の HEARTBEAT_RE/parse_heartbeat() を括弧内テキストを last_end.reason として捕捉するよう更新。実際に存在しない remote への git clone/fetch を走らせてログ行を確認し、4パターンの心拍行で parse_heartbeat() の捕捉を確認した。done にした"
+    },
+    {
       "id": "T-0159",
       "domain": "homelab",
       "title": "issue #56 へのフィードバック取り込みが autopilot 自身の投稿コメントをループバックしてしまう",

--- a/ops/archive/runs.json
+++ b/ops/archive/runs.json
@@ -1668,6 +1668,14 @@
       "by": "autopilot pod (実行役)",
       "summary": "実行役（journal run #190）。PR #377 は close・ブランチ削除済みを確認、残る中断は PR #376 のみ。GitHub Actions incident（qcvjkzcs7j74）は run #189 が見た 21:30:42Z 版から変化なし、actions/runs?head_sha= も total_count:0 のままのためリトライ見送り。feedback/健全性とも新規変化なし、T-0117/T-0158/T-0159〜T-0162 とも直列化ルールに従い今回も着手せず。",
       "prs": []
+    },
+    {
+      "n": 191,
+      "at": "2026-08-06T21:46:00Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (実行役)",
+      "summary": "実行役（journal run #191）。残る中断は PR #376 のみ。GitHub Actions incident（qcvjkzcs7j74）は21:30 UTC更新版から変化なし（investigating継続）のためリトライ見送り。feedback/健全性とも新規変化なし。run #172以降このPRの状態確認だけで約20回ほぼ同一内容を記録し続けている点に気づき、backoff の仕組みが無いことをops/inbox.mdに追記（計画役へ）。T-0117/T-0158/T-0159〜T-0162 とも直列化ルールに従い今回も着手せず。",
+      "prs": []
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -523,25 +523,6 @@
       }
     },
     {
-      "id": "T-0158",
-      "domain": "homelab",
-      "title": "loop.sh 起動直後の git fetch 失敗を『止まっている』と区別できるようにする",
-      "kind": "observability",
-      "risk": "low",
-      "status": "todo",
-      "priority": 92,
-      "why": "run #174（実行役、ops/inbox.md 経由の引き継ぎ）の発見。2026-08-06 の GitHub Actions major_outage 中、`iterate()`（apps/autopilot/loop.sh）冒頭の `git fetch --prune --quiet origin || return 1` が約2時間（17:00〜19:00 UTC 頃、iteration 13→70 の57回連続）失敗し続け、ログには `[autopilot] <ts> iteration #N end exit=1 elapsed=5〜6s` としか残らなかった。ops-health-reporter（apps/ops-health-reporter/report.py の `HEARTBEAT_RE`）はこの行から `exit_code`/`elapsed_seconds` だけを抽出して report に載せる設計（生ログは意図的に外に出さない、T-0110）のため、`exit_code!=0` が『claude -p 自体の異常』なのか『repo 同期前段の早期return』なのかをダッシュボード側から区別できず、外形的には『止まっている』のと見分けがつかなかった。実際は git 操作自体は本イテレーションでは正常に動いており、loop.sh の自己回復設計（Pod を落とさず同じ間隔で回り続ける）どおり実害なく復帰した",
-      "dod": "iterate() の各早期return（clone/fetch/checkout/reset/clean のいずれかの失敗、PROMPT_FILE 読み込み失敗）の理由を、`HEARTBEAT_RE` が既にサポートしている exit code 後の任意の括弧書き（`exit=124 (timed out after Ns) elapsed=Ns` と同型、現状は非捕捉群で読み捨てられている）に乗せて `iteration #N end exit=1 (git fetch failed) elapsed=Ns` のように出力する。あわせて report.py の `HEARTBEAT_RE`/`parse_heartbeat()` がこの括弧内テキストを捕捉し `last_end.reason` 相当のフィールドとして report に含めるようにする（生ログを外に出さない既存方針は維持し、載せるのはこの定型の理由文字列のみに限る）。ダッシュボード側の表示変更は必須ではない（report.py が値を持てば十分）。意図的に git fetch を失敗させて（例: 存在しない remote へ一時的に切り替える等、手元検証の範囲で）ログ行とパース結果を確認する",
-      "blocked_by": null,
-      "refs": [
-        "apps/autopilot/loop.sh",
-        "apps/ops-health-reporter/report.py"
-      ],
-      "created": "2026-08-06",
-      "pr": null,
-      "notes": "run #181（計画役）: ops/inbox.md（run #174 実行役の記録、autopilot/run-172-records ブランチ上で発見・処理。GitHub Actions major_outage で PR #376/#377 が blocked のため main にはまだ無い引き継ぎだった）から起票。緊急性なし（自己回復済み、データ破壊・誤動作は無い）"
-    },
-    {
       "id": "T-0163",
       "domain": "homelab",
       "title": "既知の外部障害でリトライ不能と判明した後、確認間隔を伸ばす backoff の仕組みを作る",

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -1,5 +1,35 @@
 {
-  "open": [],
+  "open": [
+    {
+      "number": 390,
+      "title": "feat(autopilot): loop.sh の起動失敗理由を心拍ログに載せる (T-0158)",
+      "url": "https://github.com/hikuohiku/homelab/pull/390",
+      "isDraft": false,
+      "createdAt": "2026-08-07T01:10:56Z",
+      "statusCheckRollup": [
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        },
+        {
+          "conclusion": "SUCCESS"
+        }
+      ],
+      "headRefName": "autopilot/T-0158-loop-fail-reason",
+      "autoMergeRequest": null
+    }
+  ],
   "merged": [
     {
       "number": 389,

--- a/ops/dashboard/prs.json
+++ b/ops/dashboard/prs.json
@@ -2,6 +2,20 @@
   "open": [],
   "merged": [
     {
+      "number": 389,
+      "title": "chore(ops): T-0162 マージ後の帳簿圧縮 (ops/ledger.py)",
+      "url": "https://github.com/hikuohiku/homelab/pull/389",
+      "mergedAt": "2026-08-07T01:02:24Z",
+      "headRefName": "autopilot/T-0162-ledger-followup"
+    },
+    {
+      "number": 388,
+      "title": "feat(dashboard): coder/immich/vaultwarden の Degraded に T-0106 既知事象の注記を追加 (T-0162)",
+      "url": "https://github.com/hikuohiku/homelab/pull/388",
+      "mergedAt": "2026-08-07T01:00:48Z",
+      "headRefName": "autopilot/T-0162-dashboard-t0106-note"
+    },
+    {
       "number": 387,
       "title": "chore(ops): T-0165 マージ後の帳簿圧縮 (ops/ledger.py)",
       "url": "https://github.com/hikuohiku/homelab/pull/387",
@@ -406,20 +420,6 @@
       "url": "https://github.com/hikuohiku/homelab/pull/327",
       "mergedAt": "2026-08-06T09:01:18Z",
       "headRefName": "autopilot/run136-planning-record"
-    },
-    {
-      "number": 326,
-      "title": "docs(ops): run #135 の journal 記録（PR #325 merge、他は blocked/needs-human）",
-      "url": "https://github.com/hikuohiku/homelab/pull/326",
-      "mergedAt": "2026-08-06T08:51:32Z",
-      "headRefName": "autopilot/run135-record-only"
-    },
-    {
-      "number": 325,
-      "title": "T-0137: syncthing の k8s 移行可否検討（実現可能と結論）",
-      "url": "https://github.com/hikuohiku/homelab/pull/325",
-      "mergedAt": "2026-08-06T08:45:11Z",
-      "headRefName": "autopilot/T-0137-syncthing-k8s-feasibility"
     }
   ]
 }

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -6097,3 +6097,32 @@ GitHub Actions incident で blocked のまま run #172〜#193 を独立に積み
 - 見つけたこと: なし
 - 次の起動へ: この回の PR の CI green を確認して merge。todo 残りは `T-0158`（priority 92）と、
   分割待ちの `T-0163`/`T-0164`
+
+## 2026-08-07 10:08 JST — run #211
+
+- 取り込んだフィードバック: なし。`ops-feedback` ブランチ引き続き不在。issue #56 を
+  `per_page=100` で全2ページ（114件）確認し、`feedback.json` の最新エントリより新しい
+  非自己投稿コメントは無し（直近の新着は autopilot 自身が投稿した T-0116 の確認依頼で、
+  `<!-- autopilot:self-posted -->` マーカーにより取り込み対象外）
+- 前回の中断: なし。オープン PR 0件、`autopilot/*` の残りブランチ 0件
+- 健全性: 直接の再確認はせず run #210 までの確認（既知事象 T-0106 のみ、異常なし）を踏襲
+- やったこと: todo 先頭 `T-0158`（priority 92、loop.sh 起動直後の git fetch 失敗を『止まっている』
+  と区別できるようにする）に着手。`apps/autopilot/loop.sh` の `iterate()` 内の各早期return
+  （clone/cd/fetch/checkout/reset/clean・PROMPT_FILE 読み込み失敗）に `FAIL_REASON` を設定し、
+  `main()` のログ行を `iteration #N end exit=1 (git fetch failed) elapsed=Ns` のように
+  括弧書きの理由付きで出力するよう変更。`apps/ops-health-reporter/report.py` の
+  `HEARTBEAT_RE`/`parse_heartbeat()` を、この括弧内テキストを捕捉し `last_end.reason` に
+  含めるよう更新（生ログを外に出さない既存方針は維持、載せるのは定型の理由文字列のみ）。
+  検証: `bash -n` で構文確認、実際に存在しない remote へ `git clone`/`git fetch` を向けて
+  `iterate()` 相当のロジックを走らせ `FAIL_REASON="git clone failed"` からログ行が
+  `... end exit=1 (git clone failed) elapsed=3s` になることを実機コマンドで確認。
+  `parse_heartbeat()` に `exit=1 (git fetch failed)`/`exit=124 (timed out after 3600s)`/
+  `exit=0`/`start` の4パターンを与え、reason の捕捉・非捕捉が期待どおりであることを確認。
+  `python3 ops/validate.py` → 0 error, 0 warning。T-0158 を done にした
+- 見つけたこと: なし
+- `python3 ops/ledger.py` を実行（T-0158 を archive へ移動）
+- 次の起動へ: この回の PR の CI green を確認して merge。merge 後、次の起動は kubectl で
+  autopilot Pod が正常に動き続けていること（ConfigMap 更新後の `reexec_if_updated` 経由の
+  自己反映）と、次に実際に git fetch 等が失敗した際に `ops-health-report` の
+  `autopilot.heartbeat.last_end.reason` が載ることを確認するとなお良い。todo 残りは
+  分割待ちの `T-0163`/`T-0164` のみ

--- a/ops/state.json
+++ b/ops/state.json
@@ -205,7 +205,9 @@
       "kind": "in-cluster-loop",
       "by": "autopilot pod (実行役)",
       "summary": "実行役（journal run #211）。前回中断なし、フィードバック新規なし、健全性は既知事象(T-0106)のみで異常なし。T-0158（loop.sh起動直後のgit fetch失敗を『止まっている』と区別できるようにする）に着手。iterate()の各早期returnにFAIL_REASONを設定しmain()のログ行に理由を載せ、ops-health-reporter/report.pyのHEARTBEAT_RE/parse_heartbeat()でlast_end.reasonとして捕捉するよう更新。実際にgit clone/fetchを失敗させてログ行とパース結果を確認しdoneにした。",
-      "prs": []
+      "prs": [
+        390
+      ]
     }
   ]
 }

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-07T00:57:24Z",
+  "updated": "2026-08-07T01:08:54Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
@@ -34,14 +34,6 @@
     "since": "2026-08-05"
   },
   "runs": [
-    {
-      "n": 191,
-      "at": "2026-08-06T21:46:00Z",
-      "kind": "in_cluster_loop",
-      "by": "autopilot pod (実行役)",
-      "summary": "実行役（journal run #191）。残る中断は PR #376 のみ。GitHub Actions incident（qcvjkzcs7j74）は21:30 UTC更新版から変化なし（investigating継続）のためリトライ見送り。feedback/健全性とも新規変化なし。run #172以降このPRの状態確認だけで約20回ほぼ同一内容を記録し続けている点に気づき、backoff の仕組みが無いことをops/inbox.mdに追記（計画役へ）。T-0117/T-0158/T-0159〜T-0162 とも直列化ルールに従い今回も着手せず。",
-      "prs": []
-    },
     {
       "n": 192,
       "at": "2026-08-06T21:56:00Z",
@@ -205,6 +197,14 @@
       "kind": "in-cluster-loop",
       "by": "autopilot pod (実行役)",
       "summary": "実行役（journal run #210）。前回中断なし（PR #386/#387 とも merge済み）、フィードバック新規なし、健全性は既知事象(T-0106)のみで異常なし。T-0163/T-0164は分割待ちのため見送り、T-0162（priority 55、レビュー役R-003、ダッシュボードのDegradedにT-0106既知事象の注記）に着手。ops/dashboard/build.py の render_pulse() に静的注記を追加、3パターンをローカル検証しdoneにした。",
+      "prs": []
+    },
+    {
+      "n": 211,
+      "at": "2026-08-07T01:08:54Z",
+      "kind": "in-cluster-loop",
+      "by": "autopilot pod (実行役)",
+      "summary": "実行役（journal run #211）。前回中断なし、フィードバック新規なし、健全性は既知事象(T-0106)のみで異常なし。T-0158（loop.sh起動直後のgit fetch失敗を『止まっている』と区別できるようにする）に着手。iterate()の各早期returnにFAIL_REASONを設定しmain()のログ行に理由を載せ、ops-health-reporter/report.pyのHEARTBEAT_RE/parse_heartbeat()でlast_end.reasonとして捕捉するよう更新。実際にgit clone/fetchを失敗させてログ行とパース結果を確認しdoneにした。",
       "prs": []
     }
   ]


### PR DESCRIPTION
## 変更点

`apps/autopilot/loop.sh` の `iterate()` が git clone/fetch/checkout/reset/clean や
PROMPT_FILE 読み込みの失敗で早期returnするとき、これまでは心拍ログが
`iteration #N end exit=1 elapsed=Ns` としか出ず、claude 自体の異常（応答なし等）と
repo 同期前段での早期returnが `ops-health-report` の `autopilot.heartbeat.last_end` から
区別できませんでした。2026-08-06 の GitHub Actions 大規模障害中、`git fetch` が
約2時間・57回連続で失敗し続けた際にこれが原因で「止まっている」のと外形上見分けが
つかなくなっていました（T-0158、実害は無し・自己回復済み）。

- `loop.sh`: 各早期returnで `FAIL_REASON` に理由（例: `git fetch failed`）を設定し、
  ログ行を `iteration #N end exit=1 (git fetch failed) elapsed=Ns` のように出力
- `apps/ops-health-reporter/report.py`: `HEARTBEAT_RE`/`parse_heartbeat()` を、この
  括弧内テキストを捕捉し `last_end.reason` として report に含めるよう更新（生ログを
  外に出さない既存方針は維持。載せるのは定型の理由文字列のみ）
- `ops/backlog.json` / `ops/journal/2026-08.md` / `ops/state.json`: T-0158 を `done` に
  し記録を追記。あわせて `ops/ledger.py` で done/dropped と古い起動記録を archive へ圧縮

## 検証したこと

- `bash -n apps/autopilot/loop.sh` で構文確認
- 存在しない remote への `git clone`/`git fetch` を実際に走らせ、`iterate()` 相当の
  ロジックが `FAIL_REASON="git clone failed"` を設定し、ログ行が
  `... end exit=1 (git clone failed) elapsed=3s` になることを確認
- `parse_heartbeat()` に `exit=1 (git fetch failed)` / `exit=124 (timed out after 3600s)` /
  `exit=0`（理由なし） / `start` の4パターンを与え、`reason` の捕捉・非捕捉が期待どおり
  であることを確認
- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/dashboard/build.py` → 例外なく完了、`ops-dashboard` ブランチへ publish 済み

## ロールバック手順

このコミットを revert して push すれば、`loop.sh` を格納する ConfigMap
（`disableNameSuffixHash: true`）の内容が旧バージョンに戻ります。稼働中の autopilot
Pod は `reexec_if_updated`（各イテレーション開始前に自分の digest を見る）が
digest の変化を検知し、Pod を作り直さずに次のイテレーション開始時点で自動的に
旧バージョンで exec し直します。手動での Pod 再起動は不要です。`report.py` 側は
`reason` フィールドが単に付かなくなるだけで、他のフィールド（exit_code/elapsed_seconds等）
の解釈には影響しません。

## 観測・操作経路への影響

この変更は autopilot 自身の実行ループ（`loop.sh`）本体に対する変更です。ロジック自体
（コマンドの実行順序・exit code の意味）は変えておらず、ログ出力の追加と
`FAIL_REASON=""` の初期化のみを加えています。万一 push した内容に構文エラー等の
不具合があった場合、次回の `reexec_if_updated` で `exec bash "${SELF}"` が失敗し
コンテナプロセスごと落ちて CrashLoopBackOff になりえます（`bash -n` による構文確認は
実施済み）。その場合は `autopilot.heartbeat` が更新されなくなるため、次回このリポジトリを
見る主体（次のクラウド routine 起動、または人間）が `ops-health-report` の
`autopilot.deployment.readyReplicas` / `heartbeat.last_end` の停止で気づけます。

## backlog task id

T-0158
