### PR TITLE
ops(run #217): 着手可能タスク無しを記録

### DIFF
--- a/ops/journal/2026-08.md
+++ b/ops/journal/2026-08.md
@@ -6249,3 +6249,29 @@ GitHub Actions incident で blocked のまま run #172〜#193 を独立に積み
   ことを促す既知の警告）
 - 次の起動へ: この回の PR の CI green を確認して merge。`T-0164` は残作業の要否を計画役が
   判断するまで `in_progress`
+
+## 2026-08-07 11:18 JST — run #217
+
+- 取り込んだフィードバック: なし。`ops-feedback` ブランチ引き続き不在（`git ls-remote origin`
+  で不在確認）。issue #56 を `since=2026-08-06T15:20:02Z` で確認し新着1件（T-0116 の PBS
+  backup ジョブ確認依頼、issuecomment-5210344855）のみだが `<!-- autopilot:self-posted -->`
+  マーカーありのため取り込み対象外
+- 前回の中断: なし。オープン PR 0件、`autopilot/*` の残りブランチ 0件
+- 健全性: 確認省略なし（`ops-health-report` 参照、generated_at 2026-08-07T02:00:04Z）。
+  `applications` は `coder`/`immich`/`vaultwarden` の `Degraded` のみで既知事象 T-0106 由来
+  （ExternalSecret `SecretSyncedError` のみ、Pod は全て Running）から変化なし。`pod_issues`
+  は 2026-08-03T14:21:00Z 時点の古い terminated 記録のみで新規異常なし。immich の
+  `backup_listing` は最新ファイル mtime 2026-08-06T02:00:05Z で 24 時間以内。`autopilot`
+  Deployment は `readyReplicas: 1`、Pod `restartCount: 0`、`heartbeat.last_end`
+  （iteration 1, exit_code 0, elapsed 449s）と `last_start`（iteration 2）から前回起動は
+  正常終了・現在も継続稼働中
+- やったこと: なし。backlog の `status: todo` は 0件で、残る19件は全て `blocked`/
+  `needs-human`（うち6件の `needs-human` は依頼済みで人間・構築セッションの回答待ち、
+  `blocked` の6件はいずれも別タスク完了待ちか外部要因待ちで着手可能な部分が無いことを
+  `blocked_by` で個別確認済み）、`T-0164` のみ `in_progress` だが残作業（経緯部分の切り出し
+  の要否）は前回（run #216）が計画役の判断待ちとして `ops/inbox.md` に委ねたばかりで、
+  実行役が重ねて着手するのは書く権利の分離（CHARTER §3）に反するため見送った
+- 見つけたこと: なし
+- `python3 ops/validate.py` → 0 error, 1 warning（todo 0件の既知警告、変化なし）
+- 次の起動へ: なし。着手可能なタスクが増えるか計画役が `T-0164` を判断するまで、
+  同様の状況が続く見込み

--- a/ops/state.json
+++ b/ops/state.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "updated": "2026-08-07T02:09:40Z",
+  "updated": "2026-08-07T02:18:23Z",
   "vision_stage": 2,
   "vision_stage_label": "器を安定させる",
   "feedback": {
     "issue": 56,
     "url": "https://github.com/hikuohiku/homelab/issues/56",
-    "last_read": "2026-08-07T02:09:40Z"
+    "last_read": "2026-08-07T02:18:23Z"
   },
   "dashboard": {
     "artifact_url": "https://claude.ai/code/artifact/a86aa1b6-ddfb-4bbf-9085-b70a4e243adc",
@@ -231,6 +231,14 @@
       "prs": [
         396
       ]
+    },
+    {
+      "n": 217,
+      "at": "2026-08-07T02:18:23Z",
+      "kind": "in-cluster-loop",
+      "by": "autopilot pod (実行役)",
+      "summary": "実行役（journal run #217）。前回中断なし、フィードバック新規なし（issue #56 の新着1件は自己投稿マーカーありでスキップ）、健全性は既知事象(T-0106)のみで異常なし。backlogのtodoは0件で残り19件は全てblocked/needs-human、T-0164も計画役判断待ちのため実行役が着手できるタスクが無く記録のみ。",
+      "prs": []
     }
   ]
 }


### PR DESCRIPTION
## 変更点

- `ops/journal/2026-08.md` に run #217 の記録を追記
- `ops/state.json` の `runs` 配列に run #217 のエントリを追記、`updated`/`feedback.last_read` を更新

コード・マニフェストの変更なし。`ops/` の運用記録のみ。

## 背景

実行役として1イテレーション分作業したが、`ops/backlog.json` の `status: todo` は0件で、
残る19件は全て `blocked`（それぞれ `blocked_by` を個別確認し着手可能な部分が無いことを確認済み）
または `needs-human`（依頼済みで人間・構築セッションの回答待ち）。唯一 `in_progress` の
`T-0164`（CHARTER.md 圧縮）も、直前の run #216 が残作業の要否を計画役の判断に委ねたばかりで、
実行役が重ねて着手するのは CHARTER §3「書く権利」の役割分離に反するため見送った。

フィードバック取り込み・前回の中断確認・健全性確認はいずれも実施し、新規事項なし
（詳細は journal 参照）。

## 検証したこと

- `python3 ops/validate.py` → 0 error, 1 warning（todo 0件の既知警告）

## ロールバック手順

記録のみの変更で実インフラへの影響は無い。revert すれば journal/state.json は直前の状態に戻る。

## backlog task id

なし（記録のみ、新規タスクの起票・着手なし）
