### PR TITLE
chore(ops): T-0163 の記録更新（PR #392, cooldown中）

### DIFF
--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "next_id": 166,
-  "updated": "2026-08-07T00:57:24Z",
+  "updated": "2026-08-07T01:33:40Z",
   "_comment": "status: todo | in_progress | blocked | needs-human | done | dropped. risk は ops/CHARTER.md §4 の区分。priority 昇順で着手する。domain は VISION.md のドメイン区分（現状は homelab のみ）。recurring なタスクは実施後 status: done にしつつ last_done/next_review を付け、next_review を過ぎたら手動で status: todo に戻す（自動再オープンの仕組みはまだ無い、T-0012 run #10 参照）。human_action は needs-human タスクに付ける任意フィールド（summary / why / steps[] / links[]）。steps は人間がそのまま実行できる粒度で書き、HTML を含めてよい",
   "tasks": [
     {
@@ -538,8 +538,8 @@
         "ops/CHARTER.md"
       ],
       "created": "2026-08-06",
-      "pr": 391,
-      "notes": "run #172-193統合時の計画役（journal run #173相当の統合作業）が起票。inbox（R-NNN無し、実行役の気づき）より。run #209〜#211（実行役）は(1)(2)が1タスクに同居し1 PR 1論点に沿わないとして着手を見送り、inboxに分割提案を記録した。run #212（実行役）でDoD(1)（CHARTER §7へのルール追加）のみ実施（#391）。DoD(2)（loop.shへのbackoff機構）は残作業のためstatusをin_progressのまま維持し、taskは分割しない — DoD(1)を切り離したことで残るDoD(2)自体が単一論点になり、分割提案の前提が解消したため"
+      "pr": 392,
+      "notes": "run #172-193統合時の計画役（journal run #173相当の統合作業）が起票。inbox（R-NNN無し、実行役の気づき）より。run #209〜#211（実行役）は(1)(2)が1タスクに同居し1 PR 1論点に沿わないとして着手を見送り、inboxに分割提案を記録した。run #212（実行役）でDoD(1)（CHARTER §7へのルール追加）のみ実施（#391）。DoD(2)（loop.shへのbackoff機構）は残作業のためstatusをin_progressのまま維持し、taskは分割しない — DoD(1)を切り離したことで残るDoD(2)自体が単一論点になり、分割提案の前提が解消したため。run #213（実行役）で DoD(2)（loop.sh の backoff 機構）を実装し PR #392 を作成した。origin/main の commit が NOOP_BACKOFF_THRESHOLD（既定3）回連続で動かなければ次の sleep を 2^n 倍（既定上限1800秒）に伸ばし、main が動いた回は即座に通常間隔へ戻す。autopilot 自身の生存に関わるコア機構の変更のため、CHARTER §4「縛る変更には実測か裏付けが要る」に倣いこの回では merge しない（cooldown。T-0158/#390 と同じ扱い）。次の起動が PR #392 を CI green 確認のうえmerge し、ConfigMap 反映後の in-cluster kubectl で Pod が Running / restarts 増加なしで回り続けていること、ops-health-report の autopilot.heartbeat が exit_code 0 で継続していることを確認してから done にする"
     },
     {
       "id": "T-0164",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -6152,3 +6152,31 @@ GitHub Actions incident で blocked のまま run #172〜#193 を独立に積み
 - `python3 ops/validate.py` → 0 error, 0 warning
 - 次の起動へ: この回の PR の CI green を確認して merge。todo 残りは分割待ちの `T-0164` のみ。
   `T-0163` は `in_progress`（DoD(2): `loop.sh` の backoff 機構）として次に着手できる
+
+## 2026-08-07 10:33 JST — run #213
+
+- 取り込んだフィードバック: なし。`ops-feedback` ブランチ引き続き不在。issue #56 を
+  `per_page=100` で全2ページ（114件）確認し、`feedback.json` の最新エントリより新しい
+  非自己投稿コメントは無し（新着1件は autopilot 自身が投稿した T-0116 の PBS backup ジョブ
+  確認依頼で、`<!-- autopilot:self-posted -->` マーカーにより取り込み対象外）
+- 前回の中断: なし。オープン PR 0件、`autopilot/*` の残りブランチ 0件（PR #391 は merge 済み）
+- 健全性: `ops-health-report`（generated_at 2026-08-07T01:00:04Z、新鮮）を確認。`coder`/
+  `immich`/`vaultwarden` の `Degraded` は既知事象 T-0106 由来（`SecretSyncedError` のみ）で
+  新規異常なし。`pod_issues` の restartCount 19 系は 2026-08-03 の古い terminated イベントで
+  変化なし。autopilot 自身の heartbeat は iteration #7 まで exit_code 0 で正常
+- やったこと: `T-0163`（in_progress）の DoD(2)（`loop.sh` の backoff 機構）に着手。
+  `origin/main` の commit が `NOOP_BACKOFF_THRESHOLD`（既定3）回連続で動かなければ
+  （`git fetch` 失敗も同列）、次の sleep を `INTERVAL_SECONDS * 2^n` に伸ばし
+  （`NOOP_BACKOFF_MAX_SECONDS`、既定1800秒で頭打ち）、動いた回は即座に通常間隔へ戻す
+  ロジックを追加。`bash -n` で構文確認、`iterate()`/`main()` の該当ロジックを bash で
+  切り出して「毎回動く」「3回連続停止後 backoff」「fetch 失敗が続く」「fetch 復旧後も
+  merge が来ない」「merge が来て即復帰」の5パターンで期待どおりの `sleep_seconds` を確認。
+  変更前の baseline として in-cluster kubectl（read-only）で `autopilot` Deployment が
+  `1/1 Running`・restarts 0 であることを確認済み。autopilot 自身の生存に関わるコア機構の
+  変更のため、CHARTER §4「縛る変更には実測か裏付けが要る」に倣い PR #392 はこの回では
+  merge しない（cooldown、T-0158/#390 と同じ扱い）
+- 見つけたこと: なし
+- 次の起動へ: PR #392 の CI green を確認して merge。merge 後、ConfigMap 反映を待って
+  in-cluster kubectl で `autopilot` Pod が `Running`／restarts 増加なしで回り続けていること、
+  `ops-health-report` の `autopilot.heartbeat` が exit_code 0 で継続していることを確認してから
+  `T-0163` を `done` にする（このタスク自体の記録は今回この PR に含める。`T-0164` は分割待ちのまま）

--- a/ops/state.json
+++ b/ops/state.json
@@ -216,6 +216,16 @@
       "by": "autopilot pod (実行役)",
       "summary": "実行役（journal run #212）。前回中断なし、フィードバック新規なし、健全性は既知事象(T-0106)のみで異常なし。todoのT-0163はrun #209〜#211で3回連続見送られており、同じ見送りを繰り返すこと自体がT-0163の問題意識と同型と判断し、DoD(1)（既知ブロッカーの重複確認を簡潔な記録に留めるCHARTERルール追加）のみ切り出して実施。CHARTER §7にルールを追加し、T-0163はDoD(2)（loop.shのbackoff機構）を残してin_progressに変更した。",
       "prs": []
+    },
+    {
+      "n": 213,
+      "at": "2026-08-07T01:33:40Z",
+      "kind": "in-cluster-loop",
+      "by": "autopilot pod (実行役)",
+      "summary": "実行役（journal run #213）。前回中断なし、フィードバック新規なし、健全性は既知事象(T-0106)のみで異常なし。T-0163（in_progress）のDoD(2)（loop.shのbackoff機構）に着手。origin/mainがNOOP_BACKOFF_THRESHOLD回連続で動かなければsleepを2^n倍（上限あり）に伸ばし、動けば即復帰するロジックを追加。オフラインでロジック検証・kubectlでbaseline確認済み。autopilot自身のコア機構の変更のためPR #392はcooldown対象としてこの回ではmergeしない。",
+      "prs": [
+        392
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`ops/` の運用記録のみ（journal・state.json の run #213 追記、`T-0163` backlog エントリの
`pr` フィールド更新と notes 追記）。コード変更は含まない。

`T-0163` の DoD(2)（`loop.sh` の backoff 機構）は別 PR #392 で実装済みだが、autopilot 自身の
生存に関わるコア機構の変更のため CHARTER §4 に倣い cooldown 中（この起動では merge しない）。
CHARTER の「cooldown 中の PR には運用記録を相乗りさせない」ルールに従い、記録だけを
この即マージ可能な PR に分けている。

## 検証したこと

- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/check_feedback.py` → 0 error, 0 warning（今回フィードバック変更は無いが、
  `ops` job の一部として確認）

## ロールバック手順

`ops/` の記録ファイルのみの変更。revert すれば journal/state.json/backlog.json の該当箇所が
そのまま元に戻る。実インフラ・スキーマへの影響なし。

## backlog task id

T-0163（記録のみ。タスク本体は PR #392 の merge 後に done にする）
