### PR TITLE
heart: アイドル化した可逆案の拒否権窓を繰り上げ (稼働率原則の一貫化)

### DIFF
--- a/ops/heart/reconcile.py
+++ b/ops/heart/reconcile.py
@@ -146,7 +146,16 @@ def decide(doc, facts, rules, now):
 
         elif state == "announced":
             if parse_iso(p["veto_deadline"]) > now:
-                continue
+                # 窓の繰り上げ: 予告時に「他が走行中」だったために窓が付いた可逆案は、
+                # アイドルになった時点で即着手してよい (窓の基準は安全性でなく稼働率 —
+                # 決定 #3「何もしてない時間が嫌」)。不可逆案は繰り上げない
+                if (
+                    p.get("irreversible")
+                    or facts.get("running_runners", 0) > 0
+                    or running > 0
+                ):
+                    continue
+                p["veto_deadline"] = now_iso(now)
             if breaker:
                 continue
             if running >= rules["runner"]["max_concurrent"]:

--- a/ops/heart/tests/test_reconcile.py
+++ b/ops/heart/tests/test_reconcile.py
@@ -100,11 +100,32 @@ class TestActivate(unittest.TestCase):
         self.assertEqual(d["projects"][0]["state"], "active")
         self.assertIn("spawn_runner", kinds(actions))
 
-    def test_announced_waits_before_deadline(self):
+    def test_announced_reversible_catches_up_when_idle(self):
+        """走行中に予告されて窓が付いた可逆案は、アイドルになったら繰り上げて即着手
+        (窓の基準は稼働率 — 決定 #3)。"""
         p = project(state="announced", veto_deadline="2026-08-07T13:00:00Z")
+        d, actions = reconcile.decide(doc(p), facts(), RULES, NOW)
+        self.assertEqual(d["projects"][0]["state"], "active")
+        self.assertIn("spawn_runner", kinds(actions))
+
+    def test_announced_irreversible_never_catches_up(self):
+        p = project(state="announced", irreversible=True,
+                    veto_deadline="2026-08-07T13:00:00Z")
         d, actions = reconcile.decide(doc(p), facts(), RULES, NOW)
         self.assertEqual(d["projects"][0]["state"], "announced")
         self.assertEqual(kinds(actions), [])
+
+    def test_announced_waits_while_busy(self):
+        waiting = project(id="P-0002", state="announced", branch="project/p-0002",
+                          veto_deadline="2026-08-07T13:00:00Z")
+        busy = project(state="active", job="runner-p-0001-a1")
+        d, actions = reconcile.decide(
+            doc(busy, waiting),
+            facts(running_runners=1, jobs={"runner-p-0001-a1": {"active": True}}),
+            RULES, NOW,
+        )
+        self.assertEqual(d["projects"][1]["state"], "announced")
+        self.assertNotIn("spawn_runner", kinds(actions))
 
     def test_concurrency_cap(self):
         ready = project(id="P-0002", state="announced",


### PR DESCRIPTION
P-0012 が「予告時に他プロジェクト走行中」だったために 24h 窓を持ったまま、システムがアイドルになっても待ち続ける矛盾の修正。窓の基準は稼働率 (決定 #3) なので、可逆案はアイドル化した時点で繰り上げて即着手する。不可逆案は繰り上げない。

## 検証
単体テスト 66 件 green (繰り上げ / 不可逆の非繰り上げ / busy 中の待機を追加)。merge 後、待機中の P-0012 が次のビートで着手される。

allow-delete: なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vbUSEgw3NSDPqJMUTJifY