### PR TITLE
heart: veto/stop 受信の可視化 (疎通試験の前提)

### DIFF
--- a/ops/heart/heart.py
+++ b/ops/heart/heart.py
@@ -212,6 +212,13 @@ class Heart:
             self.gh, self.repo_dir, cursors, self.cfg.rules,
             self.cfg.feedback_issue, self.cfg.feedback_branch,
         )
+        if vetoes or stop_all or review_needed:
+            # kill switch の受信は必ず可視化する (該当プロジェクトが無く action が
+            # 生まれない場合でも、veto 疎通試験の結果を外から確認できるように)
+            log(
+                f"feedback received: vetoes={vetoes} stop_all={stop_all} "
+                f"review_needed={len(review_needed)}"
+            )
         curriculum = facts.collect_curriculum(
             self.cfg.data_dir, self.repo_dir, self.gh
         )
@@ -265,6 +272,8 @@ class Heart:
                 "unhealthy_apps": unhealthy_apps,
                 "health_fresh": health_fresh,
                 "breaker": breaker_info,
+                "vetoes": vetoes,
+                "stop_all": stop_all,
                 "actions": [a["type"] for a in actions],
                 "shadow": self.cfg.shadow,
             },


### PR DESCRIPTION
veto 疎通試験の前提となる観測性の修正。該当プロジェクトが無い veto/stop は action を生まず、受信の痕跡がログにも metrics にも残らなかった。kill switch の受信は常にログ 1 行 + metrics のフィールドとして残す。

## 検証
単体テスト 62 件 green。merge 後、issue #56 に `veto P-0000` とコメントすると次のビート (≤2 分) の heart ログに `feedback received: vetoes=['P-0000']` が出ることを確認する (これが veto 疎通試験)。

allow-delete: なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vbUSEgw3NSDPqJMUTJifY