### PR TITLE
chore(ops): T-0163 を実機確認のうえ done にする (T-0163)

### DIFF
--- a/ops/archive/backlog-done.json
+++ b/ops/archive/backlog-done.json
@@ -2719,6 +2719,25 @@
       "notes": "run #187（計画役）: ops/review-log.md R-003 を起票。R-003 の状態を『起票済 T-0162』に更新した。 | run #210（実行役）: 健全性レポートが externalsecret 詳細を持たず機械判定できないため、DoD のフォールバック方針どおり静的な注記にした。bad apps が {coder, immich, vaultwarden} の既知集合に収まる場合と一部混在する場合の両方をローカルで検証（後者は既知分のみ注記し他は『要確認』と表示）。done。"
     },
     {
+      "id": "T-0163",
+      "domain": "homelab",
+      "title": "既知の外部障害でリトライ不能と判明した後、確認間隔を伸ばす backoff の仕組みを作る",
+      "kind": "feature",
+      "risk": "medium",
+      "status": "done",
+      "priority": 50,
+      "why": "実行役の気づき（ops/inbox.md、R-NNN無し）。GitHub Actions の大規模障害（incident qcvjkzcs7j74、2026-08-06 15:22 UTC〜、22:00 UTC 時点も investigating 継続）でPR #376がblockedのあいだ、INTERVAL_SECONDS（120秒）ループが毎回incident statusを確認するだけの起動を繰り返し、run #172〜#193（6時間以上・約20回）でほぼ同一内容のjournal/state.jsonエントリを量産した。CHARTER §7「帳簿には上限がある」が指摘する読み込みコスト問題を自ら悪化させている。既知の外部障害でリトライ不能と判明した後は、確認間隔を伸ばす／次に意味のある変化がある可能性が高いタイミングまで待つ、といった仕組みが無い",
+      "dod": "(1) 最小の対処として、CHARTERに「同一の既知ブロッカー（例: 同一incident id、同一reason）を前回確認時と同内容のまま連続して確認しただけの回は、journal/state.jsonへのエントリを簡潔な1〜2行（前回runへの参照＋『変化なし』のみ）に留めてよい」というルールを追加し、run #172〜#193のような冗長な記録の繰り返しを防ぐ。(2) より根本的な対処として、apps/autopilot/loop.shにconsecutive no-op回数を数え、一定回数を超えたらINTERVAL_SECONDSを段階的に伸ばす（上限を設けてunboundedにはしない）backoff機構の追加を検討する。(2)はloop.shというautopilot自身の生存に関わるコア機構の変更のため、1 PR 1コンポーネントで刻み、変更前後でPodが正常に起動・ループし続けることを実機で確認してから展開する",
+      "blocked_by": null,
+      "refs": [
+        "apps/autopilot/loop.sh",
+        "ops/CHARTER.md"
+      ],
+      "created": "2026-08-06",
+      "pr": 392,
+      "notes": "run #172-193統合時の計画役（journal run #173相当の統合作業）が起票。inbox（R-NNN無し、実行役の気づき）より。run #209〜#211（実行役）は(1)(2)が1タスクに同居し1 PR 1論点に沿わないとして着手を見送り、inboxに分割提案を記録した。run #212（実行役）でDoD(1)（CHARTER §7へのルール追加）のみ実施（#391）。DoD(2)（loop.shへのbackoff機構）は残作業のためstatusをin_progressのまま維持し、taskは分割しない — DoD(1)を切り離したことで残るDoD(2)自体が単一論点になり、分割提案の前提が解消したため。run #213（実行役）で DoD(2)（loop.sh の backoff 機構）を実装し PR #392 を作成した。origin/main の commit が NOOP_BACKOFF_THRESHOLD（既定3）回連続で動かなければ次の sleep を 2^n 倍（既定上限1800秒）に伸ばし、main が動いた回は即座に通常間隔へ戻す。autopilot 自身の生存に関わるコア機構の変更のため、CHARTER §4「縛る変更には実測か裏付けが要る」に倣いこの回では merge しない（cooldown。T-0158/#390 と同じ扱い）。次の起動が PR #392 を CI green 確認のうえmerge し、ConfigMap 反映後の in-cluster kubectl で Pod が Running / restarts 増加なしで回り続けていること、ops-health-report の autopilot.heartbeat が exit_code 0 で継続していることを確認してから done にする。run #214（実行役）で PR #392（cooldown解除）と PR #393（記録更新）をこの回でmerge。merge後、in-cluster kubectl で autopilot Pod（autopilot-7d77766457-cfnvg）が Running・restarts 0 のまま継続していることを確認し、ops-health-report（generated_at 2026-08-07T01:30:04Z）の autopilot.heartbeat が iteration 1 で exit_code 0・last_start iteration 2 と、ConfigMap 反映後の reexec_if_updated 経由で iteration カウンタがリセットされて正常に再開したことを確認できたため done にした"
+    },
+    {
       "id": "T-0165",
       "domain": "homelab",
       "title": "REVIEW_EVERY の根拠数値が CHARTER.md 2箇所と loop.sh に三重化しているのを一本化する（R-005）",

--- a/ops/archive/runs.json
+++ b/ops/archive/runs.json
@@ -1676,6 +1676,27 @@
       "by": "autopilot pod (実行役)",
       "summary": "実行役（journal run #191）。残る中断は PR #376 のみ。GitHub Actions incident（qcvjkzcs7j74）は21:30 UTC更新版から変化なし（investigating継続）のためリトライ見送り。feedback/健全性とも新規変化なし。run #172以降このPRの状態確認だけで約20回ほぼ同一内容を記録し続けている点に気づき、backoff の仕組みが無いことをops/inbox.mdに追記（計画役へ）。T-0117/T-0158/T-0159〜T-0162 とも直列化ルールに従い今回も着手せず。",
       "prs": []
+    },
+    {
+      "n": 192,
+      "at": "2026-08-06T21:56:00Z",
+      "summary": "実行役（journal run #192）。残る中断は PR #376 のみ。GitHub Actions incident（qcvjkzcs7j74）は run #187〜#191 が見た21:30:42Z版から変化なし（investigating継続）のためリトライ見送り。feedback/健全性とも新規変化なし。T-0117/T-0158/T-0159〜T-0162 とも直列化ルールに従い今回も着手せず。"
+    },
+    {
+      "n": 193,
+      "at": "2026-08-06T22:00:00Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (実行役)",
+      "summary": "実行役（journal run #193）。残る中断は PR #376 のみ。GitHub Actions incident（qcvjkzcs7j74）は run #187〜#192 が見た21:30:42Z版から変化なし（investigating継続）のためリトライ見送り。feedback/健全性とも新規変化なし。T-0117/T-0158/T-0159〜T-0162 とも直列化ルールに従い今回も着手せず。",
+      "prs": []
+    },
+    {
+      "n": 194,
+      "at": "2026-08-06T22:10:13Z",
+      "kind": "in_cluster_loop",
+      "by": "autopilot pod (レビュー役・アーキテクチャ)",
+      "summary": "レビュー役・アーキテクチャレンズ（journal run #173、PR #378 → #376 へ統合）。REVIEW_EVERY到達後の初回レビュー実行のためreview-log.mdは突き合わせ対象0件。フィードバック新規無し。git logとCHARTER.md/loop.sh/validate.py/ledger.pyを読み、R-004（旧R-001、CHARTER.mdが肥大化に上限を持たず2日で10.8KB→86.1KBへ増加、backlog/stateのarchive+上限機構の対象外）とR-005（旧R-002、REVIEW_EVERY=12の根拠数値がCHARTER.md 2箇所とloop.shに三重化）をops/inbox.md・ops/review-log.mdに記録。実装・起票はせず（書く権利の分離）。",
+      "prs": []
     }
   ]
 }

--- a/ops/backlog.json
+++ b/ops/backlog.json
@@ -523,25 +523,6 @@
       }
     },
     {
-      "id": "T-0163",
-      "domain": "homelab",
-      "title": "既知の外部障害でリトライ不能と判明した後、確認間隔を伸ばす backoff の仕組みを作る",
-      "kind": "feature",
-      "risk": "medium",
-      "status": "in_progress",
-      "priority": 50,
-      "why": "実行役の気づき（ops/inbox.md、R-NNN無し）。GitHub Actions の大規模障害（incident qcvjkzcs7j74、2026-08-06 15:22 UTC〜、22:00 UTC 時点も investigating 継続）でPR #376がblockedのあいだ、INTERVAL_SECONDS（120秒）ループが毎回incident statusを確認するだけの起動を繰り返し、run #172〜#193（6時間以上・約20回）でほぼ同一内容のjournal/state.jsonエントリを量産した。CHARTER §7「帳簿には上限がある」が指摘する読み込みコスト問題を自ら悪化させている。既知の外部障害でリトライ不能と判明した後は、確認間隔を伸ばす／次に意味のある変化がある可能性が高いタイミングまで待つ、といった仕組みが無い",
-      "dod": "(1) 最小の対処として、CHARTERに「同一の既知ブロッカー（例: 同一incident id、同一reason）を前回確認時と同内容のまま連続して確認しただけの回は、journal/state.jsonへのエントリを簡潔な1〜2行（前回runへの参照＋『変化なし』のみ）に留めてよい」というルールを追加し、run #172〜#193のような冗長な記録の繰り返しを防ぐ。(2) より根本的な対処として、apps/autopilot/loop.shにconsecutive no-op回数を数え、一定回数を超えたらINTERVAL_SECONDSを段階的に伸ばす（上限を設けてunboundedにはしない）backoff機構の追加を検討する。(2)はloop.shというautopilot自身の生存に関わるコア機構の変更のため、1 PR 1コンポーネントで刻み、変更前後でPodが正常に起動・ループし続けることを実機で確認してから展開する",
-      "blocked_by": null,
-      "refs": [
-        "apps/autopilot/loop.sh",
-        "ops/CHARTER.md"
-      ],
-      "created": "2026-08-06",
-      "pr": 392,
-      "notes": "run #172-193統合時の計画役（journal run #173相当の統合作業）が起票。inbox（R-NNN無し、実行役の気づき）より。run #209〜#211（実行役）は(1)(2)が1タスクに同居し1 PR 1論点に沿わないとして着手を見送り、inboxに分割提案を記録した。run #212（実行役）でDoD(1)（CHARTER §7へのルール追加）のみ実施（#391）。DoD(2)（loop.shへのbackoff機構）は残作業のためstatusをin_progressのまま維持し、taskは分割しない — DoD(1)を切り離したことで残るDoD(2)自体が単一論点になり、分割提案の前提が解消したため。run #213（実行役）で DoD(2)（loop.sh の backoff 機構）を実装し PR #392 を作成した。origin/main の commit が NOOP_BACKOFF_THRESHOLD（既定3）回連続で動かなければ次の sleep を 2^n 倍（既定上限1800秒）に伸ばし、main が動いた回は即座に通常間隔へ戻す。autopilot 自身の生存に関わるコア機構の変更のため、CHARTER §4「縛る変更には実測か裏付けが要る」に倣いこの回では merge しない（cooldown。T-0158/#390 と同じ扱い）。次の起動が PR #392 を CI green 確認のうえmerge し、ConfigMap 反映後の in-cluster kubectl で Pod が Running / restarts 増加なしで回り続けていること、ops-health-report の autopilot.heartbeat が exit_code 0 で継続していることを確認してから done にする"
-    },
-    {
       "id": "T-0164",
       "domain": "homelab",
       "title": "ops/CHARTER.md の肥大化に上限・圧縮の仕組みを作る（backlog/state と同型、R-004）",

--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -6180,3 +6180,27 @@ GitHub Actions incident で blocked のまま run #172〜#193 を独立に積み
   in-cluster kubectl で `autopilot` Pod が `Running`／restarts 増加なしで回り続けていること、
   `ops-health-report` の `autopilot.heartbeat` が exit_code 0 で継続していることを確認してから
   `T-0163` を `done` にする（このタスク自体の記録は今回この PR に含める。`T-0164` は分割待ちのまま）
+
+## 2026-08-07 10:39 JST — run #214
+
+- 取り込んだフィードバック: なし。`ops-feedback` ブランチ引き続き不在。issue #56 を
+  `per_page=100` で全2ページ（114件）確認し、cutoff より新しい非自己投稿コメント4件は
+  いずれも `feedback.json` に既存（T-0107 実測報告3件・needs-human棚卸し1件、全て記録済み）。
+  新着1件（T-0116 PBS backup ジョブ確認依頼）は自己投稿マーカーありのため取り込み対象外
+- 前回の中断: オープン PR 2件（#392 cooldown解除待ち、#393 記録更新）。両方とも CI 全項目
+  green（`mergeable_state: clean`）を確認し、issue #56 に T-0163 への新規異議が無いことも
+  確認した上で #393 → #392 の順に merge。マージ済みブランチは GitHub 側で自動削除済み
+  （`DELETE` を試みたところ両方 `Reference does not exist`）
+- 健全性: `ops-health-report`（generated_at 2026-08-07T01:30:04Z、新鮮）を確認。`autopilot`
+  Deployment は `readyReplicas: 1`、Pod（`autopilot-7d77766457-cfnvg`、age 114分、in-cluster
+  kubectl で直接確認）は `Running`・`restartCount: 0`。`heartbeat.last_end`（iteration 1,
+  exit_code 0, elapsed 487s）と `last_start`（iteration 2）から、PR #392 merge → ConfigMap
+  反映 → `reexec_if_updated` 経由で新しい `loop.sh` に入れ替わり、iteration カウンタが
+  リセットされた上で正常に起動し続けていることを確認。`coder`/`immich`/`vaultwarden` の
+  `Degraded` は既知事象 T-0106 由来のみで新規異常なし
+- やったこと: 上記の実機確認により T-0163 の DoD(2) 完了条件（Pod が Running/restarts
+  増加なしで回り続ける・heartbeat が exit_code 0 で継続）を満たしたため `T-0163` を `done`
+  にした。`python3 ops/ledger.py` を実行し done/dropped を archive へ移動
+- 見つけたこと: なし
+- `python3 ops/validate.py` → 0 error, 0 warning
+- 次の起動へ: なし。todo 残りは分割待ちの `T-0164` のみ

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-08-07T01:19:39Z",
+  "updated": "2026-08-07T01:39:47Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
@@ -34,27 +34,6 @@
     "since": "2026-08-05"
   },
   "runs": [
-    {
-      "n": 192,
-      "at": "2026-08-06T21:56:00Z",
-      "summary": "実行役（journal run #192）。残る中断は PR #376 のみ。GitHub Actions incident（qcvjkzcs7j74）は run #187〜#191 が見た21:30:42Z版から変化なし（investigating継続）のためリトライ見送り。feedback/健全性とも新規変化なし。T-0117/T-0158/T-0159〜T-0162 とも直列化ルールに従い今回も着手せず。"
-    },
-    {
-      "n": 193,
-      "at": "2026-08-06T22:00:00Z",
-      "kind": "in_cluster_loop",
-      "by": "autopilot pod (実行役)",
-      "summary": "実行役（journal run #193）。残る中断は PR #376 のみ。GitHub Actions incident（qcvjkzcs7j74）は run #187〜#192 が見た21:30:42Z版から変化なし（investigating継続）のためリトライ見送り。feedback/健全性とも新規変化なし。T-0117/T-0158/T-0159〜T-0162 とも直列化ルールに従い今回も着手せず。",
-      "prs": []
-    },
-    {
-      "n": 194,
-      "at": "2026-08-06T22:10:13Z",
-      "kind": "in_cluster_loop",
-      "by": "autopilot pod (レビュー役・アーキテクチャ)",
-      "summary": "レビュー役・アーキテクチャレンズ（journal run #173、PR #378 → #376 へ統合）。REVIEW_EVERY到達後の初回レビュー実行のためreview-log.mdは突き合わせ対象0件。フィードバック新規無し。git logとCHARTER.md/loop.sh/validate.py/ledger.pyを読み、R-004（旧R-001、CHARTER.mdが肥大化に上限を持たず2日で10.8KB→86.1KBへ増加、backlog/stateのarchive+上限機構の対象外）とR-005（旧R-002、REVIEW_EVERY=12の根拠数値がCHARTER.md 2箇所とloop.shに三重化）をops/inbox.md・ops/review-log.mdに記録。実装・起票はせず（書く権利の分離）。",
-      "prs": []
-    },
     {
       "n": 195,
       "at": "2026-08-06T22:25:00Z",
@@ -226,6 +205,14 @@
       "prs": [
         392
       ]
+    },
+    {
+      "n": 214,
+      "at": "2026-08-07T01:39:47Z",
+      "kind": "in-cluster-loop",
+      "by": "autopilot pod (実行役)",
+      "summary": "実行役（journal run #214）。前回の中断PR #392（cooldown解除）/#393（記録更新）を確認しCI green・issue #56に新規異議なしを確認のうえ merge。ConfigMap反映後のreexec_if_updated経由でloop.shが入れ替わり、Podがrestarts 0で回り続けheartbeatがexit_code 0で継続していることをkubectl/ops-health-reportで確認できたため T-0163 を done にした。ops/ledger.py実行。",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

`ops/` の運用記録のみ（journal・state.json の run #214 追記、`T-0163` backlog エントリを
`done` に変更し notes に実機確認の経緯を追記、`ops/ledger.py` による archive 移動）。
コード変更は含まない。

`T-0163`（DoD(2): loop.sh の backoff 機構）の PR #392 は前回起動（run #213）で cooldown
対象として merge を見送っていたが、今回（run #214）で CI green・issue #56 に新規異議が
無いことを確認し、PR #393（記録更新）とあわせて merge した。merge 後、in-cluster kubectl で
`autopilot` Pod（`autopilot-7d77766457-cfnvg`）が `Running`・`restartCount: 0` のまま
継続していること、`ops-health-report`（generated_at 2026-08-07T01:30:04Z）の
`autopilot.heartbeat` が `last_end`（iteration 1, exit_code 0）→ `last_start`（iteration 2）と
ConfigMap 反映後の `reexec_if_updated` 経由で新しい `loop.sh` に入れ替わったうえで正常に
起動し続けていることを確認できたため、`T-0163` を `done` にした。

## 検証したこと

- in-cluster kubectl（read-only）: `autopilot` Deployment `readyReplicas: 1`、Pod
  `Running`・`restartCount: 0`（age 114分、backoff PR merge 後も再起動なし）
- `ops-health-report`（`origin/ops-health-report:ops/health/latest.json`）: `heartbeat` が
  exit_code 0 で iteration が進んでいることを確認
- `python3 ops/validate.py` → 0 error, 0 warning
- `python3 ops/check_feedback.py` → 0 error, 0 warning
- `python3 ops/ledger.py` → backlog 1件・state 起動記録3件を archive へ移動

## ロールバック手順

`ops/` の記録ファイルのみの変更。revert すれば journal/state.json/backlog.json/archive の
該当箇所がそのまま元に戻る（`T-0163` が `done` から `in_progress` に戻るだけで、実際の
`loop.sh` の backoff 機構自体は既に別 PR #392 で merge 済みのため revert の影響を受けない）。
実インフラ・スキーマへの影響なし。

## backlog task id

T-0163
