### PR TITLE
feat(autopilot): origin/main が連続で動かないとき loop 間隔を backoff させる (T-0163)

### DIFF
--- a/apps/autopilot/loop.sh
+++ b/apps/autopilot/loop.sh
@@ -44,6 +44,13 @@ INTERVAL_SECONDS="${INTERVAL_SECONDS:-120}"
 # 1 イテレーションの上限。エージェントが 1 周を終えられずに居座ると、
 # 次の周回が永久に来ない（= 止まったのと同じ）。上限で必ず切って次へ行く
 ITERATION_TIMEOUT_SECONDS="${ITERATION_TIMEOUT_SECONDS:-3600}"
+# origin/main の commit が何周連続で動かなかったら backoff を始めるか（T-0163 DoD(2)）。
+# GitHub 側の障害等で PR が一切 land しない間、INTERVAL_SECONDS のまま回り続けると
+# ほぼ同一内容の journal/state.json エントリを量産する（run #172〜#193 の実例）。
+# main が動いた回はいつでも即座に通常間隔へ戻す
+NOOP_BACKOFF_THRESHOLD="${NOOP_BACKOFF_THRESHOLD:-3}"
+# backoff で伸ばす間隔の上限。unbounded にはしない（VISION「ループが止まる選択をしない」）
+NOOP_BACKOFF_MAX_SECONDS="${NOOP_BACKOFF_MAX_SECONDS:-1800}"
 
 # 心拍。イテレーションの開始/終了を stdout に出しておくと、`kubectl logs` だけで
 # 「いま何周目の何をしているか」が外から分かる（旧クラウド cron に無かったもの）
@@ -92,6 +99,10 @@ setup_git() {
 # exit_code のみ）から区別できず、外から『止まっている』のと見分けがつかなかったため
 iterate() {
   FAIL_REASON=""
+  # このイテレーション開始時点の origin/main。main() が前回の値と比べて
+  # consecutive no-op を数える（backoff, T-0163 DoD(2)）。fetch に失敗したら
+  # 空のままにし、main() 側で「変化なし」と同じ扱いにする
+  CURRENT_MAIN_SHA=""
 
   if [ ! -d "${REPO_DIR}/.git" ]; then
     log "cloning ${REPO_URL} into ${REPO_DIR}"
@@ -104,6 +115,7 @@ iterate() {
   # 中断の引き継ぎは origin 側（オープン PR と autopilot/* ブランチ）から拾う設計
   # なので、ローカルに残す意味が無い（CHARTER §2）
   git fetch --prune --quiet origin || { FAIL_REASON="git fetch failed"; return 1; }
+  CURRENT_MAIN_SHA="$(git rev-parse origin/main 2>/dev/null || true)"
   git checkout --quiet -B main origin/main || { FAIL_REASON="git checkout failed"; return 1; }
   git reset --hard --quiet origin/main || { FAIL_REASON="git reset failed"; return 1; }
   git clean -fdq || { FAIL_REASON="git clean failed"; return 1; }
@@ -210,6 +222,8 @@ main() {
   log "started (interval=${INTERVAL_SECONDS}s timeout=${ITERATION_TIMEOUT_SECONDS}s repo=${REPO_URL})"
 
   i=0
+  noop_count=0
+  prev_main_sha=""
   while true; do
     # イテレーションの途中では入れ替えない
     reexec_if_updated
@@ -229,12 +243,37 @@ main() {
       log "iteration #${i} end exit=${rc} elapsed=${elapsed}s"
     fi
 
+    # origin/main が前回のイテレーション開始時から動いていなければ no-op を数える
+    # （fetch 自体が失敗した = CURRENT_MAIN_SHA が空、も「動いていない」と同列に扱う。
+    # 空文字 = prev_main_sha は成り立たないので、空のときも no-op 側に倒す判定を明示する）。
+    # 動いた（新しい SHA を取得できた）ときだけ通常間隔に戻す（T-0163 DoD(2)）
+    if [ -n "${prev_main_sha}" ] && { [ -z "${CURRENT_MAIN_SHA:-}" ] || [ "${CURRENT_MAIN_SHA}" = "${prev_main_sha}" ]; }; then
+      noop_count=$((noop_count + 1))
+    else
+      noop_count=0
+    fi
+    if [ -n "${CURRENT_MAIN_SHA:-}" ]; then
+      prev_main_sha="${CURRENT_MAIN_SHA}"
+    fi
+
+    sleep_seconds="${INTERVAL_SECONDS}"
+    if [ "${noop_count}" -ge "${NOOP_BACKOFF_THRESHOLD}" ]; then
+      extra=$((noop_count - NOOP_BACKOFF_THRESHOLD + 1))
+      # 2^extra は noop_count が伸び続けると桁あふれしうるので、上限に張り付く前で頭打ちにする
+      [ "${extra}" -gt 10 ] && extra=10
+      sleep_seconds=$((INTERVAL_SECONDS * (2 ** extra)))
+      if [ "${sleep_seconds}" -gt "${NOOP_BACKOFF_MAX_SECONDS}" ]; then
+        sleep_seconds="${NOOP_BACKOFF_MAX_SECONDS}"
+      fi
+      log "backoff: origin/main unchanged for ${noop_count} consecutive iterations, next interval=${sleep_seconds}s"
+    fi
+
     # 失敗しても Pod は落とさない。CrashLoopBackOff で再起動間隔が伸びていくより、
     # 同じ間隔で回り続けて次の周回に賭ける方がループが止まらない（VISION）
     # sleep をバックグラウンドにして wait で待つ。前面で sleep すると sh は
     # それが終わるまで trap を実行しないため、待機中の SIGTERM に反応できず
     # terminationGracePeriodSeconds を待たずに SIGKILL される
-    sleep "${INTERVAL_SECONDS}" &
+    sleep "${sleep_seconds}" &
     wait $!
   done
 }


### PR DESCRIPTION
## 変更点

`apps/autopilot/loop.sh` に、`origin/main` の commit が連続で動かない（＝自分の PR が
land し続けない）ときに 1 イテレーションの間隔（`INTERVAL_SECONDS`, 既定120秒）を段階的に
伸ばす backoff を追加した。

- `origin/main` の SHA（`git fetch` 直後に取得。fetch 自体の失敗も「動いていない」と同列）が
  `NOOP_BACKOFF_THRESHOLD`（既定3）回連続で前回と同じなら、次の sleep を `INTERVAL_SECONDS * 2^n`
  に伸ばす（`NOOP_BACKOFF_MAX_SECONDS`、既定1800秒＝30分で頭打ち。unbounded にはしない）
- `origin/main` が動いた回は即座に通常間隔（120秒）へ戻す
- 役の割り当て（`PLAN_EVERY`/`REVIEW_EVERY` の周期）はイテレーション回数 `i` ベースのままで、
  backoff は sleep 時間だけに効く

## 背景

GitHub Actions の大規模障害で PR が一切 land しなかった期間（run #172〜#193、6時間以上・約20回）、
120秒間隔のままほぼ同一内容の journal/state.json エントリを量産し続けた（T-0163）。この PR は
DoD(2)（backoff 機構本体）。DoD(1)（同一の既知ブロッカーの journal 記述を簡潔にするルール）は
既に #391 で対応済み。

## 検証したこと

- `bash -n apps/autopilot/loop.sh` で構文確認
- `iterate()`/`main()` の no-op 判定・backoff 計算部分を実際に bash で切り出して実行し、
  以下のシナリオで期待どおりの `sleep_seconds` になることを確認:
  - 毎回 `origin/main` が動く通常運転 → 常に120秒
  - 3回連続で動かない → 4回目から backoff 開始、7回目以降は上限1800秒に到達
  - `git fetch` 失敗（SHA が空）が続く場合も同様に backoff → fetch が復旧しても
    merge がまだ来ていなければ backoff 継続、実際に merge が来た回に即座に120秒へ復帰
- in-cluster kubectl（read-only）で変更前の baseline を確認: `autopilot` Deployment は
  `1/1 Running`、restarts 0、`Available` 条件 True

これは autopilot 自身の生存に関わるコア機構（`loop.sh`）の変更のため、CI green と上記の
オフライン検証だけでは「実際の Pod で問題なく動き続けるか」までは確認できていない。
CHARTER §4「縛る変更には実測か裏付けが要る」に倣い、**この PR はこの起動では merge しない**
（cooldown）。次の起動が CI green を確認して merge し、ConfigMap 反映後の `reexec_if_updated`
経由で新しい `loop.sh` に入れ替わったあと、以降の起動で in-cluster kubectl により
Pod が `Running`/`restarts` 増加なしで回り続けていること・`ops-health-report` の
`autopilot.heartbeat` が exit_code 0 で継続していることを確認してから T-0163 を `done` にする
（backlog の記録更新は別 PR に分ける。cooldown 中の PR に記録を相乗りさせないルールのため）。

## ロールバック手順

この commit を revert すれば `loop.sh` は元の固定間隔（`INTERVAL_SECONDS` 常に一定）に戻る。
スキーマ・永続データは関与しないシェルスクリプトのみの変更なので、revert すれば完全に元の
挙動に戻る（データ不整合の心配なし）。

## backlog task id

T-0163
