### PR TITLE
heart fixups: Discord UA 修正 + 旧 loop の停止を git に反映

### DIFF
--- a/apps/autopilot/deployment.yaml
+++ b/apps/autopilot/deployment.yaml
@@ -6,7 +6,10 @@ metadata:
   labels:
     app: autopilot
 spec:
-  replicas: 1
+  # 旧 loop は退役を前倒しして停止 (2026-08-07、人間の判断: タスク枯渇でトークンを
+  # 消費するだけになっていた)。heart-and-projects Phase 2 でこの Deployment ごと
+  # 削除する。手動 scale では selfHeal が戻してしまうため git 側で 0 にする
+  replicas: 0
   # 2 つ動くと同じタスクで別々のブランチ・PR を作り、ops/ の記録が必ずコンフリクトする
   # （CHARTER §2 の直列化ルールは 1 プロセス内でしか効かない）。RollingUpdate だと
   # 更新中に新旧が一時的に重なるため Recreate にして、常に高々 1 つに保つ

--- a/ops/heart/notify.py
+++ b/ops/heart/notify.py
@@ -53,7 +53,12 @@ class Notifier:
         req = urllib.request.Request(
             self.webhook,
             data=json.dumps({"content": text[:1900]}).encode(),
-            headers={"Content-Type": "application/json"},
+            headers={
+                "Content-Type": "application/json",
+                # Python 既定の UA (Python-urllib/3.x) は Discord 側 (Cloudflare) が
+                # 403 で弾く。2026-08-07 の疎通試験で実測 (curl は 204、urllib は 403)
+                "User-Agent": "homelab-heart/1 (+https://github.com/hikuohiku/homelab)",
+            },
             method="POST",
         )
         with urllib.request.urlopen(req, timeout=15):
@@ -153,7 +158,10 @@ def main():
     req = urllib.request.Request(
         url,
         data=json.dumps({"content": f"[test] {text}"}).encode(),
-        headers={"Content-Type": "application/json"},
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "homelab-heart/1 (+https://github.com/hikuohiku/homelab)",
+        },
         method="POST",
     )
     with urllib.request.urlopen(req, timeout=15) as resp:


### PR DESCRIPTION
Phase 1 デプロイ検証で見つかった 2 件の修正。

## 変更点
- **notify.py**: Discord webhook が Python 既定の User-Agent を 403 で弾く (疎通試験の実測: curl は 204、urllib は 403)。UA を明示
- **旧 autopilot Deployment を replicas: 0 に**: 人間が手動 scale で止めた判断を git に反映 (selfHeal で 1 に戻されるのを防ぐ)。Phase 2 で Deployment ごと削除予定

## 検証
- 単体テスト 62 件 green、validate.py 0 error
- merge 後: ArgoCD の autopilot アプリの auto-sync が有効なら、旧 loop は停止のまま heart (shadow) と PVC が作成される

## ロールバック
- replicas を 1 に戻す revert で旧 loop が再開する

allow-delete: なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vbUSEgw3NSDPqJMUTJifY